### PR TITLE
Move CodeOf to code.go

### DIFF
--- a/code.go
+++ b/code.go
@@ -187,6 +187,15 @@ func (c Code) String() string {
 	return fmt.Sprintf("Code(%d)", c)
 }
 
+// CodeOf returns the error's status code if it is or wraps a *connect.Error
+// and CodeUnknown otherwise.
+func CodeOf(err error) Code {
+	if connectErr, ok := asError(err); ok {
+		return connectErr.Code()
+	}
+	return CodeUnknown
+}
+
 func httpToCode(httpCode int) Code {
 	// https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md
 	// Note that this is not just the inverse of the gRPC-to-HTTP mapping.

--- a/error.go
+++ b/error.go
@@ -132,15 +132,6 @@ func (e *Error) Trailer() http.Header {
 	return e.trailer
 }
 
-// CodeOf returns the error's status code if it is or wraps a *connect.Error
-// and CodeUnknown otherwise.
-func CodeOf(err error) Code {
-	if connectErr, ok := asError(err); ok {
-		return connectErr.Code()
-	}
-	return CodeUnknown
-}
-
 // errorf calls fmt.Errorf with the supplied template and arguments, then wraps
 // the resulting error.
 func errorf(c Code, template string, args ...any) *Error {


### PR DESCRIPTION
I get why it was in `error.go` but it seems to make more sense that code-related things go in `code.go`, thoughts?