### PR TITLE
Fix auto-rename bug in end-of-stream logic

### DIFF
--- a/protocol_grpc_lpm.go
+++ b/protocol_grpc_lpm.go
@@ -182,7 +182,7 @@ func (u *unmarshaler) Unmarshal(message any) (retErr *Error) {
 			if err != nil && !errors.Is(err, io.EOF) {
 				return errorf(CodeUnknown, "error reading length-prefixed message data: %w", err)
 			}
-			if errors.Is(err, io.EOF) && prefixBytesRead == 0 {
+			if errors.Is(err, io.EOF) && bytesRead == 0 {
 				// We've gotten zero-length chunk of data. Message is likely malformed,
 				// don't wait for additional chunks.
 				return errorf(


### PR DESCRIPTION
The termination condition on this while loop was incorrect; I think this snuck in during a partially-automated rename of a super-short variable.

This is rather difficult to reach in tests - it'll take a bit longer than I have tonight to write a test that's low level enough to reach this code. I'm filing an issue so I don't forget.