### PR TITLE
Fix trailers-only responses

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -274,13 +274,8 @@ func TestServer(t *testing.T) {
 			assert.Equal(t, connectErr.Code(), connect.CodeResourceExhausted)
 			assert.Equal(t, connectErr.Error(), "ResourceExhausted: "+errorMessage)
 			assert.Zero(t, connectErr.Details())
-			assert.Equal(t, connectErr.Header().Get(handlerHeader), headerValue)
-			// FIXME: whether the metadata set by the handler is sent as HTTP headers
-			// or trailers is complex: it depends on the gRPC variant in use and
-			// whether or not any messages were sent on the stream. This isn't great,
-			// since changing protocols now requires code changes.
-			t.Skip("FIXME: address in next commit")
-			assert.Equal(t, connectErr.Trailer().Get(handlerTrailer), trailerValue)
+			assert.Equal(t, connectErr.Meta().Get(handlerHeader), headerValue)
+			assert.Equal(t, connectErr.Meta().Get(handlerTrailer), trailerValue)
 		})
 	}
 	testMatrix := func(t *testing.T, server *httptest.Server, bidi bool) {
@@ -438,8 +433,8 @@ func (p pingServer) Fail(ctx context.Context, req *connect.Request[pingv1.FailRe
 		return nil, err
 	}
 	err := connect.NewError(connect.Code(req.Msg.Code), errors.New(errorMessage))
-	err.Header().Set(handlerHeader, headerValue)
-	err.Trailer().Set(handlerTrailer, trailerValue)
+	err.Meta().Set(handlerHeader, headerValue)
+	err.Meta().Set(handlerTrailer, trailerValue)
 	return nil, err
 }
 

--- a/error_test.go
+++ b/error_test.go
@@ -37,10 +37,8 @@ func TestErrorNilUnderlying(t *testing.T) {
 	assert.Nil(t, anyErr)
 	err.AddDetail(detail)
 	assert.Equal(t, len(err.Details()), 1)
-	err.Header().Set("foo", "bar")
-	assert.Equal(t, err.Header().Get("foo"), "bar")
-	err.Trailer().Set("baz", "quux")
-	assert.Equal(t, err.Trailer().Get("baz"), "quux")
+	err.Meta().Set("foo", "bar")
+	assert.Equal(t, err.Meta().Get("foo"), "bar")
 	assert.Equal(t, CodeOf(err), CodeUnknown)
 }
 

--- a/protocol_grpc_client_stream.go
+++ b/protocol_grpc_client_stream.go
@@ -191,8 +191,8 @@ func (cs *duplexClientStream) Receive(message any) error {
 			// This is expected from a protocol perspective, but receiving trailers
 			// means that we're _not_ getting a message. For users to realize that
 			// the stream has ended, Receive must return an error.
-			serverErr.header = cs.ResponseHeader()
-			serverErr.trailer = cs.response.Trailer
+			serverErr.meta = cs.ResponseHeader()
+			mergeHeaders(serverErr.meta, cs.response.Trailer)
 			cs.setResponseError(serverErr)
 			return serverErr
 		}
@@ -301,8 +301,8 @@ func (cs *duplexClientStream) makeRequest(prepared chan struct{}) {
 	// When there's no body, gRPC-Web servers will send error information in the
 	// HTTP headers.
 	if err := extractError(cs.protobuf, res.Header); cs.web && err != nil {
-		err.header = res.Header
-		err.trailer = res.Trailer
+		err.meta = res.Header
+		mergeHeaders(err.meta, res.Trailer)
 		cs.setResponseError(err)
 		return
 	}

--- a/protocol_grpc_handler_stream.go
+++ b/protocol_grpc_handler_stream.go
@@ -86,8 +86,9 @@ func (hs *handlerSender) Send(message any) error {
 func (hs *handlerSender) Close(err error) error {
 	defer hs.flush()
 	if connectErr, ok := asError(err); ok {
-		mergeHeaders(hs.Header(), connectErr.header)
-		mergeHeaders(hs.Trailer(), connectErr.trailer)
+		// For now, assume that error metadata should be sent as HTTP trailers.
+		// We'll handle exceptions below.
+		mergeHeaders(hs.Trailer(), connectErr.meta)
 	}
 	if hs.web && !hs.wroteToBody {
 		// Regardless of whether we're using standard gRPC or gRPC-Web, we should


### PR DESCRIPTION
In the first commit, fix how handlers send trailers-only responses. This
introduces even more awkwardness in the header/trailer APIs on `Error`, so the
second commit changes the `Error` APIs a bit. Both commits have longer commit
messages which may add some context for reviewers.
