### PR TITLE
Expose errors from discard

### DIFF
--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -180,7 +180,7 @@ func (g *grpcHandler) NewStream(
 		// Negotiation failed, so we can't establish a stream. To make the
 		// request's HTTP trailers visible to interceptors, we should try to read
 		// the body to EOF.
-		discard(request.Body)
+		_ = discard(request.Body)
 		return sender, receiver, failed
 	}
 	return sender, receiver, nil

--- a/protocol_grpc_util.go
+++ b/protocol_grpc_util.go
@@ -148,13 +148,14 @@ func statusFromError(err error) (*statusv1.Status, *Error) {
 	return status, nil
 }
 
-func discard(reader io.Reader) {
+func discard(reader io.Reader) error {
 	if lr, ok := reader.(*io.LimitedReader); ok {
-		_, _ = io.Copy(io.Discard, lr)
-		return
+		_, err := io.Copy(io.Discard, lr)
+		return err
 	}
 	// We don't want to get stuck throwing data away forever, so limit how much
 	// we're willing to do here: at most, we'll copy 4 MiB.
 	lr := &io.LimitedReader{R: reader, N: 1024 * 1024 * 4}
-	_, _ = io.Copy(io.Discard, lr)
+	_, err := io.Copy(io.Discard, lr)
+	return err
 }


### PR DESCRIPTION
Discard is designed to throw away the request body. Typically, we've
encountered an error and we're trying to get to the HTTP trailers or
we're making a best effort to re-use TCP connections. In a few places,
though, it makes sense to bubble errors in discard further up.
