### PR TITLE
Add tests for errors.Is behavior

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -81,3 +81,16 @@ func TestErrorDetails(t *testing.T) {
 	connectErr.AddDetail(detail)
 	assert.Equal(t, connectErr.Details(), []ErrorDetail{detail})
 }
+
+func TestErrorIs(t *testing.T) {
+	// errors.New and fmt.Errorf return *errors.errorString. errors.Is
+	// considers two *errors.errorStrings equal iff they have the same address.
+	err := errors.New("oh no")
+	assert.False(t, errors.Is(err, errors.New("oh no")))
+	assert.True(t, errors.Is(err, err))
+	// Our errors should have the same semantics. Note that we'd need to extend
+	// the ErrorDetail interface to support value equality.
+	connectErr := NewError(CodeUnavailable, err)
+	assert.False(t, errors.Is(connectErr, NewError(CodeUnavailable, err)))
+	assert.True(t, errors.Is(connectErr, connectErr))
+}


### PR DESCRIPTION
Add some unit tests that explore the behavior of `errors.Is` with our
errors and the stdlib. Conclusion is that we should keep behavior the
same: `errors.Is` checks whether two `*connect.Error`s have the same
address, not whether they point to equivalent values (whatever that
means). This matches the standard library's most common error type.

I'm not super-experienced with the newish `Is` and `As` APIs, but this
feels right to me. Supporting some value comparison for our errors would
require value comparisons on the `ErrorDetail` interface and
`http.Header`, which gets into some very awkward territory (does order
matter?). The standard library uses address comparisons even for a
simple string, so I think we're on safe ground doing the same.
