### PR TITLE
Make consume-to-end streams iterators

### DIFF
--- a/health/health_test.go
+++ b/health/health_test.go
@@ -80,10 +80,10 @@ func TestHealth(t *testing.T) {
 		)
 		assert.Nil(t, err, "rpc error")
 		defer stream.Close()
-		_, err = stream.Receive()
-		assert.NotNil(t, err, "receive err")
+		assert.False(t, stream.Receive(), "receive")
+		assert.NotNil(t, stream.Err(), "receive err")
 		var connectErr *connect.Error
-		ok := errors.As(err, &connectErr)
+		ok := errors.As(stream.Err(), &connectErr)
 		assert.True(t, ok, "convert to connect error")
 		assert.Equal(t, connectErr.Code(), connect.CodeUnimplemented, "error code")
 	})


### PR DESCRIPTION
The handler's view of client streaming RPCs and the client's view of
server streaming RPCs are both consume-to-end iterators. Today, working
with these streams is awkward: the success cases end up deeply nested in
`if errors.Is(err, io.EOF)` blocks.

Per Luke's suggestion, this commit changes these stream types to look
more like `bufio.Scanner`. To my eye, this makes the user's code a lot
easier to follow.
