### PR TITLE
Generate aliases for connect.Request/Response

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,7 @@ type PingServer struct {
   pingv1connect.UnimplementedPingServiceHandler // returns errors from all methods
 }
 
-func (ps *PingServer) Ping(
-  ctx context.Context,
-  req *connect.Request[pingv1.PingRequest],
-) (*connect.Response[pingv1.PingResponse], error) {
+func (ps *PingServer) Ping(ctx context.Context, req *pingv1connect.PingRequest) (*pingv1connect.PingResponse, error) {
   // connect.Request and connect.Response give you direct access to headers and
   // trailers. No context-based nonsense!
   log.Println(req.Header().Get("Some-Header"))

--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -195,9 +195,7 @@ type notModifiedPingServer struct {
 	etag string
 }
 
-func (s *notModifiedPingServer) Ping(
-	_ context.Context,
-	req *connect.Request[pingv1.PingRequest]) (*connect.Response[pingv1.PingResponse], error) {
+func (s *notModifiedPingServer) Ping(_ context.Context, req *pingv1connect.PingRequest) (*pingv1connect.PingResponse, error) {
 	if req.HTTPMethod() == http.MethodGet && req.Header().Get("If-None-Match") == s.etag {
 		return nil, connect.NewNotModifiedError(http.Header{"Etag": []string{s.etag}})
 	}

--- a/error_not_modified_example_test.go
+++ b/error_not_modified_example_test.go
@@ -34,10 +34,7 @@ type ExampleCachingPingServer struct {
 // Ping is idempotent and free of side effects (and the Protobuf schema
 // indicates this), so clients using the Connect protocol may call it with HTTP
 // GET requests. This implementation uses Etags to manage client-side caching.
-func (*ExampleCachingPingServer) Ping(
-	_ context.Context,
-	req *connect.Request[pingv1.PingRequest],
-) (*connect.Response[pingv1.PingResponse], error) {
+func (*ExampleCachingPingServer) Ping(_ context.Context, req *pingv1connect.PingRequest) (*pingv1connect.PingResponse, error) {
 	resp := connect.NewResponse(&pingv1.PingResponse{
 		Number: req.Msg.Number,
 	})

--- a/handler_example_test.go
+++ b/handler_example_test.go
@@ -30,10 +30,7 @@ type ExamplePingServer struct {
 }
 
 // Ping implements pingv1connect.PingServiceHandler.
-func (*ExamplePingServer) Ping(
-	_ context.Context,
-	request *connect.Request[pingv1.PingRequest],
-) (*connect.Response[pingv1.PingResponse], error) {
+func (*ExamplePingServer) Ping(_ context.Context, request *pingv1connect.PingRequest) (*pingv1connect.PingResponse, error) {
 	return connect.NewResponse(
 		&pingv1.PingResponse{
 			Number: request.Msg.Number,

--- a/handler_ext_test.go
+++ b/handler_ext_test.go
@@ -24,7 +24,6 @@ import (
 
 	connect "connectrpc.com/connect"
 	"connectrpc.com/connect/internal/assert"
-	pingv1 "connectrpc.com/connect/internal/gen/connect/ping/v1"
 	"connectrpc.com/connect/internal/gen/connect/ping/v1/pingv1connect"
 )
 
@@ -213,6 +212,6 @@ type successPingServer struct {
 	pingv1connect.UnimplementedPingServiceHandler
 }
 
-func (successPingServer) Ping(context.Context, *connect.Request[pingv1.PingRequest]) (*connect.Response[pingv1.PingResponse], error) {
-	return &connect.Response[pingv1.PingResponse]{}, nil
+func (successPingServer) Ping(context.Context, *pingv1connect.PingRequest) (*pingv1connect.PingResponse, error) {
+	return &pingv1connect.PingResponse{}, nil
 }

--- a/internal/gen/connect/collide/v1/collidev1connect/collide.connect.go
+++ b/internal/gen/connect/collide/v1/collidev1connect/collide.connect.go
@@ -51,9 +51,14 @@ const (
 	CollideServiceImportProcedure = "/connect.collide.v1.CollideService/Import"
 )
 
+type (
+	ImportRequest  = connect.Request[v1.ImportRequest]
+	ImportResponse = connect.Response[v1.ImportResponse]
+)
+
 // CollideServiceClient is a client for the connect.collide.v1.CollideService service.
 type CollideServiceClient interface {
-	Import(context.Context, *connect.Request[v1.ImportRequest]) (*connect.Response[v1.ImportResponse], error)
+	Import(context.Context, *ImportRequest) (*ImportResponse, error)
 }
 
 // NewCollideServiceClient constructs a client for the connect.collide.v1.CollideService service. By
@@ -80,13 +85,13 @@ type collideServiceClient struct {
 }
 
 // Import calls connect.collide.v1.CollideService.Import.
-func (c *collideServiceClient) Import(ctx context.Context, req *connect.Request[v1.ImportRequest]) (*connect.Response[v1.ImportResponse], error) {
+func (c *collideServiceClient) Import(ctx context.Context, req *ImportRequest) (*ImportResponse, error) {
 	return c._import.CallUnary(ctx, req)
 }
 
 // CollideServiceHandler is an implementation of the connect.collide.v1.CollideService service.
 type CollideServiceHandler interface {
-	Import(context.Context, *connect.Request[v1.ImportRequest]) (*connect.Response[v1.ImportResponse], error)
+	Import(context.Context, *ImportRequest) (*ImportResponse, error)
 }
 
 // NewCollideServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -113,6 +118,6 @@ func NewCollideServiceHandler(svc CollideServiceHandler, opts ...connect.Handler
 // UnimplementedCollideServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedCollideServiceHandler struct{}
 
-func (UnimplementedCollideServiceHandler) Import(context.Context, *connect.Request[v1.ImportRequest]) (*connect.Response[v1.ImportResponse], error) {
+func (UnimplementedCollideServiceHandler) Import(context.Context, *ImportRequest) (*ImportResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.collide.v1.CollideService.Import is not implemented"))
 }

--- a/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
@@ -64,16 +64,25 @@ const (
 	PingServiceCumSumProcedure = "/connect.ping.v1.PingService/CumSum"
 )
 
+type (
+	PingRequest    = connect.Request[v1.PingRequest]
+	PingResponse   = connect.Response[v1.PingResponse]
+	FailRequest    = connect.Request[v1.FailRequest]
+	FailResponse   = connect.Response[v1.FailResponse]
+	SumResponse    = connect.Response[v1.SumResponse]
+	CountUpRequest = connect.Request[v1.CountUpRequest]
+)
+
 // PingServiceClient is a client for the connect.ping.v1.PingService service.
 type PingServiceClient interface {
 	// Ping sends a ping to the server to determine if it's reachable.
-	Ping(context.Context, *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error)
+	Ping(context.Context, *PingRequest) (*PingResponse, error)
 	// Fail always fails.
-	Fail(context.Context, *connect.Request[v1.FailRequest]) (*connect.Response[v1.FailResponse], error)
+	Fail(context.Context, *FailRequest) (*FailResponse, error)
 	// Sum calculates the sum of the numbers sent on the stream.
 	Sum(context.Context) *connect.ClientStreamForClient[v1.SumRequest, v1.SumResponse]
 	// CountUp returns a stream of the numbers up to the given request.
-	CountUp(context.Context, *connect.Request[v1.CountUpRequest]) (*connect.ServerStreamForClient[v1.CountUpResponse], error)
+	CountUp(context.Context, *CountUpRequest) (*connect.ServerStreamForClient[v1.CountUpResponse], error)
 	// CumSum determines the cumulative sum of all the numbers sent on the stream.
 	CumSum(context.Context) *connect.BidiStreamForClient[v1.CumSumRequest, v1.CumSumResponse]
 }
@@ -127,12 +136,12 @@ type pingServiceClient struct {
 }
 
 // Ping calls connect.ping.v1.PingService.Ping.
-func (c *pingServiceClient) Ping(ctx context.Context, req *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error) {
+func (c *pingServiceClient) Ping(ctx context.Context, req *PingRequest) (*PingResponse, error) {
 	return c.ping.CallUnary(ctx, req)
 }
 
 // Fail calls connect.ping.v1.PingService.Fail.
-func (c *pingServiceClient) Fail(ctx context.Context, req *connect.Request[v1.FailRequest]) (*connect.Response[v1.FailResponse], error) {
+func (c *pingServiceClient) Fail(ctx context.Context, req *FailRequest) (*FailResponse, error) {
 	return c.fail.CallUnary(ctx, req)
 }
 
@@ -142,7 +151,7 @@ func (c *pingServiceClient) Sum(ctx context.Context) *connect.ClientStreamForCli
 }
 
 // CountUp calls connect.ping.v1.PingService.CountUp.
-func (c *pingServiceClient) CountUp(ctx context.Context, req *connect.Request[v1.CountUpRequest]) (*connect.ServerStreamForClient[v1.CountUpResponse], error) {
+func (c *pingServiceClient) CountUp(ctx context.Context, req *CountUpRequest) (*connect.ServerStreamForClient[v1.CountUpResponse], error) {
 	return c.countUp.CallServerStream(ctx, req)
 }
 
@@ -154,13 +163,13 @@ func (c *pingServiceClient) CumSum(ctx context.Context) *connect.BidiStreamForCl
 // PingServiceHandler is an implementation of the connect.ping.v1.PingService service.
 type PingServiceHandler interface {
 	// Ping sends a ping to the server to determine if it's reachable.
-	Ping(context.Context, *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error)
+	Ping(context.Context, *PingRequest) (*PingResponse, error)
 	// Fail always fails.
-	Fail(context.Context, *connect.Request[v1.FailRequest]) (*connect.Response[v1.FailResponse], error)
+	Fail(context.Context, *FailRequest) (*FailResponse, error)
 	// Sum calculates the sum of the numbers sent on the stream.
-	Sum(context.Context, *connect.ClientStream[v1.SumRequest]) (*connect.Response[v1.SumResponse], error)
+	Sum(context.Context, *connect.ClientStream[v1.SumRequest]) (*SumResponse, error)
 	// CountUp returns a stream of the numbers up to the given request.
-	CountUp(context.Context, *connect.Request[v1.CountUpRequest], *connect.ServerStream[v1.CountUpResponse]) error
+	CountUp(context.Context, *CountUpRequest, *connect.ServerStream[v1.CountUpResponse]) error
 	// CumSum determines the cumulative sum of all the numbers sent on the stream.
 	CumSum(context.Context, *connect.BidiStream[v1.CumSumRequest, v1.CumSumResponse]) error
 }
@@ -218,19 +227,19 @@ func NewPingServiceHandler(svc PingServiceHandler, opts ...connect.HandlerOption
 // UnimplementedPingServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedPingServiceHandler struct{}
 
-func (UnimplementedPingServiceHandler) Ping(context.Context, *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error) {
+func (UnimplementedPingServiceHandler) Ping(context.Context, *PingRequest) (*PingResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Ping is not implemented"))
 }
 
-func (UnimplementedPingServiceHandler) Fail(context.Context, *connect.Request[v1.FailRequest]) (*connect.Response[v1.FailResponse], error) {
+func (UnimplementedPingServiceHandler) Fail(context.Context, *FailRequest) (*FailResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Fail is not implemented"))
 }
 
-func (UnimplementedPingServiceHandler) Sum(context.Context, *connect.ClientStream[v1.SumRequest]) (*connect.Response[v1.SumResponse], error) {
+func (UnimplementedPingServiceHandler) Sum(context.Context, *connect.ClientStream[v1.SumRequest]) (*SumResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Sum is not implemented"))
 }
 
-func (UnimplementedPingServiceHandler) CountUp(context.Context, *connect.Request[v1.CountUpRequest], *connect.ServerStream[v1.CountUpResponse]) error {
+func (UnimplementedPingServiceHandler) CountUp(context.Context, *CountUpRequest, *connect.ServerStream[v1.CountUpResponse]) error {
 	return connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.CountUp is not implemented"))
 }
 

--- a/recover_ext_test.go
+++ b/recover_ext_test.go
@@ -33,16 +33,13 @@ type panicPingServer struct {
 	panicWith any
 }
 
-func (s *panicPingServer) Ping(
-	context.Context,
-	*connect.Request[pingv1.PingRequest],
-) (*connect.Response[pingv1.PingResponse], error) {
+func (s *panicPingServer) Ping(context.Context, *pingv1connect.PingRequest) (*pingv1connect.PingResponse, error) {
 	panic(s.panicWith) //nolint:forbidigo
 }
 
 func (s *panicPingServer) CountUp(
 	_ context.Context,
-	_ *connect.Request[pingv1.CountUpRequest],
+	_ *pingv1connect.CountUpRequest,
 	stream *connect.ServerStream[pingv1.CountUpResponse],
 ) error {
 	if err := stream.Send(&pingv1.CountUpResponse{}); err != nil {


### PR DESCRIPTION
Reduce Connect's generics-induced wordiness by generating type aliases
for `connect.Request` and `connect.Response`.

For an actual net reduction in wordiness, we can't generate long
identifiers. That reduces our ability to manage name collisions, so we
only generate aliases for messages that are declared in the same file
and used exclusively as requests or responses (but not both). Notably,
we don't attempt to generate aliases for the stream types - they end up
even wordier than the generic types, and they end up very confusingly
named.

Fixes #451. Would probably benefit from review by @jhump and @emcfarlane.
