### PR TITLE
Revert "Assign handler variable"

### DIFF
--- a/reflection.go
+++ b/reflection.go
@@ -32,7 +32,7 @@ import "net/http"
 // https://github.com/fullstorydev/grpcurl.
 func NewReflectionHandler(registrar *Registrar, options ...HandlerOption) (string, http.Handler) {
 	const serviceName = "/grpc.reflection.v1alpha.ServerReflection/"
-	handler := NewBidiStreamHandler(
+	return serviceName, NewBidiStreamHandler(
 		serviceName+"ServerReflectionInfo",
 		registrar.serverReflectionInfo,
 		// To avoid runtime panics from protobuf registry conflicts with
@@ -43,5 +43,4 @@ func NewReflectionHandler(registrar *Registrar, options ...HandlerOption) (strin
 		WithHandlerOptions(options...),
 		&disableRegistrationOption{},
 	)
-	return serviceName, handler
 }


### PR DESCRIPTION
Reverts bufbuild/connect#138. We just decided that we don't need to hit these issues as they come up for now, we're just going to wait until https://pkg.go.dev/golang.org/x/tools/go/analysis is good to go for 1.18.