### PR TITLE
Move protobuf-specific routing to generated code

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -97,7 +97,7 @@ func NewService(
 ) *rerpc.Service {
 	return healthrpc.NewFullHealth(
 		&server{check: checker},
-		append(opts, rerpc.OverrideProtobufPackage("grpc.health.v1"))...,
+		append(opts, rerpc.ReplaceProcedurePrefix("internal.", "grpc."))...,
 	)
 }
 
@@ -122,7 +122,7 @@ func NewClient(baseURL string, doer rerpc.Doer, opts ...rerpc.ClientOption) (*Cl
 	c, err := healthrpc.NewHealthClient(
 		baseURL,
 		doer,
-		append(opts, rerpc.OverrideProtobufPackage("grpc.health.v1"))...,
+		append(opts, rerpc.ReplaceProcedurePrefix("internal.", "grpc."))...,
 	)
 	if err != nil {
 		return nil, err

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -54,7 +54,7 @@ func TestHealth(t *testing.T) {
 		client, err := healthrpc.NewHealthClient(
 			server.URL,
 			server.Client(),
-			rerpc.OverrideProtobufPackage("grpc.health.v1"),
+			rerpc.ReplaceProcedurePrefix("internal.", "grpc."),
 		)
 		assert.Nil(t, err, "client construction error")
 		stream, err := client.Watch(

--- a/internal/crosstest/gen/proto/go-rerpc/cross/v1test/cross_rerpc.pb.go
+++ b/internal/crosstest/gen/proto/go-rerpc/cross/v1test/cross_rerpc.pb.go
@@ -66,9 +66,7 @@ func NewCrossServiceClient(baseURL string, doer rerpc.Doer, opts ...rerpc.Client
 	pingFunc, err := rerpc.NewClientFunc[v1test.PingRequest, v1test.PingResponse](
 		doer,
 		baseURL,
-		"cross.v1test", // protobuf package
-		"CrossService", // protobuf service
-		"Ping",         // protobuf method
+		"cross.v1test.CrossService/Ping",
 		opts...,
 	)
 	if err != nil {
@@ -77,9 +75,7 @@ func NewCrossServiceClient(baseURL string, doer rerpc.Doer, opts ...rerpc.Client
 	failFunc, err := rerpc.NewClientFunc[v1test.FailRequest, v1test.FailResponse](
 		doer,
 		baseURL,
-		"cross.v1test", // protobuf package
-		"CrossService", // protobuf service
-		"Fail",         // protobuf method
+		"cross.v1test.CrossService/Fail",
 		opts...,
 	)
 	if err != nil {
@@ -89,9 +85,7 @@ func NewCrossServiceClient(baseURL string, doer rerpc.Doer, opts ...rerpc.Client
 		doer,
 		rerpc.StreamTypeClient,
 		baseURL,
-		"cross.v1test", // protobuf package
-		"CrossService", // protobuf service
-		"Sum",          // protobuf method
+		"cross.v1test.CrossService/Sum",
 		opts...,
 	)
 	if err != nil {
@@ -101,9 +95,7 @@ func NewCrossServiceClient(baseURL string, doer rerpc.Doer, opts ...rerpc.Client
 		doer,
 		rerpc.StreamTypeServer,
 		baseURL,
-		"cross.v1test", // protobuf package
-		"CrossService", // protobuf service
-		"CountUp",      // protobuf method
+		"cross.v1test.CrossService/CountUp",
 		opts...,
 	)
 	if err != nil {
@@ -113,9 +105,7 @@ func NewCrossServiceClient(baseURL string, doer rerpc.Doer, opts ...rerpc.Client
 		doer,
 		rerpc.StreamTypeBidirectional,
 		baseURL,
-		"cross.v1test", // protobuf package
-		"CrossService", // protobuf service
-		"CumSum",       // protobuf method
+		"cross.v1test.CrossService/CumSum",
 		opts...,
 	)
 	if err != nil {
@@ -248,9 +238,8 @@ func NewFullCrossService(svc FullCrossServiceServer, opts ...rerpc.HandlerOption
 	}, opts...)
 
 	ping, err := rerpc.NewUnaryHandler(
-		"cross.v1test", // protobuf package
-		"CrossService", // protobuf service
-		"Ping",         // protobuf method
+		"cross.v1test.CrossService/Ping", // procedure name
+		"cross.v1test.CrossService",      // reflection name
 		svc.Ping,
 		opts...,
 	)
@@ -260,9 +249,8 @@ func NewFullCrossService(svc FullCrossServiceServer, opts ...rerpc.HandlerOption
 	handlers = append(handlers, *ping)
 
 	fail, err := rerpc.NewUnaryHandler(
-		"cross.v1test", // protobuf package
-		"CrossService", // protobuf service
-		"Fail",         // protobuf method
+		"cross.v1test.CrossService/Fail", // procedure name
+		"cross.v1test.CrossService",      // reflection name
 		svc.Fail,
 		opts...,
 	)
@@ -273,9 +261,8 @@ func NewFullCrossService(svc FullCrossServiceServer, opts ...rerpc.HandlerOption
 
 	sum, err := rerpc.NewStreamingHandler(
 		rerpc.StreamTypeClient,
-		"cross.v1test", // protobuf package
-		"CrossService", // protobuf service
-		"Sum",          // protobuf method
+		"cross.v1test.CrossService/Sum", // procedure name
+		"cross.v1test.CrossService",     // reflection name
 		func(ctx context.Context, sender rerpc.Sender, receiver rerpc.Receiver) {
 			typed := handlerstream.NewClient[v1test.SumRequest, v1test.SumResponse](sender, receiver)
 			err := svc.Sum(ctx, typed)
@@ -301,9 +288,8 @@ func NewFullCrossService(svc FullCrossServiceServer, opts ...rerpc.HandlerOption
 
 	countUp, err := rerpc.NewStreamingHandler(
 		rerpc.StreamTypeServer,
-		"cross.v1test", // protobuf package
-		"CrossService", // protobuf service
-		"CountUp",      // protobuf method
+		"cross.v1test.CrossService/CountUp", // procedure name
+		"cross.v1test.CrossService",         // reflection name
 		func(ctx context.Context, sender rerpc.Sender, receiver rerpc.Receiver) {
 			typed := handlerstream.NewServer[v1test.CountUpResponse](sender)
 			req, err := rerpc.ReceiveRequest[v1test.CountUpRequest](receiver)
@@ -338,9 +324,8 @@ func NewFullCrossService(svc FullCrossServiceServer, opts ...rerpc.HandlerOption
 
 	cumSum, err := rerpc.NewStreamingHandler(
 		rerpc.StreamTypeBidirectional,
-		"cross.v1test", // protobuf package
-		"CrossService", // protobuf service
-		"CumSum",       // protobuf method
+		"cross.v1test.CrossService/CumSum", // procedure name
+		"cross.v1test.CrossService",        // reflection name
 		func(ctx context.Context, sender rerpc.Sender, receiver rerpc.Receiver) {
 			typed := handlerstream.NewBidirectional[v1test.CumSumRequest, v1test.CumSumResponse](sender, receiver)
 			err := svc.CumSum(ctx, typed)

--- a/internal/gen/proto/go-rerpc/grpc/health/v1/health_rerpc.pb.go
+++ b/internal/gen/proto/go-rerpc/grpc/health/v1/health_rerpc.pb.go
@@ -93,9 +93,7 @@ func NewHealthClient(baseURL string, doer rerpc.Doer, opts ...rerpc.ClientOption
 	checkFunc, err := rerpc.NewClientFunc[v1.HealthCheckRequest, v1.HealthCheckResponse](
 		doer,
 		baseURL,
-		"internal.health.v1", // protobuf package
-		"Health",             // protobuf service
-		"Check",              // protobuf method
+		"internal.health.v1.Health/Check",
 		opts...,
 	)
 	if err != nil {
@@ -105,9 +103,7 @@ func NewHealthClient(baseURL string, doer rerpc.Doer, opts ...rerpc.ClientOption
 		doer,
 		rerpc.StreamTypeServer,
 		baseURL,
-		"internal.health.v1", // protobuf package
-		"Health",             // protobuf service
-		"Watch",              // protobuf method
+		"internal.health.v1.Health/Watch",
 		opts...,
 	)
 	if err != nil {
@@ -226,9 +222,8 @@ func NewFullHealth(svc FullHealthServer, opts ...rerpc.HandlerOption) *rerpc.Ser
 	}, opts...)
 
 	check, err := rerpc.NewUnaryHandler(
-		"internal.health.v1", // protobuf package
-		"Health",             // protobuf service
-		"Check",              // protobuf method
+		"internal.health.v1.Health/Check", // procedure name
+		"internal.health.v1.Health",       // reflection name
 		svc.Check,
 		opts...,
 	)
@@ -239,9 +234,8 @@ func NewFullHealth(svc FullHealthServer, opts ...rerpc.HandlerOption) *rerpc.Ser
 
 	watch, err := rerpc.NewStreamingHandler(
 		rerpc.StreamTypeServer,
-		"internal.health.v1", // protobuf package
-		"Health",             // protobuf service
-		"Watch",              // protobuf method
+		"internal.health.v1.Health/Watch", // procedure name
+		"internal.health.v1.Health",       // reflection name
 		func(ctx context.Context, sender rerpc.Sender, receiver rerpc.Receiver) {
 			typed := handlerstream.NewServer[v1.HealthCheckResponse](sender)
 			req, err := rerpc.ReceiveRequest[v1.HealthCheckRequest](receiver)

--- a/internal/gen/proto/go-rerpc/grpc/reflection/v1alpha/reflection_rerpc.pb.go
+++ b/internal/gen/proto/go-rerpc/grpc/reflection/v1alpha/reflection_rerpc.pb.go
@@ -66,9 +66,7 @@ func NewServerReflectionClient(baseURL string, doer rerpc.Doer, opts ...rerpc.Cl
 		doer,
 		rerpc.StreamTypeBidirectional,
 		baseURL,
-		"internal.reflection.v1alpha1", // protobuf package
-		"ServerReflection",             // protobuf service
-		"ServerReflectionInfo",         // protobuf method
+		"internal.reflection.v1alpha1.ServerReflection/ServerReflectionInfo",
 		opts...,
 	)
 	if err != nil {
@@ -134,9 +132,8 @@ func NewFullServerReflection(svc FullServerReflectionServer, opts ...rerpc.Handl
 
 	serverReflectionInfo, err := rerpc.NewStreamingHandler(
 		rerpc.StreamTypeBidirectional,
-		"internal.reflection.v1alpha1", // protobuf package
-		"ServerReflection",             // protobuf service
-		"ServerReflectionInfo",         // protobuf method
+		"internal.reflection.v1alpha1.ServerReflection/ServerReflectionInfo", // procedure name
+		"internal.reflection.v1alpha1.ServerReflection",                      // reflection name
 		func(ctx context.Context, sender rerpc.Sender, receiver rerpc.Receiver) {
 			typed := handlerstream.NewBidirectional[v1alpha.ServerReflectionRequest, v1alpha.ServerReflectionResponse](sender, receiver)
 			err := svc.ServerReflectionInfo(ctx, typed)

--- a/internal/gen/proto/go-rerpc/rerpc/ping/v1test/ping_rerpc.pb.go
+++ b/internal/gen/proto/go-rerpc/rerpc/ping/v1test/ping_rerpc.pb.go
@@ -67,9 +67,7 @@ func NewPingServiceClient(baseURL string, doer rerpc.Doer, opts ...rerpc.ClientO
 	pingFunc, err := rerpc.NewClientFunc[v1test.PingRequest, v1test.PingResponse](
 		doer,
 		baseURL,
-		"rerpc.ping.v1test", // protobuf package
-		"PingService",       // protobuf service
-		"Ping",              // protobuf method
+		"rerpc.ping.v1test.PingService/Ping",
 		opts...,
 	)
 	if err != nil {
@@ -78,9 +76,7 @@ func NewPingServiceClient(baseURL string, doer rerpc.Doer, opts ...rerpc.ClientO
 	failFunc, err := rerpc.NewClientFunc[v1test.FailRequest, v1test.FailResponse](
 		doer,
 		baseURL,
-		"rerpc.ping.v1test", // protobuf package
-		"PingService",       // protobuf service
-		"Fail",              // protobuf method
+		"rerpc.ping.v1test.PingService/Fail",
 		opts...,
 	)
 	if err != nil {
@@ -90,9 +86,7 @@ func NewPingServiceClient(baseURL string, doer rerpc.Doer, opts ...rerpc.ClientO
 		doer,
 		rerpc.StreamTypeClient,
 		baseURL,
-		"rerpc.ping.v1test", // protobuf package
-		"PingService",       // protobuf service
-		"Sum",               // protobuf method
+		"rerpc.ping.v1test.PingService/Sum",
 		opts...,
 	)
 	if err != nil {
@@ -102,9 +96,7 @@ func NewPingServiceClient(baseURL string, doer rerpc.Doer, opts ...rerpc.ClientO
 		doer,
 		rerpc.StreamTypeServer,
 		baseURL,
-		"rerpc.ping.v1test", // protobuf package
-		"PingService",       // protobuf service
-		"CountUp",           // protobuf method
+		"rerpc.ping.v1test.PingService/CountUp",
 		opts...,
 	)
 	if err != nil {
@@ -114,9 +106,7 @@ func NewPingServiceClient(baseURL string, doer rerpc.Doer, opts ...rerpc.ClientO
 		doer,
 		rerpc.StreamTypeBidirectional,
 		baseURL,
-		"rerpc.ping.v1test", // protobuf package
-		"PingService",       // protobuf service
-		"CumSum",            // protobuf method
+		"rerpc.ping.v1test.PingService/CumSum",
 		opts...,
 	)
 	if err != nil {
@@ -250,9 +240,8 @@ func NewFullPingService(svc FullPingServiceServer, opts ...rerpc.HandlerOption) 
 	}, opts...)
 
 	ping, err := rerpc.NewUnaryHandler(
-		"rerpc.ping.v1test", // protobuf package
-		"PingService",       // protobuf service
-		"Ping",              // protobuf method
+		"rerpc.ping.v1test.PingService/Ping", // procedure name
+		"rerpc.ping.v1test.PingService",      // reflection name
 		svc.Ping,
 		opts...,
 	)
@@ -262,9 +251,8 @@ func NewFullPingService(svc FullPingServiceServer, opts ...rerpc.HandlerOption) 
 	handlers = append(handlers, *ping)
 
 	fail, err := rerpc.NewUnaryHandler(
-		"rerpc.ping.v1test", // protobuf package
-		"PingService",       // protobuf service
-		"Fail",              // protobuf method
+		"rerpc.ping.v1test.PingService/Fail", // procedure name
+		"rerpc.ping.v1test.PingService",      // reflection name
 		svc.Fail,
 		opts...,
 	)
@@ -275,9 +263,8 @@ func NewFullPingService(svc FullPingServiceServer, opts ...rerpc.HandlerOption) 
 
 	sum, err := rerpc.NewStreamingHandler(
 		rerpc.StreamTypeClient,
-		"rerpc.ping.v1test", // protobuf package
-		"PingService",       // protobuf service
-		"Sum",               // protobuf method
+		"rerpc.ping.v1test.PingService/Sum", // procedure name
+		"rerpc.ping.v1test.PingService",     // reflection name
 		func(ctx context.Context, sender rerpc.Sender, receiver rerpc.Receiver) {
 			typed := handlerstream.NewClient[v1test.SumRequest, v1test.SumResponse](sender, receiver)
 			err := svc.Sum(ctx, typed)
@@ -303,9 +290,8 @@ func NewFullPingService(svc FullPingServiceServer, opts ...rerpc.HandlerOption) 
 
 	countUp, err := rerpc.NewStreamingHandler(
 		rerpc.StreamTypeServer,
-		"rerpc.ping.v1test", // protobuf package
-		"PingService",       // protobuf service
-		"CountUp",           // protobuf method
+		"rerpc.ping.v1test.PingService/CountUp", // procedure name
+		"rerpc.ping.v1test.PingService",         // reflection name
 		func(ctx context.Context, sender rerpc.Sender, receiver rerpc.Receiver) {
 			typed := handlerstream.NewServer[v1test.CountUpResponse](sender)
 			req, err := rerpc.ReceiveRequest[v1test.CountUpRequest](receiver)
@@ -340,9 +326,8 @@ func NewFullPingService(svc FullPingServiceServer, opts ...rerpc.HandlerOption) 
 
 	cumSum, err := rerpc.NewStreamingHandler(
 		rerpc.StreamTypeBidirectional,
-		"rerpc.ping.v1test", // protobuf package
-		"PingService",       // protobuf service
-		"CumSum",            // protobuf method
+		"rerpc.ping.v1test.PingService/CumSum", // procedure name
+		"rerpc.ping.v1test.PingService",        // reflection name
 		func(ctx context.Context, sender rerpc.Sender, receiver rerpc.Receiver) {
 			typed := handlerstream.NewBidirectional[v1test.CumSumRequest, v1test.CumSumResponse](sender, receiver)
 			err := svc.CumSum(ctx, typed)

--- a/reflection/reflection.go
+++ b/reflection/reflection.go
@@ -44,12 +44,15 @@ type Registrar interface {
 // https://github.com/grpc/grpc/blob/master/doc/server-reflection.md, and
 // https://github.com/fullstorydev/grpcurl.
 func NewService(reg Registrar, opts ...rerpc.HandlerOption) *rerpc.Service {
-	const pkg = "grpc.reflection.v1alpha"
+	const (
+		prefix      = "internal.reflection.v1alpha1."
+		replacement = "grpc.reflection.v1alpha."
+	)
 	opts = append([]rerpc.HandlerOption{
 		rerpc.Codec(protobuf.NameBinary, protobuf.NewBinary()),
 		rerpc.Codec(protobuf.NameJSON, protobuf.NewJSON()),
 	}, opts...)
-	opts = append(opts, rerpc.OverrideProtobufPackage(pkg))
+	opts = append(opts, rerpc.ReplaceProcedurePrefix(prefix, replacement))
 	return reflectionrpc.NewFullServerReflection(
 		&server{reg: reg},
 		opts...,

--- a/reflection/reflection_test.go
+++ b/reflection/reflection_test.go
@@ -46,7 +46,7 @@ func TestReflection(t *testing.T) {
 	](
 		server.Client(),
 		server.URL,
-		"grpc.reflection.v1alpha", "ServerReflection", "ServerReflectionInfo",
+		"grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
 		rerpc.Codec(protobuf.NameBinary, protobuf.NewBinary()),
 	)
 	assert.Nil(t, err, "client construction error")

--- a/registrar.go
+++ b/registrar.go
@@ -45,13 +45,9 @@ func (r *Registrar) IsRegistered(service string) bool {
 
 // Registers a protobuf package and service combination. Safe to call
 // concurrently.
-func (r *Registrar) register(pkg, service string) {
-	if pkg == "" || service == "" {
-		return
-	}
-	fqn := pkg + "." + service
+func (r *Registrar) register(name string) {
 	r.mu.Lock()
-	r.services[fqn] = struct{}{}
+	r.services[name] = struct{}{}
 	r.mu.Unlock()
 }
 


### PR DESCRIPTION
Rather than having the main package deal directly in the
protobuf-specific triple of (package name, service name, method name),
have the generated code set the full procedure name and the name exposed
for reflection.

Fixes #29.
