### PR TITLE
Improve docs on unexported types

### DIFF
--- a/example_init_test.go
+++ b/example_init_test.go
@@ -16,8 +16,10 @@ var examplePingServer *inMemoryServer
 // inMemoryServer is an HTTP server that uses in-memory pipes instead of TCP.
 // It supports HTTP/2 and has TLS enabled.
 //
-// It's intended to be a preconfigured, faster alternative to the standard
-// library's httptest.inMemoryServer.
+// The Go Playground panics if we try to start a TCP-backed server. If you're
+// not familiar with the Playground's behavior, it looks like our examples are
+// broken. This server lets us write examples that work in the playground
+// without abstracting over HTTP.
 type inMemoryServer struct {
 	server   *httptest.Server
 	listener *memoryListener

--- a/protocol.go
+++ b/protocol.go
@@ -16,6 +16,10 @@ import (
 // puts those strings into the "Grpc-Timeout" HTTP header. Other protocols
 // might encode durations differently, put them into a different HTTP header,
 // or ignore them entirely.
+//
+// We don't have any short-term plans to export this interface; it's just here
+// to separate the protocol-specific portions of connect from the
+// protocol-agnostic plumbing.
 type protocol interface {
 	NewHandler(*protocolHandlerParams) protocolHandler
 	NewClient(*protocolClientParams) (protocolClient, error)


### PR DESCRIPTION
Add a bit to the documentation for the `inMemoryServer` and `protocol`
types, explaining what they are and why we have them. They're not
exported, but it may be worth explaining their purpose to readers
browsing the code.
