### PR TITLE
Disable automatic whole-stream gzip in benchmarks

### DIFF
--- a/internal/crosstest/cross_bench_test.go
+++ b/internal/crosstest/cross_bench_test.go
@@ -33,6 +33,11 @@ func BenchmarkReRPC(b *testing.B) {
 	server.StartTLS()
 	defer server.Close()
 
+	doer := server.Client()
+	httpTransport, ok := doer.Transport.(*http.Transport)
+	assert.True(b, ok, "expected HTTP client to have *http.Transport as RoundTripper")
+	httpTransport.DisableCompression = true
+
 	client, err := crossrpc.NewCrossServiceClient(
 		server.URL,
 		server.Client(),

--- a/internal/gen/proto/go-rerpc/rerpc/ping/v1test/ping_rerpc.pb.go
+++ b/internal/gen/proto/go-rerpc/rerpc/ping/v1test/ping_rerpc.pb.go
@@ -9,12 +9,11 @@ package pingv1test
 import (
 	context "context"
 	errors "errors"
-	strings "strings"
-
 	rerpc "github.com/rerpc/rerpc"
 	callstream "github.com/rerpc/rerpc/callstream"
 	handlerstream "github.com/rerpc/rerpc/handlerstream"
 	v1test "github.com/rerpc/rerpc/internal/gen/proto/go/rerpc/ping/v1test"
+	strings "strings"
 )
 
 // This is a compile-time assertion to ensure that this generated file and the

--- a/rerpctest/mem.go
+++ b/rerpctest/mem.go
@@ -38,12 +38,14 @@ func NewServer(h http.Handler) *Server {
 }
 
 // Client returns an HTTP client configured to trust the server's TLS
-// certificate and use HTTP/2 over an in-memory pipe. It closes its idle
-// connections when the server is closed.
+// certificate and use HTTP/2 over an in-memory pipe. Automatic HTTP-level gzip
+// compression is disabled. It closes its idle connections when the server is
+// closed.
 func (s *Server) Client() *http.Client {
 	c := s.srv.Client()
 	if tr, ok := c.Transport.(*http.Transport); ok {
 		tr.DialContext = s.lis.DialContext
+		tr.DisableCompression = true
 	}
 	return c
 }


### PR DESCRIPTION
In a wonderful misfeature from early in Go's life, `http.Client`
_automatically_ requests gzipped responses and transparently
decompresses them. We should encourage users to disable this feature
(already shown in the client example), since we're handling compression
on a per-message basis already. Disabling it in our benchmarks shaves
off an allocation.
