### PR TITLE
Include Go 1.21.0 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.19.x, 1.20.x, 1.21.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -38,5 +38,5 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.20.x'
+        if: matrix.go-version == '1.21.x'
         run: make checkgenerate && make lint

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        go-version: [1.19.x,1.20.x]
+        go-version: [1.19.x,1.20.x,1.21.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,10 +7,6 @@ linters-settings:
     include:
       # No zero values for param structs.
       - 'connectrpc\.com/connect\..*[pP]arams'
-      # No zero values for ClientStream, ServerStream, and friends.
-      - 'connectrpc\.com/connect\.ClientStream.*'
-      - 'connectrpc\.com/connect\.ServerStream.*'
-      - 'connectrpc\.com/connect\.BidiStream.*'
   forbidigo:
     forbid:
       - '^fmt\.Print'
@@ -38,6 +34,7 @@ linters:
   enable-all: true
   disable:
     - cyclop            # covered by gocyclo
+    - depguard          # unnecessary for small libraries
     - deadcode          # abandoned
     - exhaustivestruct  # replaced by exhaustruct
     - funlen            # rely on code review to limit function length

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-print-directory
 BIN := .tmp/bin
+export PATH := $(BIN):$(PATH)
+export GOBIN := $(abspath $(BIN))
 COPYRIGHT_YEARS := 2021-2023
 LICENSE_IGNORE := --ignore /testdata/
 # Set to use a different compiler. For example, `GO=go1.18rc1 make test`.
@@ -42,20 +44,20 @@ install: ## Install all binaries
 lint: $(BIN)/golangci-lint $(BIN)/buf ## Lint Go and protobuf
 	test -z "$$($(BIN)/buf format -d . | tee /dev/stderr)"
 	$(GO) vet ./...
-	$(BIN)/golangci-lint run
-	$(BIN)/buf lint
-	$(BIN)/buf format -d --exit-code
+	golangci-lint run
+	buf lint
+	buf format -d --exit-code
 
 .PHONY: lintfix
 lintfix: $(BIN)/golangci-lint $(BIN)/buf ## Automatically fix some lint errors
-	$(BIN)/golangci-lint run --fix
-	$(BIN)/buf format -w
+	golangci-lint run --fix
+	buf format -w
 
 .PHONY: generate
 generate: $(BIN)/buf $(BIN)/protoc-gen-go $(BIN)/protoc-gen-connect-go $(BIN)/license-header ## Regenerate code and licenses
 	rm -rf internal/gen
 	PATH="$(abspath $(BIN))" $(BIN)/buf generate
-	$(BIN)/license-header \
+	license-header \
 		--license-type apache \
 		--copyright-holder "Buf Technologies, Inc." \
 		--year-range "$(COPYRIGHT_YEARS)" $(LICENSE_IGNORE)
@@ -76,19 +78,18 @@ $(BIN)/protoc-gen-connect-go:
 
 $(BIN)/buf: Makefile
 	@mkdir -p $(@D)
-	GOBIN="$(abspath $(@D))" $(GO) install github.com/bufbuild/buf/cmd/buf@v1.18.0
+	$(GO) install github.com/bufbuild/buf/cmd/buf@v1.18.0
 
 $(BIN)/license-header: Makefile
 	@mkdir -p $(@D)
-	GOBIN="$(abspath $(@D))" $(GO) install \
-		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.18.0
+	$(GO) install github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.18.0
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN="$(abspath $(@D))" $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1
 
 $(BIN)/protoc-gen-go: Makefile go.mod
 	@mkdir -p $(@D)
 	@# The version of protoc-gen-go is determined by the version in go.mod
-	GOBIN="$(abspath $(@D))" $(GO) install google.golang.org/protobuf/cmd/protoc-gen-go
+	$(GO) install google.golang.org/protobuf/cmd/protoc-gen-go
 

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN="$(abspath $(@D))" $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
+	GOBIN="$(abspath $(@D))" $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1
 
 $(BIN)/protoc-gen-go: Makefile go.mod
 	@mkdir -p $(@D)

--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ configuring timeouts, connection pools, observability, and h2c.
 
 This module is stable. It supports:
 
-* The [two most recent major releases][go-support-policy] of Go.
+* The three most recent major releases of Go. Keep in mind that [only the last
+  two releases receive security patches][go-support-policy].
 * [APIv2] of Protocol Buffers in Go (`google.golang.org/protobuf`).
 
 Within those parameters, `connect` follows semantic versioning. We will


### PR DESCRIPTION
Include Go 1.21.0 in CI, and update `golangci-lint` to a version that supports
the new runtime.

As part of this change, we're committing to support for the last 3 versions of
Go. This ends up including a version of Go that no longer receives security
patches, but it matches AWS and some large companies' very slow upgrade cycles.
