### PR TITLE
Support manual CI triggers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
     branches: [main]
   schedule:
     - cron: '15 22 * * *'
+  workflow_dispatch: {} # support manual runs
 # Prevent writing to the repository using the CI token.
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
 permissions: read-all


### PR DESCRIPTION
To let us trigger CI runs from the web UI, we need the workflow to support this
trigger type.
