### PR TITLE
Small documentation fixes

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,4 +1,3 @@
-
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge
@@ -61,8 +60,8 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-akshay@akshayshah.org. All complaints will be reviewed and investigated
-promptly and fairly.
+conduct@buf.build. All complaints will be reviewed and investigated promptly
+and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.

--- a/README.md
+++ b/README.md
@@ -148,5 +148,4 @@ Offered under the [Apache 2 license][license].
 [license]: https://github.com/bufbuild/connect/blob/main/LICENSE.txt
 [prod-client]: https://pkg.go.dev/github.com/bufbuild/connect#example-Client
 [prod-server]: https://pkg.go.dev/github.com/bufbuild/connect#example-package
-[proto3]: https://cloud.google.com/apis/design/proto3
 [protobuf]: https://developers.google.com/protocol-buffers


### PR DESCRIPTION
Remove an unneeded href from the readme and fix the contact email for CoC
complaints.
