### PR TITLE
Update Github Actions configuration

### DIFF
--- a/.github/codeql-analysis.disabled.yml
+++ b/.github/codeql-analysis.disabled.yml
@@ -10,6 +10,7 @@
 # supported CodeQL languages.
 #
 name: "CodeQL"
+# TODO: Re-enable when CodeQL supports Go 1.18.
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.0-beta1]
+        go-version: [1.18.0-beta2]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -29,5 +29,5 @@ jobs:
       - name: Test
         run: make test
       - name: Lint
-        if: matrix.go-version == '1.18.0-beta1'
+        if: matrix.go-version == '1.18.0-beta2'
         run: make lint


### PR DESCRIPTION
CodeQL doesn't support Go 1.18 yet, so we should just disable it for
now. Tests should run on Go 1.18beta2 now that it's released.

cc @doriable