### PR TITLE
Don't spam the terminal by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+MAKEFLAGS += --no-print-directory
 MAKEGO := make/go
 MAKEGO_REMOTE := https://github.com/bufbuild/makego.git
 PROJECT := connect


### PR DESCRIPTION
GNU Make 4.0 was released in October 2013, so it's now common. It
drastically increases the spamminess of our Make setup, since it
effectively logs to stdout every time a sub-make invocation starts and
ends. This line suppresses the spam by default and has no effect on GNU
Make 3.8 (OS X's default).
