### PR TITLE
Leverage managed mode more

### DIFF
--- a/internal/proto/connectext/grpc/health/v1/health.proto
+++ b/internal/proto/connectext/grpc/health/v1/health.proto
@@ -22,8 +22,6 @@ syntax = "proto3";
 //   https://github.com/grpc/grpc/blob/master/src/proto/grpc/health/v1/health.proto
 package internal.health.v1;
 
-option go_package = "github.com/bufbuild/connect/internal/gen/proto/go/grpc/health/v1;healthpb";
-
 message HealthCheckRequest {
   string service = 1;
 }

--- a/internal/proto/connectext/grpc/reflection/v1alpha/reflection.proto
+++ b/internal/proto/connectext/grpc/reflection/v1alpha/reflection.proto
@@ -22,8 +22,6 @@ syntax = "proto3";
 //   https://github.com/grpc/grpc/blob/master/src/proto/grpc/reflection/v1alpha/reflection.proto
 package internal.reflection.v1alpha1;
 
-option go_package = "github.com/bufbuild/connect/internal/gen/proto/go/grpc/status/v1alpha1;reflectionpb";
-
 service ServerReflection {
   // The reflection service is structured as a bidirectional stream, ensuring
   // all related requests go to a single server.

--- a/internal/proto/connectext/grpc/status/v1/status.proto
+++ b/internal/proto/connectext/grpc/status/v1/status.proto
@@ -20,8 +20,6 @@ package grpc.status.v1;
 
 import "google/protobuf/any.proto";
 
-option go_package = "github.com/bufbuild/connect/internal/gen/proto/go/grpc/status/v1;statuspb";
-
 // See https://cloud.google.com/apis/design/errors.
 //
 // This struct must remain binary-compatible with


### PR DESCRIPTION
We don't need `go_package` options in the protobuf files anymore, since
we're using Buf's managed mode.
