### PR TITLE
Use plain http.Header throughout

### DIFF
--- a/client.go
+++ b/client.go
@@ -135,7 +135,7 @@ func NewClientStream(
 		}
 		h := make(http.Header, 8) // arbitrary power of two, prevent immediate resizing
 		pclient.WriteRequestHeader(h)
-		sender, receiver := pclient.NewStream(ctx, Header{raw: h})
+		sender, receiver := pclient.NewStream(ctx, h)
 		if ic := cfg.Interceptor; ic != nil {
 			sender = ic.WrapSender(ctx, sender)
 			receiver = ic.WrapReceiver(ctx, receiver)
@@ -200,7 +200,7 @@ func NewClientFunc[Req, Res any](
 		// To make the specification and RPC headers visible to the full interceptor
 		// chain (as though they were supplied by the caller), we'll add them here.
 		msg.spec = spec
-		pclient.WriteRequestHeader(msg.Header().raw)
+		pclient.WriteRequestHeader(msg.Header())
 		res, err := send(ctx, msg)
 		if err != nil {
 			return nil, err

--- a/clientstream/stream.go
+++ b/clientstream/stream.go
@@ -2,7 +2,11 @@
 // point of view.
 package clientstream
 
-import "github.com/rerpc/rerpc"
+import (
+	"net/http"
+
+	"github.com/rerpc/rerpc"
+)
 
 // Client is the client's view of a client streaming RPC.
 type Client[Req, Res any] struct {
@@ -17,7 +21,7 @@ func NewClient[Req, Res any](s rerpc.Sender, r rerpc.Receiver) *Client[Req, Res]
 
 // Header returns the request headers. Headers are sent to the server with the
 // first call to Send.
-func (c *Client[Req, Res]) Header() rerpc.Header {
+func (c *Client[Req, Res]) Header() http.Header {
 	return c.sender.Header()
 }
 
@@ -66,7 +70,7 @@ func (s *Server[Res]) Receive() (*Res, error) {
 
 // ReceivedHeader returns the headers received from the server. It blocks until
 // the first call to Receive returns.
-func (s *Server[Res]) ReceivedHeader() rerpc.Header {
+func (s *Server[Res]) ReceivedHeader() http.Header {
 	return s.receiver.Header()
 }
 
@@ -88,7 +92,7 @@ func NewBidirectional[Req, Res any](s rerpc.Sender, r rerpc.Receiver) *Bidirecti
 
 // Header returns the request headers. Headers are sent with the first call to
 // Send.
-func (b *Bidirectional[Req, Res]) Header() rerpc.Header {
+func (b *Bidirectional[Req, Res]) Header() http.Header {
 	return b.sender.Header()
 }
 
@@ -120,6 +124,6 @@ func (b *Bidirectional[Req, Res]) CloseReceive() error {
 
 // ReceivedHeader returns the headers received from the server. It blocks until
 // the first call to Receive returns.
-func (b *Bidirectional[Req, Res]) ReceivedHeader() rerpc.Header {
+func (b *Bidirectional[Req, Res]) ReceivedHeader() http.Header {
 	return b.receiver.Header()
 }

--- a/handler.go
+++ b/handler.go
@@ -181,9 +181,7 @@ func NewUnaryHandler[Req, Res any](
 			_ = sender.Close(err)
 			return
 		}
-		for k, v := range res.Header().raw {
-			sender.Header().raw[k] = v
-		}
+		mergeHeaders(sender.Header(), res.Header())
 		_ = sender.Close(sender.Send(res.Any()))
 	}
 
@@ -282,10 +280,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// error to be seen by interceptors, so we provide no-op Sender and
 		// Receiver implementations.
 		if clientVisibleError != nil && sender == nil {
-			sender = newNopSender(h.spec, Header{raw: w.Header()})
+			sender = newNopSender(h.spec, w.Header())
 		}
 		if clientVisibleError != nil && receiver == nil {
-			receiver = newNopReceiver(h.spec, Header{raw: r.Header})
+			receiver = newNopReceiver(h.spec, r.Header)
 		}
 		if ic := h.interceptor; ic != nil {
 			// Unary interceptors were handled in NewUnaryHandler.

--- a/handler_stream.go
+++ b/handler_stream.go
@@ -80,8 +80,8 @@ func (hs *handlerSender) Spec() Specification {
 	return hs.spec
 }
 
-func (hs *handlerSender) Header() Header {
-	return Header{raw: hs.writer.Header()}
+func (hs *handlerSender) Header() http.Header {
+	return hs.writer.Header()
 }
 
 func (hs *handlerSender) sendErrorGRPC(err error) error {
@@ -101,7 +101,7 @@ func (hs *handlerSender) sendErrorGRPC(err error) error {
 	}
 	hs.writer.Header().Set("Grpc-Status", code)
 	hs.writer.Header().Set("Grpc-Message", percentEncode(s.Message))
-	hs.writer.Header().Set("Grpc-Status-Details-Bin", encodeBinaryHeader(bin))
+	hs.writer.Header().Set("Grpc-Status-Details-Bin", EncodeBinaryHeader(bin))
 	return nil
 }
 
@@ -147,8 +147,8 @@ func (hr *handlerReceiver) Spec() Specification {
 	return hr.spec
 }
 
-func (hr *handlerReceiver) Header() Header {
-	return Header{raw: hr.request.Header}
+func (hr *handlerReceiver) Header() http.Header {
+	return hr.request.Header
 }
 
 func statusFromError(err error) *statuspb.Status {

--- a/interceptor.go
+++ b/interceptor.go
@@ -2,12 +2,13 @@ package rerpc
 
 import (
 	"context"
+	"net/http"
 )
 
 type AnyRequest interface {
 	Any() any
 	Spec() Specification
-	Header() Header
+	Header() http.Header
 
 	// Only internal implementations, so we can add methods without breaking
 	// backward compatibility.
@@ -16,7 +17,7 @@ type AnyRequest interface {
 
 type AnyResponse interface {
 	Any() any
-	Header() Header
+	Header() http.Header
 
 	// Only internal implementations, so we can add methods without breaking
 	// backward compatibility.

--- a/interceptor_ext_test.go
+++ b/interceptor_ext_test.go
@@ -102,8 +102,8 @@ func TestOnionOrderingEndToEnd(t *testing.T) {
 	// Helper function: returns a function that asserts that there's some value
 	// set for header "expect", and adds a value for header "add".
 	newInspector := func(expect, add string) func(rerpc.Specification,
-		rerpc.Header) {
-		return func(spec rerpc.Specification, h rerpc.Header) {
+		http.Header) {
+		return func(spec rerpc.Specification, h http.Header) {
 			if expect != "" {
 				assert.NotZero(
 					t,
@@ -117,7 +117,7 @@ func TestOnionOrderingEndToEnd(t *testing.T) {
 	}
 	// Helper function: asserts that there's a value present for header keys
 	// "one", "two", "three", and "four".
-	assertAllPresent := func(spec rerpc.Specification, h rerpc.Header) {
+	assertAllPresent := func(spec rerpc.Specification, h http.Header) {
 		for _, k := range []string{"one", "two", "three", "four"} {
 			assert.NotZero(
 				t,
@@ -142,7 +142,7 @@ func TestOnionOrderingEndToEnd(t *testing.T) {
 	clientOnion := rerpc.Interceptors(
 		rerpc.NewHeaderInterceptor(
 			// 1 (start). request: should see protocol-related headers
-			func(_ rerpc.Specification, h rerpc.Header) {
+			func(_ rerpc.Specification, h http.Header) {
 				assert.NotZero(t, h.Get("Grpc-Accept-Encoding"), "grpc-accept-encoding missing")
 			},
 			// 12 (end). response: check "one"-"four"

--- a/protocol.go
+++ b/protocol.go
@@ -93,8 +93,9 @@ type protocolClient interface {
 
 	// NewStream constructs a Sender and Receiver for the message exchange.
 	//
-	// When constructing a stream for a unary call, implementations may assume
-	// that the sender's Send and Close methods return before the receiver's
-	// Receive or Close methods are called.
-	NewStream(context.Context, Header) (Sender, Receiver)
+	// Implementations should assume that the supplied HTTP headers have already
+	// been populated by WriteRequestHeader. When constructing a stream for a
+	// unary call, implementations may assume that the sender's Send and Close
+	// methods return before the receiver's Receive or Close methods are called.
+	NewStream(context.Context, http.Header) (Sender, Receiver)
 }

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -200,7 +200,7 @@ func (g *grpcClient) WriteRequestHeader(h http.Header) {
 	h["Te"] = []string{"trailers"}
 }
 
-func (g *grpcClient) NewStream(ctx context.Context, h Header) (Sender, Receiver) {
+func (g *grpcClient) NewStream(ctx context.Context, h http.Header) (Sender, Receiver) {
 	// In a typical HTTP/1.1 request, we'd put the body into a bytes.Buffer, hand
 	// the buffer to http.NewRequest, and fire off the request with doer.Do. That
 	// won't work here because we're establishing a stream - we don't even have

--- a/stream.go
+++ b/stream.go
@@ -9,14 +9,14 @@ type Request[Req any] struct {
 	Msg *Req
 
 	spec Specification
-	hdr  Header
+	hdr  http.Header
 }
 
 // NewRequest constructs a Request.
 func NewRequest[Req any](msg *Req) *Request[Req] {
 	return &Request[Req]{
 		Msg: msg,
-		hdr: Header{raw: make(http.Header)},
+		hdr: make(http.Header),
 	}
 }
 
@@ -47,7 +47,7 @@ func (r *Request[_]) Spec() Specification {
 }
 
 // Header returns the HTTP headers for this request.
-func (r *Request[_]) Header() Header {
+func (r *Request[_]) Header() http.Header {
 	return r.hdr
 }
 
@@ -58,14 +58,14 @@ func (r *Request[_]) internalOnly() {}
 type Response[Res any] struct {
 	Msg *Res
 
-	hdr Header
+	hdr http.Header
 }
 
 // NewResponse constructs a Response.
 func NewResponse[Res any](msg *Res) *Response[Res] {
 	return &Response[Res]{
 		Msg: msg,
-		hdr: Header{raw: make(http.Header)},
+		hdr: make(http.Header),
 	}
 }
 
@@ -90,7 +90,7 @@ func (r *Response[_]) Any() any {
 }
 
 // Header returns the HTTP headers for this response.
-func (r *Response[_]) Header() Header {
+func (r *Response[_]) Header() http.Header {
 	return r.hdr
 }
 
@@ -103,7 +103,7 @@ type Sender interface {
 	Close(error) error
 
 	Spec() Specification
-	Header() Header
+	Header() http.Header
 }
 
 // Receiver is the readable side of a bidirectional stream of messages.
@@ -112,24 +112,24 @@ type Receiver interface {
 	Close() error
 
 	Spec() Specification
-	Header() Header
+	Header() http.Header
 }
 
 type nopSender struct {
 	spec   Specification
-	header Header
+	header http.Header
 }
 
 var _ Sender = (*nopSender)(nil)
 
-func newNopSender(spec Specification, header Header) *nopSender {
+func newNopSender(spec Specification, header http.Header) *nopSender {
 	return &nopSender{
 		spec:   spec,
 		header: header,
 	}
 }
 
-func (n *nopSender) Header() Header {
+func (n *nopSender) Header() http.Header {
 	return n.header
 }
 
@@ -147,12 +147,12 @@ func (n *nopSender) Close(_ error) error {
 
 type nopReceiver struct {
 	spec   Specification
-	header Header
+	header http.Header
 }
 
 var _ Receiver = (*nopReceiver)(nil)
 
-func newNopReceiver(spec Specification, header Header) *nopReceiver {
+func newNopReceiver(spec Specification, header http.Header) *nopReceiver {
 	return &nopReceiver{
 		spec:   spec,
 		header: header,
@@ -163,7 +163,7 @@ func (n *nopReceiver) Spec() Specification {
 	return n.spec
 }
 
-func (n *nopReceiver) Header() Header {
+func (n *nopReceiver) Header() http.Header {
 	return n.header
 }
 


### PR DESCRIPTION
Remove our wrapper type and use plain http.Header throughout. This is
simpler and more similar to net/http, though there's now a chance for
users to write headers that are meaningful to the protocol (e.g.,
Transfer-Encoding or Grpc-Encoding) and encountering errors.

If we want pluggable protocols, we need something like this anyways.
Protocols need to write transport-level headers, so we'd need a way to
bypass validation. Once validation isn't guaranteed, it's a lot less
valuable - and what does it mean to validate headers if some third-party
protocol has assigned meaning to `X-Foo-Encoding`?

Depends on #55.