### PR TITLE
Simplify internal/assert

### DIFF
--- a/code_test.go
+++ b/code_test.go
@@ -32,7 +32,7 @@ func TestCode(t *testing.T) {
 		assert.False(
 			t,
 			strings.Contains(code.String(), "("),
-			"update Code.String() method for new codes!",
+			assert.Sprintf("update Code.String() method for new code %v", code),
 		)
 	}
 }

--- a/error_test.go
+++ b/error_test.go
@@ -29,19 +29,19 @@ import (
 
 func TestErrorNilUnderlying(t *testing.T) {
 	err := NewError(CodeUnknown, nil)
-	assert.NotNil(t, err, "should be allowed to wrap a nil error")
-	assert.Equal(t, err.Error(), CodeUnknown.String(), "message")
-	assert.Equal(t, err.Code(), CodeUnknown, "code")
-	assert.Zero(t, err.Details(), "details")
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), CodeUnknown.String())
+	assert.Equal(t, err.Code(), CodeUnknown)
+	assert.Zero(t, err.Details())
 	detail, anyErr := anypb.New(&emptypb.Empty{})
-	assert.Nil(t, anyErr, "create proto.Any")
+	assert.Nil(t, anyErr)
 	err.AddDetail(detail)
-	assert.Equal(t, len(err.Details()), 1, "details")
+	assert.Equal(t, len(err.Details()), 1)
 	err.Header().Set("foo", "bar")
-	assert.Equal(t, err.Header().Get("foo"), "bar", "header")
+	assert.Equal(t, err.Header().Get("foo"), "bar")
 	err.Trailer().Set("baz", "quux")
-	assert.Equal(t, err.Trailer().Get("baz"), "quux", "trailer")
-	assert.Equal(t, CodeOf(err), CodeUnknown, "code")
+	assert.Equal(t, err.Trailer().Get("baz"), "quux")
+	assert.Equal(t, CodeOf(err), CodeUnknown)
 }
 
 func TestErrorFormatting(t *testing.T) {
@@ -49,11 +49,10 @@ func TestErrorFormatting(t *testing.T) {
 		t,
 		NewError(CodeUnavailable, errors.New("")).Error(),
 		CodeUnavailable.String(),
-		"no message",
 	)
 	got := NewError(CodeUnavailable, errors.New("foo")).Error()
-	assert.True(t, strings.Contains(got, CodeUnavailable.String()), "error text should include code")
-	assert.True(t, strings.Contains(got, "foo"), "error text should include message")
+	assert.True(t, strings.Contains(got, CodeUnavailable.String()))
+	assert.True(t, strings.Contains(got, "foo"))
 }
 
 func TestErrorCode(t *testing.T) {
@@ -62,8 +61,8 @@ func TestErrorCode(t *testing.T) {
 		NewError(CodeUnavailable, errors.New("foo")),
 	)
 	connectErr, ok := asError(err)
-	assert.True(t, ok, "extract connect error")
-	assert.Equal(t, connectErr.Code(), CodeUnavailable, "extracted code")
+	assert.True(t, ok)
+	assert.Equal(t, connectErr.Code(), CodeUnavailable)
 }
 
 func TestCodeOf(t *testing.T) {
@@ -71,17 +70,16 @@ func TestCodeOf(t *testing.T) {
 		t,
 		CodeOf(NewError(CodeUnavailable, errors.New("foo"))),
 		CodeUnavailable,
-		"explicitly-set code",
 	)
-	assert.Equal(t, CodeOf(errors.New("foo")), CodeUnknown, "fallback code")
+	assert.Equal(t, CodeOf(errors.New("foo")), CodeUnknown)
 }
 
 func TestErrorDetails(t *testing.T) {
 	second := durationpb.New(time.Second)
 	detail, err := anypb.New(second)
-	assert.Nil(t, err, "create anypb.Any")
+	assert.Nil(t, err)
 	connectErr := NewError(CodeUnknown, errors.New("error with details"))
-	assert.Zero(t, connectErr.Details(), "details before adding")
+	assert.Zero(t, connectErr.Details())
 	connectErr.AddDetail(detail)
-	assert.Equal(t, connectErr.Details(), []ErrorDetail{detail}, "details after adding")
+	assert.Equal(t, connectErr.Details(), []ErrorDetail{detail})
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -16,7 +16,6 @@ package connect_test
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -44,23 +43,23 @@ func TestHandlerReadMaxBytes(t *testing.T) {
 		server.URL,
 		connect.WithGRPC(),
 	)
-	assert.Nil(t, err, "client construction error")
+	assert.Nil(t, err)
 
 	padding := "padding                      "
 	req := &pingpb.PingRequest{Number: 42, Text: padding}
 	// Ensure that the probe is actually too big.
 	probeBytes, err := proto.Marshal(req)
-	assert.Nil(t, err, "marshal request")
-	assert.Equal(t, len(probeBytes), readMaxBytes+1, "probe size")
+	assert.Nil(t, err)
+	assert.Equal(t, len(probeBytes), readMaxBytes+1)
 
 	_, err = client.Ping(context.Background(), connect.NewEnvelope(req))
 
-	assert.NotNil(t, err, "ping error")
-	assert.Equal(t, connect.CodeOf(err), connect.CodeInvalidArgument, "error code")
+	assert.NotNil(t, err)
+	assert.Equal(t, connect.CodeOf(err), connect.CodeInvalidArgument)
 	const expect = "larger than configured max"
 	assert.True(
 		t,
 		strings.Contains(err.Error(), expect),
-		fmt.Sprintf("error msg %q contains %q", err.Error(), expect),
+		assert.Sprintf("error msg %q contains %q", err.Error(), expect),
 	)
 }

