### PR TITLE
Simplify compressors & handle errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -167,7 +167,7 @@ type clientConfiguration struct {
 	Procedure              string
 	CompressMinBytes       int
 	Interceptor            Interceptor
-	CompressionPools       map[string]compressionPool
+	CompressionPools       map[string]*compressionPool
 	Codec                  Codec
 	RequestCompressionName string
 }
@@ -176,7 +176,7 @@ func newClientConfiguration(url string, options []ClientOption) (*clientConfigur
 	protoPath := extractProtobufPath(url)
 	config := clientConfiguration{
 		Procedure:        protoPath,
-		CompressionPools: make(map[string]compressionPool),
+		CompressionPools: make(map[string]*compressionPool),
 	}
 	WithProtoBinaryCodec().applyToClient(&config)
 	WithGzip().applyToClient(&config)

--- a/handler.go
+++ b/handler.go
@@ -242,7 +242,7 @@ func (h *Handler) failNegotiation(w http.ResponseWriter, code int) {
 }
 
 type handlerConfiguration struct {
-	CompressionPools map[string]compressionPool
+	CompressionPools map[string]*compressionPool
 	Codecs           map[string]Codec
 	CompressMinBytes int
 	Interceptor      Interceptor
@@ -255,7 +255,7 @@ func newHandlerConfiguration(procedure string, options []HandlerOption) *handler
 	protoPath := extractProtobufPath(procedure)
 	config := handlerConfiguration{
 		Procedure:        protoPath,
-		CompressionPools: make(map[string]compressionPool),
+		CompressionPools: make(map[string]*compressionPool),
 		Codecs:           make(map[string]Codec),
 		HandleGRPC:       true,
 		HandleGRPCWeb:    true,

--- a/option.go
+++ b/option.go
@@ -114,10 +114,10 @@ func WithCodec(codec Codec) Option {
 // using both WithCompression and WithRequestCompression.
 //
 // Calling WithCompression with an empty name or nil constructors is a no-op.
-func WithCompression[D Decompressor, C Compressor](
+func WithCompression(
 	name string,
-	newDecompressor func() D,
-	newCompressor func() C,
+	newDecompressor func() Decompressor,
+	newCompressor func() Compressor,
 ) Option {
 	return &compressionOption{
 		Name:            name,
@@ -149,8 +149,8 @@ func WithCompressMinBytes(min int) Option {
 func WithGzip() Option {
 	return WithCompression(
 		compressionGzip,
-		func() *gzip.Reader { return &gzip.Reader{} },
-		func() *gzip.Writer { return gzip.NewWriter(ioutil.Discard) },
+		func() Decompressor { return &gzip.Reader{} },
+		func() Compressor { return gzip.NewWriter(ioutil.Discard) },
 	)
 }
 
@@ -261,7 +261,7 @@ func (o *codecOption) applyToHandler(config *handlerConfiguration) {
 
 type compressionOption struct {
 	Name            string
-	CompressionPool compressionPool
+	CompressionPool *compressionPool
 }
 
 func (o *compressionOption) applyToClient(config *clientConfiguration) {
@@ -272,7 +272,7 @@ func (o *compressionOption) applyToHandler(config *handlerConfiguration) {
 	o.apply(config.CompressionPools)
 }
 
-func (o *compressionOption) apply(m map[string]compressionPool) {
+func (o *compressionOption) apply(m map[string]*compressionPool) {
 	if o.Name == "" || o.CompressionPool == nil {
 		return
 	}

--- a/protocol_grpc_handler_stream.go
+++ b/protocol_grpc_handler_stream.go
@@ -30,8 +30,8 @@ func newHandlerStream(
 	compressMinBytes int,
 	codec Codec,
 	protobuf Codec, // for errors
-	requestCompressionPools compressionPool,
-	responseCompressionPools compressionPool,
+	requestCompressionPools *compressionPool,
+	responseCompressionPools *compressionPool,
 ) (*handlerSender, *handlerReceiver) {
 	sender := &handlerSender{
 		spec: spec,


### PR DESCRIPTION
Looking at the compression code again, we're not getting much value from
generics. `WithCompression` is also the only generic `Option`, which is
a little weird.

This PR changes the compression pools to work with interfaces instead,
which makes them quite a bit simpler. They're just as resistant to user
error, but ever so slightly easier for us to mess up; I think it's a
worthwhile tradeoff for the simplicity.

The PR also handles errors from the pool in `protocol_grpc_lpm.go`.
Against my better judgment, we'll just kick some of these errors back to
the caller - it's not worth a special hook just to log this one error.
