### PR TITLE
Handle HTTP/2 trailers-only responses correctly

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -87,8 +87,7 @@ type Receiver interface {
 
 	Spec() Specification
 	Header() http.Header
-	// Trailers are populated only after Receive returns an error wrapping
-	// io.EOF.
+	// Trailers are populated only after Receive returns an error.
 	Trailer() http.Header
 }
 

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -269,6 +269,8 @@ func (g *grpcClient) NewStream(
 		trailer:          make(http.Header),
 		web:              g.web,
 		reader:           pipeReader,
+		responseHeader:   make(http.Header),
+		responseTrailer:  make(http.Header),
 		compressionPools: g.compressionPools,
 		responseReady:    make(chan struct{}),
 	}

--- a/protocol_grpc_handler_stream.go
+++ b/protocol_grpc_handler_stream.go
@@ -116,9 +116,12 @@ func (hs *handlerSender) Close(err error) error {
 	}
 	// We're using standard gRPC. Even if we haven't written to the body and
 	// we're sending a "trailers-only" response, we must send trailing metadata
-	// as HTTP trailers. In net/http's ResponseWriter API, we do that by writing
-	// to the headers map with a special prefix. This is purely an implementation
-	// detail, so we should hide it and _not_ mutate the user-visible headers.
+	// as HTTP trailers. (If we had frame-level control of the HTTP/2 layer, we
+	// could send a single HEADER frame and no DATA frames, but net/http doesn't
+	// expose APIs that low-level.) In net/http's ResponseWriter API, we do that
+	// by writing to the headers map with a special prefix. This is purely an
+	// implementation detail, so we should hide it and _not_ mutate the
+	// user-visible headers.
 	for key, values := range mergedTrailers {
 		for _, value := range values {
 			hs.writer.Header().Add(http.TrailerPrefix+key, value)


### PR DESCRIPTION
net/http doesn't expose the low-level APIs required for us to send
trailers-only responses, but we need to handle them correctly to interop
with grpc-go. Unfortunately, it's not possible for us to test this
without pulling in grpc-go (or writing something similar on top of a
TCP). Instead, we should rely on the cross-tests.