--- a/header_test.go
+++ b/header_test.go
@@ -55,11 +55,11 @@ func TestPercentEncodingQuick(t *testing.T) {
 
 func TestPercentEncoding(t *testing.T) {
 	roundtrip := func(input string) {
-		assert.True(t, utf8.ValidString(input), "input invalid UTF-8")
+		assert.True(t, utf8.ValidString(input), assert.Sprintf("input invalid UTF-8"))
 		encoded := percentEncode(input)
 		t.Logf("%q encoded as %q", input, encoded)
 		decoded := percentDecode(encoded)
-		assert.Equal(t, decoded, input, "roundtrip corrupted string")
+		assert.Equal(t, decoded, input)
 	}
 
 	roundtrip("foo")
@@ -82,5 +82,5 @@ func TestHeaderMerge(t *testing.T) {
 		"Bar": []string{"one"},
 		"Baz": nil,
 	}
-	assert.Equal(t, header, expect, "merge result")
+	assert.Equal(t, header, expect)
 }

--- a/health_test.go
+++ b/health_test.go
@@ -49,34 +49,34 @@ func TestHealth(t *testing.T) {
 		server.URL+"/grpc.health.v1.Health/Check",
 		connect.WithGRPC(),
 	)
-	assert.Nil(t, err, "client construction error")
+	assert.Nil(t, err)
 
 	t.Run("process", func(t *testing.T) {
 		res, err := client.CallUnary(
 			context.Background(),
 			connect.NewEnvelope(&healthpb.HealthCheckRequest{}),
 		)
-		assert.Nil(t, err, "rpc error")
-		assert.Equal(t, res.Msg.Status, connect.HealthStatusServing, "status")
+		assert.Nil(t, err)
+		assert.Equal(t, res.Msg.Status, connect.HealthStatusServing)
 	})
 	t.Run("known", func(t *testing.T) {
 		res, err := client.CallUnary(
 			context.Background(),
 			connect.NewEnvelope(&healthpb.HealthCheckRequest{Service: pingFQN}),
 		)
-		assert.Nil(t, err, "rpc error")
-		assert.Equal(t, res.Msg.Status, connect.HealthStatusServing, "status")
+		assert.Nil(t, err)
+		assert.Equal(t, res.Msg.Status, connect.HealthStatusServing)
 	})
 	t.Run("unknown", func(t *testing.T) {
 		_, err := client.CallUnary(
 			context.Background(),
 			connect.NewEnvelope(&healthpb.HealthCheckRequest{Service: unknown}),
 		)
-		assert.NotNil(t, err, "rpc error")
+		assert.NotNil(t, err)
 		var connectErr *connect.Error
 		ok := errors.As(err, &connectErr)
-		assert.True(t, ok, "convert to connect error")
-		assert.Equal(t, connectErr.Code(), connect.CodeNotFound, "error code")
+		assert.True(t, ok)
+		assert.Equal(t, connectErr.Code(), connect.CodeNotFound)
 	})
 	t.Run("watch", func(t *testing.T) {
 		client, err := connect.NewClient[healthpb.HealthCheckRequest, healthpb.HealthCheckResponse](
@@ -84,18 +84,18 @@ func TestHealth(t *testing.T) {
 			server.URL+"/grpc.health.v1.Health/Watch",
 			connect.WithGRPC(),
 		)
-		assert.Nil(t, err, "client construction error")
+		assert.Nil(t, err)
 		stream, err := client.CallServerStream(
 			context.Background(),
 			connect.NewEnvelope(&healthpb.HealthCheckRequest{Service: pingFQN}),
 		)
-		assert.Nil(t, err, "rpc error")
+		assert.Nil(t, err)
 		defer stream.Close()
-		assert.False(t, stream.Receive(), "receive")
-		assert.NotNil(t, stream.Err(), "receive err")
+		assert.False(t, stream.Receive())
+		assert.NotNil(t, stream.Err())
 		var connectErr *connect.Error
 		ok := errors.As(stream.Err(), &connectErr)
-		assert.True(t, ok, "convert to connect error")
-		assert.Equal(t, connectErr.Code(), connect.CodeUnimplemented, "error code")
+		assert.True(t, ok)
+		assert.Equal(t, connectErr.Code(), connect.CodeUnimplemented)
 	})
 }

--- a/interceptor_ext_test.go
+++ b/interceptor_ext_test.go
@@ -16,7 +16,6 @@ package connect_test
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -30,7 +29,7 @@ import (
 
 func TestClientStreamErrors(t *testing.T) {
 	_, err := pingrpc.NewPingServiceClient(http.DefaultClient, "INVALID_URL", connect.WithGRPC())
-	assert.NotNil(t, err, "client construction error")
+	assert.NotNil(t, err)
 	// We don't even get to calling methods on the client, so there's no question
 	// of interceptors running. Once we're calling methods on the client, all
 	// errors are visible to interceptors.
@@ -60,13 +59,13 @@ func TestHandlerStreamErrors(t *testing.T) {
 			server.URL+"/connect.ping.v1test.PingService/Ping",
 			strings.NewReader(""),
 		)
-		assert.Nil(t, err, "error constructing request")
+		assert.Nil(t, err)
 		request.Header.Set("Content-Type", "application/grpc+proto")
 		request.Header.Set("Grpc-Timeout", "INVALID")
 		res, err := server.Client().Do(request)
-		assert.Nil(t, err, "network error sending request")
-		assert.Equal(t, res.StatusCode, http.StatusOK, "response HTTP status")
-		assert.True(t, called, "expected interceptors to be called")
+		assert.Nil(t, err)
+		assert.Equal(t, res.StatusCode, http.StatusOK)
+		assert.True(t, called)
 	})
 	t.Run("stream", func(t *testing.T) {
 		defer reset()
@@ -75,13 +74,13 @@ func TestHandlerStreamErrors(t *testing.T) {
 			server.URL+"/connect.ping.v1test.PingService/CountUp",
 			strings.NewReader(""),
 		)
-		assert.Nil(t, err, "error constructing request")
+		assert.Nil(t, err)
 		request.Header.Set("Content-Type", "application/grpc+proto")
 		request.Header.Set("Grpc-Timeout", "INVALID")
 		res, err := server.Client().Do(request)
-		assert.Nil(t, err, "network error sending request")
-		assert.Equal(t, res.StatusCode, http.StatusOK, "response HTTP status")
-		assert.True(t, called, "expected interceptors to be called")
+		assert.Nil(t, err)
+		assert.Equal(t, res.StatusCode, http.StatusOK)
+		assert.True(t, called)
 	})
 }
 
