### PR TITLE
Use header-merging helper in handler_stream.go

### DIFF
--- a/handler_stream.go
+++ b/handler_stream.go
@@ -72,14 +72,8 @@ func (c *ClientStream[Req, Res]) SendAndClose(envelope *Response[Res]) error {
 	if err := c.receiver.Close(); err != nil {
 		return err
 	}
-	sendHeader := c.sender.Header()
-	for k, v := range envelope.header {
-		sendHeader[k] = append(sendHeader[k], v...)
-	}
-	sendTrailer := c.sender.Trailer()
-	for k, v := range envelope.trailer {
-		sendTrailer[k] = append(sendTrailer[k], v...)
-	}
+	mergeHeaders(c.sender.Header(), envelope.header)
+	mergeHeaders(c.sender.Trailer(), envelope.trailer)
 	return c.sender.Send(envelope.Msg)
 }
 


### PR DESCRIPTION
This code used to be in a separate package, so we were doing this by
hand. Using the helper is just as fast and less verbose.
