### PR TITLE
Change error variable name to err for generated New.*Client functions

### DIFF
--- a/cmd/protoc-gen-connect-go/generate.go
+++ b/cmd/protoc-gen-connect-go/generate.go
@@ -204,7 +204,7 @@ func clientImplementation(g *protogen.GeneratedFile, service *protogen.Service, 
 		", opts ...", clientOption, ") (", names.Client, ", error) {")
 	g.P("baseURL = ", stringsPackage.Ident("TrimRight"), `(baseURL, "/")`)
 	for _, method := range service.Methods {
-		g.P(unexport(method.GoName), "Client, ", unexport(method.GoName), "Err := ",
+		g.P(unexport(method.GoName), "Client, err := ",
 			connectPackage.Ident("NewClient"),
 			"[", method.Input.GoIdent, ", ", method.Output.GoIdent, "]",
 			"(",
@@ -214,8 +214,8 @@ func clientImplementation(g *protogen.GeneratedFile, service *protogen.Service, 
 		g.P("doer,")
 		g.P("opts...,")
 		g.P(")")
-		g.P("if ", unexport(method.GoName), "Err != nil {")
-		g.P("return nil, ", unexport(method.GoName), "Err")
+		g.P("if err != nil {")
+		g.P("return nil, err")
 		g.P("}")
 	}
 	g.P("return &", names.ClientImpl, "{")

--- a/internal/gen/proto/connect/connect/ping/v1test/ping_connect.pb.go
+++ b/internal/gen/proto/connect/connect/ping/v1test/ping_connect.pb.go
@@ -56,50 +56,50 @@ type PingServiceClient interface {
 // https://acme.com/grpc).
 func NewPingServiceClient(baseURL string, doer connect.Doer, opts ...connect.ClientOption) (PingServiceClient, error) {
 	baseURL = strings.TrimRight(baseURL, "/")
-	pingClient, pingErr := connect.NewClient[v1test.PingRequest, v1test.PingResponse](
+	pingClient, err := connect.NewClient[v1test.PingRequest, v1test.PingResponse](
 		baseURL,
 		"connect.ping.v1test.PingService/Ping",
 		doer,
 		opts...,
 	)
-	if pingErr != nil {
-		return nil, pingErr
+	if err != nil {
+		return nil, err
 	}
-	failClient, failErr := connect.NewClient[v1test.FailRequest, v1test.FailResponse](
+	failClient, err := connect.NewClient[v1test.FailRequest, v1test.FailResponse](
 		baseURL,
 		"connect.ping.v1test.PingService/Fail",
 		doer,
 		opts...,
 	)
-	if failErr != nil {
-		return nil, failErr
+	if err != nil {
+		return nil, err
 	}
-	sumClient, sumErr := connect.NewClient[v1test.SumRequest, v1test.SumResponse](
+	sumClient, err := connect.NewClient[v1test.SumRequest, v1test.SumResponse](
 		baseURL,
 		"connect.ping.v1test.PingService/Sum",
 		doer,
 		opts...,
 	)
-	if sumErr != nil {
-		return nil, sumErr
+	if err != nil {
+		return nil, err
 	}
-	countUpClient, countUpErr := connect.NewClient[v1test.CountUpRequest, v1test.CountUpResponse](
+	countUpClient, err := connect.NewClient[v1test.CountUpRequest, v1test.CountUpResponse](
 		baseURL,
 		"connect.ping.v1test.PingService/CountUp",
 		doer,
 		opts...,
 	)
-	if countUpErr != nil {
-		return nil, countUpErr
+	if err != nil {
+		return nil, err
 	}
-	cumSumClient, cumSumErr := connect.NewClient[v1test.CumSumRequest, v1test.CumSumResponse](
+	cumSumClient, err := connect.NewClient[v1test.CumSumRequest, v1test.CumSumResponse](
 		baseURL,
 		"connect.ping.v1test.PingService/CumSum",
 		doer,
 		opts...,
 	)
-	if cumSumErr != nil {
-		return nil, cumSumErr
+	if err != nil {
+		return nil, err
 	}
 	return &pingServiceClient{
 		ping:    pingClient,

--- a/internal/gen/proto/connect/grpc/health/v1/health_connect.pb.go
+++ b/internal/gen/proto/connect/grpc/health/v1/health_connect.pb.go
@@ -65,23 +65,23 @@ type HealthClient interface {
 // https://acme.com/grpc).
 func NewHealthClient(baseURL string, doer connect.Doer, opts ...connect.ClientOption) (HealthClient, error) {
 	baseURL = strings.TrimRight(baseURL, "/")
-	checkClient, checkErr := connect.NewClient[v1.HealthCheckRequest, v1.HealthCheckResponse](
+	checkClient, err := connect.NewClient[v1.HealthCheckRequest, v1.HealthCheckResponse](
 		baseURL,
 		"internal.health.v1.Health/Check",
 		doer,
 		opts...,
 	)
-	if checkErr != nil {
-		return nil, checkErr
+	if err != nil {
+		return nil, err
 	}
-	watchClient, watchErr := connect.NewClient[v1.HealthCheckRequest, v1.HealthCheckResponse](
+	watchClient, err := connect.NewClient[v1.HealthCheckRequest, v1.HealthCheckResponse](
 		baseURL,
 		"internal.health.v1.Health/Watch",
 		doer,
 		opts...,
 	)
-	if watchErr != nil {
-		return nil, watchErr
+	if err != nil {
+		return nil, err
 	}
 	return &healthClient{
 		check: checkClient,

--- a/internal/gen/proto/connect/grpc/reflection/v1alpha/reflection_connect.pb.go
+++ b/internal/gen/proto/connect/grpc/reflection/v1alpha/reflection_connect.pb.go
@@ -50,14 +50,14 @@ type ServerReflectionClient interface {
 // https://acme.com/grpc).
 func NewServerReflectionClient(baseURL string, doer connect.Doer, opts ...connect.ClientOption) (ServerReflectionClient, error) {
 	baseURL = strings.TrimRight(baseURL, "/")
-	serverReflectionInfoClient, serverReflectionInfoErr := connect.NewClient[v1alpha.ServerReflectionRequest, v1alpha.ServerReflectionResponse](
+	serverReflectionInfoClient, err := connect.NewClient[v1alpha.ServerReflectionRequest, v1alpha.ServerReflectionResponse](
 		baseURL,
 		"internal.reflection.v1alpha1.ServerReflection/ServerReflectionInfo",
 		doer,
 		opts...,
 	)
-	if serverReflectionInfoErr != nil {
-		return nil, serverReflectionInfoErr
+	if err != nil {
+		return nil, err
 	}
 	return &serverReflectionClient{
 		serverReflectionInfo: serverReflectionInfoClient,


### PR DESCRIPTION
The nittiest of nits: this changes the error variable name to `err` from `methodNameErr` when calling `NewClient` in generated `New.*Client` functions. There's no need to have a separate variable name for each - after each assignment to `err`, we check `if err != nil` anyways, and just naming this error variable `err` seems more idiomatic.