### PR TITLE
Remove details from Wrap error constructor

### DIFF
--- a/error.go
+++ b/error.go
@@ -37,20 +37,13 @@ type Error struct {
 	details []*anypb.Any
 }
 
-// Wrap annotates any error with a status code and error details. If the code
-// is CodeOK, the returned error is nil.
-func Wrap(c Code, err error, details ...proto.Message) *Error {
+// Wrap annotates any error with a status code. If the code is CodeOK, the
+// returned error is nil.
+func Wrap(c Code, err error) *Error {
 	if c == CodeOK {
 		return nil
 	}
-	e := &Error{
-		code: c,
-		err:  err,
-	}
-	if len(details) > 0 {
-		e.SetDetails(details...)
-	}
-	return e
+	return &Error{code: c, err: err}
 }
 
 // Errorf calls fmt.Errorf with the supplied template and arguments, then wraps


### PR DESCRIPTION
Slightly reduce the prominence of error details in our API by removing
them from the `Wrap` signature. Now that `Wrap` returns an `*Error`,
it's pretty easy to chain a `SetDetails` call anyways.