@@ -94,7 +93,7 @@ func TestOnionOrderingEndToEnd(t *testing.T) {
 				assert.NotZero(
 					t,
 					h.Get(expect),
-					fmt.Sprintf(
+					assert.Sprintf(
 						"%s (IsClient %v): header %q missing: %v",
 						spec.Procedure,
 						spec.IsClient,
@@ -113,7 +112,7 @@ func TestOnionOrderingEndToEnd(t *testing.T) {
 			assert.NotZero(
 				t,
 				h.Get(k),
-				fmt.Sprintf(
+				assert.Sprintf(
 					"%s (IsClient %v): checking all headers, %q missing: %v",
 					spec.Procedure,
 					spec.IsClient,
@@ -139,7 +138,7 @@ func TestOnionOrderingEndToEnd(t *testing.T) {
 		newHeaderInterceptor(
 			// 1 (start). request: should see protocol-related headers
 			func(_ connect.Specification, h http.Header) {
-				assert.NotZero(t, h.Get("Grpc-Accept-Encoding"), "grpc-accept-encoding missing")
+				assert.NotZero(t, h.Get("Grpc-Accept-Encoding"))
 			},
 			// 12 (end). response: check "one"-"four"
 			assertAllPresent,
@@ -184,13 +183,13 @@ func TestOnionOrderingEndToEnd(t *testing.T) {
 		connect.WithGRPC(),
 		clientOnion,
 	)
-	assert.Nil(t, err, "client construction error")
+	assert.Nil(t, err)
 
 	_, err = client.Ping(context.Background(), connect.NewEnvelope(&pingpb.PingRequest{Number: 10}))
-	assert.Nil(t, err, "error calling Ping")
+	assert.Nil(t, err)
 
 	_, err = client.CountUp(context.Background(), connect.NewEnvelope(&pingpb.CountUpRequest{Number: 10}))
-	assert.Nil(t, err, "error calling CountUp")
+	assert.Nil(t, err)
 }
 
 // headerInterceptor makes it easier to write interceptors that inspect or

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -22,63 +22,63 @@ import (
 
 func TestAssertions(t *testing.T) {
 	t.Run("equal", func(t *testing.T) {
-		Equal(t, 1, 1, "1 == 1")
-		NotEqual(t, 1, 2, "1 != 2")
+		Equal(t, 1, 1, Sprintf("1 == %d", 1))
+		NotEqual(t, 1, 2)
 	})
 
 	t.Run("nil", func(t *testing.T) {
-		Nil(t, nil, "")
-		Nil(t, (*chan int)(nil), "")
-		Nil(t, (*func())(nil), "")
-		Nil(t, (*map[int]int)(nil), "")
-		Nil(t, (*pair)(nil), "")
-		Nil(t, (*[]int)(nil), "")
+		Nil(t, nil)
+		Nil(t, (*chan int)(nil))
+		Nil(t, (*func())(nil))
+		Nil(t, (*map[int]int)(nil))
+		Nil(t, (*pair)(nil))
+		Nil(t, (*[]int)(nil))
 
-		NotNil(t, make(chan int), "")
-		NotNil(t, func() {}, "")
-		NotNil(t, any(1), "")
-		NotNil(t, make(map[int]int), "")
-		NotNil(t, &pair{}, "")
-		NotNil(t, make([]int, 0), "")
+		NotNil(t, make(chan int))
+		NotNil(t, func() {})
+		NotNil(t, any(1))
+		NotNil(t, make(map[int]int))
+		NotNil(t, &pair{})
+		NotNil(t, make([]int, 0))
 
-		NotNil(t, "foo", "")
-		NotNil(t, 0, "")
-		NotNil(t, false, "")
-		NotNil(t, pair{}, "")
+		NotNil(t, "foo")
+		NotNil(t, 0)
+		NotNil(t, false)
+		NotNil(t, pair{})
 	})
 
 	t.Run("zero", func(t *testing.T) {
 		var n *int
-		Zero(t, n, "")
+		Zero(t, n)
 		var p pair
-		Zero(t, p, "")
+		Zero(t, p)
 		var null *pair
-		Zero(t, null, "")
+		Zero(t, null)
 		var s []int
-		Zero(t, s, "")
+		Zero(t, s)
 		var m map[string]string
-		Zero(t, m, "")
-		NotZero(t, 3, "")
+		Zero(t, m)
+		NotZero(t, 3)
 	})
 
 	t.Run("error chain", func(t *testing.T) {
 		want := errors.New("base error")
-		ErrorIs(t, fmt.Errorf("context: %w", want), want, "")
+		ErrorIs(t, fmt.Errorf("context: %w", want), want)
 	})
 
 	t.Run("unexported fields", func(t *testing.T) {
 		// Two pairs differ only in an unexported field.
 		p1 := pair{1, 2}
 		p2 := pair{1, 3}
-		NotEqual(t, p1, p2, "")
+		NotEqual(t, p1, p2)
 	})
 
 	t.Run("regexp", func(t *testing.T) {
-		Match(t, "foobar", `^foo`, "")
+		Match(t, "foobar", `^foo`)
 	})
 
 	t.Run("panics", func(t *testing.T) {
-		Panics(t, func() { panic("testing") }, "")
+		Panics(t, func() { panic("testing") })
 	})
 }
 

--- a/protobuf_util_test.go
+++ b/protobuf_util_test.go
@@ -15,7 +15,6 @@
 package connect
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/bufbuild/connect/internal/assert"
@@ -59,6 +58,5 @@ func assertParsedProtobufURL(t testing.TB, inputURL, expectService, expectPath s
 			FullyQualifiedServiceName: expectService,
 			ProtoPath:                 expectPath,
 		},
-		fmt.Sprintf("%q", inputURL),
 	)
 }

--- a/protocol_grpc_timeout_test.go
+++ b/protocol_grpc_timeout_test.go
@@ -25,38 +25,38 @@ import (
 
 func TestParseTimeout(t *testing.T) {
 	_, err := parseTimeout("")
-	assert.True(t, err == errNoTimeout, "expect errNoTimeout for empty string")
+	assert.True(t, err == errNoTimeout)
 
 	_, err = parseTimeout("foo")
-	assert.NotNil(t, err, "foo")
+	assert.NotNil(t, err)
 	_, err = parseTimeout("12xS")
-	assert.NotNil(t, err, "12xS")
+	assert.NotNil(t, err)
 	_, err = parseTimeout("999999999n") // 9 digits
-	assert.NotNil(t, err, "too many digits")
-	assert.False(t, err == errNoTimeout, "too many digits")
+	assert.NotNil(t, err)
+	assert.False(t, err == errNoTimeout)
 	_, err = parseTimeout("99999999H") // 8 digits but overflows time.Duration
-	assert.True(t, err == errNoTimeout, "effectively unbounded")
+	assert.True(t, err == errNoTimeout)
 
 	d, err := parseTimeout("45S")
-	assert.Nil(t, err, "45S")
-	assert.Equal(t, d, 45*time.Second, "45S")
+	assert.Nil(t, err)
+	assert.Equal(t, d, 45*time.Second)
 
 	const long = "99999999S"
 	d, err = parseTimeout(long) // 8 digits, shouldn't overflow
-	assert.Nil(t, err, long)
-	assert.Equal(t, d, 99999999*time.Second, long)
+	assert.Nil(t, err)
+	assert.Equal(t, d, 99999999*time.Second)
 }
 
 func TestEncodeTimeout(t *testing.T) {
 	to, err := encodeTimeout(time.Hour + time.Second)
-	assert.Nil(t, err, "1h1s")
-	assert.Equal(t, to, "3601000m", "1h1s")
+	assert.Nil(t, err)
+	assert.Equal(t, to, "3601000m")
 	to, err = encodeTimeout(time.Duration(math.MaxInt64))
-	assert.Nil(t, err, "max duration")
-	assert.Equal(t, to, "2562047H", "max duration")
+	assert.Nil(t, err)
+	assert.Equal(t, to, "2562047H")
 	to, err = encodeTimeout(-1 * time.Hour)
-	assert.Nil(t, err, "negative duration")
-	assert.Equal(t, to, "0n", "negative duration")
+	assert.Nil(t, err)
+	assert.Equal(t, to, "0n")
 }
 
 func TestEncodeTimeoutQuick(t *testing.T) {

--- a/reflection_test.go
+++ b/reflection_test.go
@@ -51,7 +51,7 @@ func TestReflection(t *testing.T) {
 		server.URL+"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
 		connect.WithGRPC(),
 	)
-	assert.Nil(t, err, "client construction error")
+	assert.Nil(t, err)
 	call := func(req *reflectionpb.ServerReflectionRequest) (*reflectionpb.ServerReflectionResponse, error) {
 		res, err := client.CallUnary(context.Background(), connect.NewEnvelope(req))
 		if err != nil {
@@ -68,7 +68,7 @@ func TestReflection(t *testing.T) {
 			},
 		}
 		res, err := call(req)
-		assert.Nil(t, err, "reflection RPC error")
+		assert.Nil(t, err)
 		expect := &reflectionpb.ServerReflectionResponse{
 			ValidHost:       req.Host,
 			OriginalRequest: req,
@@ -80,7 +80,7 @@ func TestReflection(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, res, expect, "response")
+		assert.Equal(t, res, expect)
 	})
 	t.Run("file_by_filename", func(t *testing.T) {
 		req := &reflectionpb.ServerReflectionRequest{
@@ -90,15 +90,14 @@ func TestReflection(t *testing.T) {
 			},
 		}
 		res, err := call(req)
-		assert.Nil(t, err, "reflection RPC error")
-		assert.Nil(t, res.GetErrorResponse(), "error in response")
+		assert.Nil(t, err)
+		assert.Nil(t, res.GetErrorResponse())
 		fds := res.GetFileDescriptorResponse()
-		assert.NotNil(t, fds, "file descriptor response")
-		assert.Equal(t, len(fds.FileDescriptorProto), 1, "number of fds returned")
+		assert.NotNil(t, fds)
+		assert.Equal(t, len(fds.FileDescriptorProto), 1)
 		assert.True(
 			t,
 			bytes.Contains(fds.FileDescriptorProto[0], []byte(pingRequestFQN)),
-			"fd should contain PingRequest struct",
 		)
 	})
 	t.Run("file_containing_symbol", func(t *testing.T) {
@@ -109,15 +108,14 @@ func TestReflection(t *testing.T) {
 			},
 		}
 		res, err := call(req)
-		assert.Nil(t, err, "reflection RPC error")
-		assert.Nil(t, res.GetErrorResponse(), "error in response")
+		assert.Nil(t, err)
+		assert.Nil(t, res.GetErrorResponse())
 		fds := res.GetFileDescriptorResponse()
-		assert.NotNil(t, fds, "file descriptor response")
-		assert.Equal(t, len(fds.FileDescriptorProto), 1, "number of fds returned")
+		assert.NotNil(t, fds)
+		assert.Equal(t, len(fds.FileDescriptorProto), 1)
 		assert.True(
 			t,
 			bytes.Contains(fds.FileDescriptorProto[0], []byte(pingRequestFQN)),
-			"fd should contain PingRequest struct",
 		)
 	})
 	t.Run("file_containing_extension", func(t *testing.T) {
@@ -131,11 +129,11 @@ func TestReflection(t *testing.T) {
 			},
 		}
 		res, err := call(req)
-		assert.Nil(t, err, "reflection RPC error")
+		assert.Nil(t, err)
 		msgerr := res.GetErrorResponse()
-		assert.NotNil(t, msgerr, "error in response proto")
-		assert.Equal(t, msgerr.ErrorCode, int32(connect.CodeNotFound), "error code")
-		assert.NotZero(t, msgerr.ErrorMessage, "error message")
+		assert.NotNil(t, msgerr)
+		assert.Equal(t, msgerr.ErrorCode, int32(connect.CodeNotFound))
+		assert.NotZero(t, msgerr.ErrorMessage)
 	})
 	t.Run("all_extension_numbers_of_type", func(t *testing.T) {
 		req := &reflectionpb.ServerReflectionRequest{
@@ -145,7 +143,7 @@ func TestReflection(t *testing.T) {
 			},
 		}
 		res, err := call(req)
-		assert.Nil(t, err, "reflection RPC error")
+		assert.Nil(t, err)
 		expect := &reflectionpb.ServerReflectionResponse{
 			ValidHost:       req.Host,
 			OriginalRequest: req,
@@ -155,6 +153,6 @@ func TestReflection(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, res, expect, "response")
+		assert.Equal(t, res, expect)
 	})
 }


### PR DESCRIPTION
Our `internal/assert` package used to sport more features, but we've gradually
trimmed it down to a small core. This PR removes the nearly-unused `params`
struct and makes assertion messages optional.

At this point, `params` should be reserved for structs used to pass large
numbers of parameters (for example, `protocolHandlerParams`). `config` structs
are used only for functional options.

Fixes #122.
