### PR TITLE
Switch to makego and delete crosstests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           stable: false
-          go-version: 1.18rc1
+          go-version: 1.18.0-rc1
       - name: cache
         if: success()
         uses: actions/cache@v2


### PR DESCRIPTION
This likely deletes some of the stuff that was previously in the `Makefile`, although I preserved `make bench` somewhat hackily.

This doesn't really work though because of the multiple go modules, see TODO.