### PR TITLE
No request trailers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ type PingServer struct {
 
 func (ps *PingServer) Ping(
   ctx context.Context,
-  req *connect.Envelope[pingv1.PingRequest]) (*connect.Envelope[pingv1.PingResponse], error) {
-  // connect.Envelope gives you direct access to headers and trailers.
-  // No context-based nonsense!
+  req *connect.Request[pingv1.PingRequest]) (*connect.Response[pingv1.PingResponse], error) {
+  // connect.Request and connect.Response give you direct access to headers and
+  // trailers. No context-based nonsense!
   log.Println(req.Header().Get("Some-Header"))
-  res := connect.NewEnvelope(&pingv1.PingResponse{
-    // req.Msg is a strongly-typed *pingv1.PingRequest, so
-    // we can access its fields without type assertions.
+  res := connect.NewResponse(&pingv1.PingResponse{
+    // req.Msg is a strongly-typed *pingv1.PingRequest, so we can access its
+    // fields without type assertions.
     Number: req.Msg.Number,
   })
   res.Header().Set("Some-Other-Header", "hello!")
@@ -97,7 +97,7 @@ func main() {
   if err != nil {
     log.Fatalln(err)
   }
-  req := connect.NewEnvelope(&pingv1.PingRequest{
+  req := connect.NewRequest(&pingv1.PingRequest{
     Number: 42,
   })
   req.Header().Set("Some-Header", "hello from connect")

--- a/client_example_test.go
+++ b/client_example_test.go
@@ -70,7 +70,7 @@ func Example_client() {
 	}
 	res, err := client.Ping(
 		context.Background(),
-		connect.NewEnvelope(&pingv1.PingRequest{Number: 42}),
+		connect.NewRequest(&pingv1.PingRequest{Number: 42}),
 	)
 	if err != nil {
 		logger.Println("error:", err)

--- a/client_stream.go
+++ b/client_stream.go
@@ -45,11 +45,11 @@ func (c *ClientStreamForClient[Req, Res]) Send(msg *Req) error {
 
 // CloseAndReceive closes the send side of the stream and waits for the
 // response.
-func (c *ClientStreamForClient[Req, Res]) CloseAndReceive() (*Envelope[Res], error) {
+func (c *ClientStreamForClient[Req, Res]) CloseAndReceive() (*Response[Res], error) {
 	if err := c.sender.Close(nil); err != nil {
 		return nil, err
 	}
-	res, err := receiveUnaryEnvelope[Res](c.receiver)
+	res, err := receiveUnaryResponse[Res](c.receiver)
 	if err != nil {
 		_ = c.receiver.Close()
 		return nil, err

--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -268,7 +268,7 @@ func clientSignature(g *protogen.GeneratedFile, method *protogen.Method, named b
 	}
 	if method.Desc.IsStreamingServer() {
 		return method.GoName + "(" + ctxName + " " + g.QualifiedGoIdent(contextPackage.Ident("Context")) +
-			", " + reqName + " *" + g.QualifiedGoIdent(connectPackage.Ident("Envelope")) + "[" +
+			", " + reqName + " *" + g.QualifiedGoIdent(connectPackage.Ident("Request")) + "[" +
 			g.QualifiedGoIdent(method.Input.GoIdent) + "]) " +
 			"(*" + g.QualifiedGoIdent(connectPackage.Ident("ServerStreamForClient")) +
 			"[" + g.QualifiedGoIdent(method.Output.GoIdent) + "]" +
@@ -384,7 +384,7 @@ func serverSignatureParams(g *protogen.GeneratedFile, method *protogen.Method, n
 	if method.Desc.IsStreamingServer() {
 		// server streaming
 		return "(" + ctxName + g.QualifiedGoIdent(contextPackage.Ident("Context")) +
-			", " + reqName + "*" + g.QualifiedGoIdent(connectPackage.Ident("Envelope")) + "[" +
+			", " + reqName + "*" + g.QualifiedGoIdent(connectPackage.Ident("Request")) + "[" +
 			g.QualifiedGoIdent(method.Input.GoIdent) + "], " +
 			streamName + "*" + g.QualifiedGoIdent(connectPackage.Ident("ServerStream")) +
 			"[" + g.QualifiedGoIdent(method.Output.GoIdent) + "]" +
@@ -392,9 +392,9 @@ func serverSignatureParams(g *protogen.GeneratedFile, method *protogen.Method, n
 	}
 	// unary
 	return "(" + ctxName + g.QualifiedGoIdent(contextPackage.Ident("Context")) +
-		", " + reqName + "*" + g.QualifiedGoIdent(connectPackage.Ident("Envelope")) + "[" +
+		", " + reqName + "*" + g.QualifiedGoIdent(connectPackage.Ident("Request")) + "[" +
 		g.QualifiedGoIdent(method.Input.GoIdent) + "]) " +
-		"(*" + g.QualifiedGoIdent(connectPackage.Ident("Envelope")) + "[" +
+		"(*" + g.QualifiedGoIdent(connectPackage.Ident("Response")) + "[" +
 		g.QualifiedGoIdent(method.Output.GoIdent) + "], error)"
 }
 

--- a/handler_example_test.go
+++ b/handler_example_test.go
@@ -33,9 +33,9 @@ type ExamplePingServer struct {
 // Ping implements pingv1connect.PingServiceHandler.
 func (*ExamplePingServer) Ping(
 	_ context.Context,
-	req *connect.Envelope[pingv1.PingRequest],
-) (*connect.Envelope[pingv1.PingResponse], error) {
-	return connect.NewEnvelope(&pingv1.PingResponse{
+	req *connect.Request[pingv1.PingRequest],
+) (*connect.Response[pingv1.PingResponse], error) {
+	return connect.NewResponse(&pingv1.PingResponse{
 		Number: req.Msg.Number,
 		Text:   req.Msg.Text,
 	}), nil

--- a/handler_stream.go
+++ b/handler_stream.go
@@ -68,7 +68,7 @@ func (c *ClientStream[Req, Res]) Err() error {
 
 // SendAndClose closes the receive side of the stream, then sends a response
 // back to the client.
-func (c *ClientStream[Req, Res]) SendAndClose(envelope *Envelope[Res]) error {
+func (c *ClientStream[Req, Res]) SendAndClose(envelope *Response[Res]) error {
 	if err := c.receiver.Close(); err != nil {
 		return err
 	}

--- a/handler_test.go
+++ b/handler_test.go
@@ -52,7 +52,7 @@ func TestHandlerReadMaxBytes(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, len(probeBytes), readMaxBytes+1)
 
-	_, err = client.Ping(context.Background(), connect.NewEnvelope(req))
+	_, err = client.Ping(context.Background(), connect.NewRequest(req))
 
 	assert.NotNil(t, err)
 	assert.Equal(t, connect.CodeOf(err), connect.CodeInvalidArgument)

--- a/health.go
+++ b/health.go
@@ -93,12 +93,12 @@ func NewHealthHandler(
 	mux := http.NewServeMux()
 	check := NewUnaryHandler(
 		serviceName+"Check",
-		func(ctx context.Context, req *Envelope[healthv1.HealthCheckRequest]) (*Envelope[healthv1.HealthCheckResponse], error) {
+		func(ctx context.Context, req *Request[healthv1.HealthCheckRequest]) (*Response[healthv1.HealthCheckResponse], error) {
 			status, err := checker(ctx, req.Msg.Service)
 			if err != nil {
 				return nil, err
 			}
-			return NewEnvelope(&healthv1.HealthCheckResponse{Status: status}), nil
+			return NewResponse(&healthv1.HealthCheckResponse{Status: status}), nil
 		},
 		WithHandlerOptions(options...),
 		// To avoid runtime panics from protobuf registry conflicts with
@@ -113,7 +113,7 @@ func NewHealthHandler(
 		serviceName+"Watch",
 		func(
 			_ context.Context,
-			_ *Envelope[healthv1.HealthCheckRequest],
+			_ *Request[healthv1.HealthCheckRequest],
 			_ *ServerStream[healthv1.HealthCheckResponse],
 		) error {
 			return NewError(

--- a/health_test.go
+++ b/health_test.go
@@ -54,7 +54,7 @@ func TestHealth(t *testing.T) {
 	t.Run("process", func(t *testing.T) {
 		res, err := client.CallUnary(
 			context.Background(),
-			connect.NewEnvelope(&healthv1.HealthCheckRequest{}),
+			connect.NewRequest(&healthv1.HealthCheckRequest{}),
 		)
 		assert.Nil(t, err)
 		assert.Equal(t, res.Msg.Status, connect.HealthStatusServing)
@@ -62,7 +62,7 @@ func TestHealth(t *testing.T) {
 	t.Run("known", func(t *testing.T) {
 		res, err := client.CallUnary(
 			context.Background(),
-			connect.NewEnvelope(&healthv1.HealthCheckRequest{Service: pingFQN}),
+			connect.NewRequest(&healthv1.HealthCheckRequest{Service: pingFQN}),
 		)
 		assert.Nil(t, err)
 		assert.Equal(t, res.Msg.Status, connect.HealthStatusServing)
@@ -70,7 +70,7 @@ func TestHealth(t *testing.T) {
 	t.Run("unknown", func(t *testing.T) {
 		_, err := client.CallUnary(
 			context.Background(),
-			connect.NewEnvelope(&healthv1.HealthCheckRequest{Service: unknown}),
+			connect.NewRequest(&healthv1.HealthCheckRequest{Service: unknown}),
 		)
 		assert.NotNil(t, err)
 		var connectErr *connect.Error
@@ -87,7 +87,7 @@ func TestHealth(t *testing.T) {
 		assert.Nil(t, err)
 		stream, err := client.CallServerStream(
 			context.Background(),
-			connect.NewEnvelope(&healthv1.HealthCheckRequest{Service: pingFQN}),
+			connect.NewRequest(&healthv1.HealthCheckRequest{Service: pingFQN}),
 		)
 		assert.Nil(t, err)
 		defer stream.Close()

--- a/interceptor.go
+++ b/interceptor.go
@@ -20,9 +20,10 @@ import (
 
 // UnaryFunc is the generic signature of a unary RPC. Interceptors wrap Funcs.
 //
-// The type of the request and response struct depend on the codec being used.
-// When using protobuf, they'll always be proto.Message implementations.
-type UnaryFunc func(context.Context, AnyEnvelope) (AnyEnvelope, error)
+// The type of the request and response structs depend on the codec being used.
+// When using protobuf, request.Any() and response.Any() will always be
+// proto.Message implementations.
+type UnaryFunc func(context.Context, AnyRequest) (AnyResponse, error)
 
 // An Interceptor adds logic to a generated handler or client, like the
 // decorators or middleware you may have seen in other libraries. Interceptors

--- a/interceptor_example_test.go
+++ b/interceptor_example_test.go
@@ -28,7 +28,7 @@ func ExampleInterceptor() {
 	logger := log.New(os.Stdout, "" /* prefix */, 0 /* flags */)
 	loggingInterceptor := connect.UnaryInterceptorFunc(
 		func(next connect.UnaryFunc) connect.UnaryFunc {
-			return connect.UnaryFunc(func(ctx context.Context, req connect.AnyEnvelope) (connect.AnyEnvelope, error) {
+			return connect.UnaryFunc(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 				logger.Println("calling:", req.Spec().Procedure)
 				logger.Println("request:", req.Any())
 				res, err := next(ctx, req)
@@ -51,7 +51,7 @@ func ExampleInterceptor() {
 		logger.Println("error:", err)
 		return
 	}
-	client.Ping(context.Background(), connect.NewEnvelope(&pingv1.PingRequest{Number: 42}))
+	client.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{Number: 42}))
 
 	// Output:
 	// calling: /connect.ping.v1.PingService/Ping
@@ -63,7 +63,7 @@ func ExampleWithInterceptors() {
 	logger := log.New(os.Stdout, "" /* prefix */, 0 /* flags */)
 	outer := connect.UnaryInterceptorFunc(
 		func(next connect.UnaryFunc) connect.UnaryFunc {
-			return connect.UnaryFunc(func(ctx context.Context, req connect.AnyEnvelope) (connect.AnyEnvelope, error) {
+			return connect.UnaryFunc(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 				logger.Println("outer interceptor: before call")
 				res, err := next(ctx, req)
 				logger.Println("outer interceptor: after call")
@@ -73,7 +73,7 @@ func ExampleWithInterceptors() {
 	)
 	inner := connect.UnaryInterceptorFunc(
 		func(next connect.UnaryFunc) connect.UnaryFunc {
-			return connect.UnaryFunc(func(ctx context.Context, req connect.AnyEnvelope) (connect.AnyEnvelope, error) {
+			return connect.UnaryFunc(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 				logger.Println("inner interceptor: before call")
 				res, err := next(ctx, req)
 				logger.Println("inner interceptor: after call")
@@ -91,7 +91,7 @@ func ExampleWithInterceptors() {
 		logger.Println("error:", err)
 		return
 	}
-	client.Ping(context.Background(), connect.NewEnvelope(&pingv1.PingRequest{}))
+	client.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{}))
 
 	// Output:
 	// outer interceptor: before call

--- a/interceptor_ext_test.go
+++ b/interceptor_ext_test.go
@@ -185,10 +185,10 @@ func TestOnionOrderingEndToEnd(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	_, err = client.Ping(context.Background(), connect.NewEnvelope(&pingv1.PingRequest{Number: 10}))
+	_, err = client.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{Number: 10}))
 	assert.Nil(t, err)
 
-	_, err = client.CountUp(context.Background(), connect.NewEnvelope(&pingv1.CountUpRequest{Number: 10}))
+	_, err = client.CountUp(context.Background(), connect.NewRequest(&pingv1.CountUpRequest{Number: 10}))
 	assert.Nil(t, err)
 }
 
@@ -223,7 +223,7 @@ func newHeaderInterceptor(
 }
 
 func (h *headerInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
-	f := func(ctx context.Context, req connect.AnyEnvelope) (connect.AnyEnvelope, error) {
+	f := func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 		h.inspectRequestHeader(req.Spec(), req.Header())
 		res, err := next(ctx, req)
 		if err != nil {
@@ -298,7 +298,7 @@ type assertCalledInterceptor struct {
 
 func (i *assertCalledInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 	return connect.UnaryFunc(
-		func(ctx context.Context, req connect.AnyEnvelope) (connect.AnyEnvelope, error) {
+		func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 			*i.called = true
 			return next(ctx, req)
 		},

--- a/internal/gen/connect/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/connect/connect/ping/v1/pingv1connect/ping.connect.go
@@ -37,13 +37,13 @@ const _ = connect.IsAtLeastVersion0_0_1
 // PingServiceClient is a client for the connect.ping.v1.PingService service.
 type PingServiceClient interface {
 	// Ping sends a ping to the server to determine if it's reachable.
-	Ping(context.Context, *connect.Envelope[v1.PingRequest]) (*connect.Envelope[v1.PingResponse], error)
+	Ping(context.Context, *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error)
 	// Fail always fails.
-	Fail(context.Context, *connect.Envelope[v1.FailRequest]) (*connect.Envelope[v1.FailResponse], error)
+	Fail(context.Context, *connect.Request[v1.FailRequest]) (*connect.Response[v1.FailResponse], error)
 	// Sum calculates the sum of the numbers sent on the stream.
 	Sum(context.Context) *connect.ClientStreamForClient[v1.SumRequest, v1.SumResponse]
 	// CountUp returns a stream of the numbers up to the given request.
-	CountUp(context.Context, *connect.Envelope[v1.CountUpRequest]) (*connect.ServerStreamForClient[v1.CountUpResponse], error)
+	CountUp(context.Context, *connect.Request[v1.CountUpRequest]) (*connect.ServerStreamForClient[v1.CountUpResponse], error)
 	// CumSum determines the cumulative sum of all the numbers sent on the stream.
 	CumSum(context.Context) *connect.BidiStreamForClient[v1.CumSumRequest, v1.CumSumResponse]
 }
@@ -116,12 +116,12 @@ type pingServiceClient struct {
 }
 
 // Ping calls connect.ping.v1.PingService.Ping.
-func (c *pingServiceClient) Ping(ctx context.Context, req *connect.Envelope[v1.PingRequest]) (*connect.Envelope[v1.PingResponse], error) {
+func (c *pingServiceClient) Ping(ctx context.Context, req *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error) {
 	return c.ping.CallUnary(ctx, req)
 }
 
 // Fail calls connect.ping.v1.PingService.Fail.
-func (c *pingServiceClient) Fail(ctx context.Context, req *connect.Envelope[v1.FailRequest]) (*connect.Envelope[v1.FailResponse], error) {
+func (c *pingServiceClient) Fail(ctx context.Context, req *connect.Request[v1.FailRequest]) (*connect.Response[v1.FailResponse], error) {
 	return c.fail.CallUnary(ctx, req)
 }
 
@@ -131,7 +131,7 @@ func (c *pingServiceClient) Sum(ctx context.Context) *connect.ClientStreamForCli
 }
 
 // CountUp calls connect.ping.v1.PingService.CountUp.
-func (c *pingServiceClient) CountUp(ctx context.Context, req *connect.Envelope[v1.CountUpRequest]) (*connect.ServerStreamForClient[v1.CountUpResponse], error) {
+func (c *pingServiceClient) CountUp(ctx context.Context, req *connect.Request[v1.CountUpRequest]) (*connect.ServerStreamForClient[v1.CountUpResponse], error) {
 	return c.countUp.CallServerStream(ctx, req)
 }
 
@@ -143,13 +143,13 @@ func (c *pingServiceClient) CumSum(ctx context.Context) *connect.BidiStreamForCl
 // PingServiceHandler is an implementation of the connect.ping.v1.PingService service.
 type PingServiceHandler interface {
 	// Ping sends a ping to the server to determine if it's reachable.
-	Ping(context.Context, *connect.Envelope[v1.PingRequest]) (*connect.Envelope[v1.PingResponse], error)
+	Ping(context.Context, *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error)
 	// Fail always fails.
-	Fail(context.Context, *connect.Envelope[v1.FailRequest]) (*connect.Envelope[v1.FailResponse], error)
+	Fail(context.Context, *connect.Request[v1.FailRequest]) (*connect.Response[v1.FailResponse], error)
 	// Sum calculates the sum of the numbers sent on the stream.
 	Sum(context.Context, *connect.ClientStream[v1.SumRequest, v1.SumResponse]) error
 	// CountUp returns a stream of the numbers up to the given request.
-	CountUp(context.Context, *connect.Envelope[v1.CountUpRequest], *connect.ServerStream[v1.CountUpResponse]) error
+	CountUp(context.Context, *connect.Request[v1.CountUpRequest], *connect.ServerStream[v1.CountUpResponse]) error
 	// CumSum determines the cumulative sum of all the numbers sent on the stream.
 	CumSum(context.Context, *connect.BidiStream[v1.CumSumRequest, v1.CumSumResponse]) error
 }
@@ -192,11 +192,11 @@ func NewPingServiceHandler(svc PingServiceHandler, opts ...connect.HandlerOption
 // UnimplementedPingServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedPingServiceHandler struct{}
 
-func (UnimplementedPingServiceHandler) Ping(context.Context, *connect.Envelope[v1.PingRequest]) (*connect.Envelope[v1.PingResponse], error) {
+func (UnimplementedPingServiceHandler) Ping(context.Context, *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Ping isn't implemented"))
 }
 
-func (UnimplementedPingServiceHandler) Fail(context.Context, *connect.Envelope[v1.FailRequest]) (*connect.Envelope[v1.FailResponse], error) {
+func (UnimplementedPingServiceHandler) Fail(context.Context, *connect.Request[v1.FailRequest]) (*connect.Response[v1.FailResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Fail isn't implemented"))
 }
 
@@ -204,7 +204,7 @@ func (UnimplementedPingServiceHandler) Sum(context.Context, *connect.ClientStrea
 	return connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Sum isn't implemented"))
 }
 
-func (UnimplementedPingServiceHandler) CountUp(context.Context, *connect.Envelope[v1.CountUpRequest], *connect.ServerStream[v1.CountUpResponse]) error {
+func (UnimplementedPingServiceHandler) CountUp(context.Context, *connect.Request[v1.CountUpRequest], *connect.ServerStream[v1.CountUpResponse]) error {
 	return connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.CountUp isn't implemented"))
 }
 

--- a/internal/gen/connect/connectext/grpc/health/v1/healthv1connect/health.connect.go
+++ b/internal/gen/connect/connectext/grpc/health/v1/healthv1connect/health.connect.go
@@ -38,7 +38,7 @@ const _ = connect.IsAtLeastVersion0_0_1
 type HealthClient interface {
 	// If the requested service is unknown, the call will fail with status
 	// NOT_FOUND.
-	Check(context.Context, *connect.Envelope[v1.HealthCheckRequest]) (*connect.Envelope[v1.HealthCheckResponse], error)
+	Check(context.Context, *connect.Request[v1.HealthCheckRequest]) (*connect.Response[v1.HealthCheckResponse], error)
 	// Performs a watch for the serving status of the requested service.
 	// The server will immediately send back a message indicating the current
 	// serving status.  It will then subsequently send a new message whenever
@@ -54,7 +54,7 @@ type HealthClient interface {
 	// should assume this method is not supported and should not retry the
 	// call.  If the call terminates with any other status (including OK),
 	// clients should retry the call with appropriate exponential backoff.
-	Watch(context.Context, *connect.Envelope[v1.HealthCheckRequest]) (*connect.ServerStreamForClient[v1.HealthCheckResponse], error)
+	Watch(context.Context, *connect.Request[v1.HealthCheckRequest]) (*connect.ServerStreamForClient[v1.HealthCheckResponse], error)
 }
 
 // NewHealthClient constructs a client for the internal.health.v1.Health service. By default, it
@@ -95,12 +95,12 @@ type healthClient struct {
 }
 
 // Check calls internal.health.v1.Health.Check.
-func (c *healthClient) Check(ctx context.Context, req *connect.Envelope[v1.HealthCheckRequest]) (*connect.Envelope[v1.HealthCheckResponse], error) {
+func (c *healthClient) Check(ctx context.Context, req *connect.Request[v1.HealthCheckRequest]) (*connect.Response[v1.HealthCheckResponse], error) {
 	return c.check.CallUnary(ctx, req)
 }
 
 // Watch calls internal.health.v1.Health.Watch.
-func (c *healthClient) Watch(ctx context.Context, req *connect.Envelope[v1.HealthCheckRequest]) (*connect.ServerStreamForClient[v1.HealthCheckResponse], error) {
+func (c *healthClient) Watch(ctx context.Context, req *connect.Request[v1.HealthCheckRequest]) (*connect.ServerStreamForClient[v1.HealthCheckResponse], error) {
 	return c.watch.CallServerStream(ctx, req)
 }
 
@@ -108,7 +108,7 @@ func (c *healthClient) Watch(ctx context.Context, req *connect.Envelope[v1.Healt
 type HealthHandler interface {
 	// If the requested service is unknown, the call will fail with status
 	// NOT_FOUND.
-	Check(context.Context, *connect.Envelope[v1.HealthCheckRequest]) (*connect.Envelope[v1.HealthCheckResponse], error)
+	Check(context.Context, *connect.Request[v1.HealthCheckRequest]) (*connect.Response[v1.HealthCheckResponse], error)
 	// Performs a watch for the serving status of the requested service.
 	// The server will immediately send back a message indicating the current
 	// serving status.  It will then subsequently send a new message whenever
@@ -124,7 +124,7 @@ type HealthHandler interface {
 	// should assume this method is not supported and should not retry the
 	// call.  If the call terminates with any other status (including OK),
 	// clients should retry the call with appropriate exponential backoff.
-	Watch(context.Context, *connect.Envelope[v1.HealthCheckRequest], *connect.ServerStream[v1.HealthCheckResponse]) error
+	Watch(context.Context, *connect.Request[v1.HealthCheckRequest], *connect.ServerStream[v1.HealthCheckResponse]) error
 }
 
 // NewHealthHandler builds an HTTP handler from the service implementation. It returns the path on
@@ -150,10 +150,10 @@ func NewHealthHandler(svc HealthHandler, opts ...connect.HandlerOption) (string,
 // UnimplementedHealthHandler returns CodeUnimplemented from all methods.
 type UnimplementedHealthHandler struct{}
 
-func (UnimplementedHealthHandler) Check(context.Context, *connect.Envelope[v1.HealthCheckRequest]) (*connect.Envelope[v1.HealthCheckResponse], error) {
+func (UnimplementedHealthHandler) Check(context.Context, *connect.Request[v1.HealthCheckRequest]) (*connect.Response[v1.HealthCheckResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("internal.health.v1.Health.Check isn't implemented"))
 }
 
-func (UnimplementedHealthHandler) Watch(context.Context, *connect.Envelope[v1.HealthCheckRequest], *connect.ServerStream[v1.HealthCheckResponse]) error {
+func (UnimplementedHealthHandler) Watch(context.Context, *connect.Request[v1.HealthCheckRequest], *connect.ServerStream[v1.HealthCheckResponse]) error {
 	return connect.NewError(connect.CodeUnimplemented, errors.New("internal.health.v1.Health.Watch isn't implemented"))
 }

--- a/reflection_test.go
+++ b/reflection_test.go
@@ -53,7 +53,7 @@ func TestReflection(t *testing.T) {
 	)
 	assert.Nil(t, err)
 	call := func(req *reflectionv1alpha1.ServerReflectionRequest) (*reflectionv1alpha1.ServerReflectionResponse, error) {
-		res, err := client.CallUnary(context.Background(), connect.NewEnvelope(req))
+		res, err := client.CallUnary(context.Background(), connect.NewRequest(req))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When implementing gRPC-Web support, I forgot that the gRPC specification
doesn't allow clients to send trailers. In the HTTP/2 gRPC protocol,
they can still send plain HTTP trailers - they just don't have any
special meaning to the gRPC layer. For gRPC-Web, though, we shouldn't
let clients send trailers at all.

Unfortunately, this breaks the symmetry between requests and responses,
so we're back to `Request` and `Response` instead of `Envelope`. With
all the other cleanups we've done since, though, this is less bad than
it used to be. (This effectively rolls back large portions of #85.)
