### PR TITLE
Prefer t.Cleanup to close test servers

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -41,7 +41,7 @@ func BenchmarkConnect(b *testing.B) {
 	server := httptest.NewUnstartedServer(mux)
 	server.EnableHTTP2 = true
 	server.StartTLS()
-	defer server.Close()
+	b.Cleanup(server.Close)
 
 	httpClient := server.Client()
 	httpTransport, ok := httpClient.Transport.(*http.Transport)
@@ -116,7 +116,7 @@ func BenchmarkREST(b *testing.B) {
 	server := httptest.NewUnstartedServer(http.HandlerFunc(handler))
 	server.EnableHTTP2 = true
 	server.StartTLS()
-	defer server.Close()
+	b.Cleanup(server.Close)
 	twoMiB := strings.Repeat("a", 2*1024*1024)
 	b.ResetTimer()
 

--- a/compression_test.go
+++ b/compression_test.go
@@ -43,7 +43,7 @@ func TestAcceptEncodingOrdering(t *testing.T) {
 		called = true
 	})
 	server := httptest.NewServer(verify)
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	client := NewClient[emptypb.Empty, emptypb.Empty](
 		server.Client(),

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -429,7 +429,7 @@ func TestServer(t *testing.T) {
 	t.Run("http1", func(t *testing.T) {
 		t.Parallel()
 		server := httptest.NewServer(mux)
-		defer server.Close()
+		t.Cleanup(server.Close)
 		testMatrix(t, server, false /* bidi */)
 	})
 	t.Run("http2", func(t *testing.T) {
@@ -437,7 +437,7 @@ func TestServer(t *testing.T) {
 		server := httptest.NewUnstartedServer(mux)
 		server.EnableHTTP2 = true
 		server.StartTLS()
-		defer server.Close()
+		t.Cleanup(server.Close)
 		testMatrix(t, server, true /* bidi */)
 	})
 }
@@ -511,7 +511,7 @@ func TestHeaderBasic(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.Handle(pingv1connect.NewPingServiceHandler(pingServer))
 	server := httptest.NewServer(mux)
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	client := pingv1connect.NewPingServiceClient(server.Client(), server.URL)
 	request := connect.NewRequest(&pingv1.PingRequest{})
@@ -595,7 +595,7 @@ func TestTimeoutParsing(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.Handle(pingv1connect.NewPingServiceHandler(pingServer))
 	server := httptest.NewServer(mux)
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -608,7 +608,7 @@ func TestFailCodec(t *testing.T) {
 	t.Parallel()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	t.Cleanup(server.Close)
 	client := pingv1connect.NewPingServiceClient(
 		server.Client(),
 		server.URL,
@@ -626,7 +626,7 @@ func TestContextError(t *testing.T) {
 	t.Parallel()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	t.Cleanup(server.Close)
 	client := pingv1connect.NewPingServiceClient(
 		server.Client(),
 		server.URL,
@@ -653,7 +653,7 @@ func TestGRPCMarshalStatusError(t *testing.T) {
 	server := httptest.NewUnstartedServer(mux)
 	server.EnableHTTP2 = true
 	server.StartTLS()
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	assertInternalError := func(tb testing.TB, opts ...connect.ClientOption) {
 		tb.Helper()
@@ -779,7 +779,7 @@ func TestBidiRequiresHTTP2(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	t.Cleanup(server.Close)
 	client := pingv1connect.NewPingServiceClient(
 		server.Client(),
 		server.URL,
@@ -900,7 +900,7 @@ func TestCustomCompression(t *testing.T) {
 		connect.WithCompression(compressionName, decompressor, compressor),
 	))
 	server := httptest.NewServer(mux)
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	client := pingv1connect.NewPingServiceClient(server.Client(),
 		server.URL,
@@ -921,7 +921,7 @@ func TestClientWithoutGzipSupport(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.Handle(pingv1connect.NewPingServiceHandler(pingServer{}))
 	server := httptest.NewServer(mux)
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	client := pingv1connect.NewPingServiceClient(server.Client(),
 		server.URL,
@@ -976,7 +976,7 @@ func TestInterceptorReturnsWrongType(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.Handle(pingv1connect.NewPingServiceHandler(pingServer{}))
 	server := httptest.NewServer(mux)
-	defer server.Close()
+	t.Cleanup(server.Close)
 	client := pingv1connect.NewPingServiceClient(server.Client(), server.URL, connect.WithInterceptors(connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, request connect.AnyRequest) (connect.AnyResponse, error) {
 			if _, err := next(ctx, request); err != nil {

--- a/interceptor_ext_test.go
+++ b/interceptor_ext_test.go
@@ -128,7 +128,7 @@ func TestOnionOrderingEndToEnd(t *testing.T) {
 		),
 	)
 	server := httptest.NewServer(mux)
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	client := pingv1connect.NewPingServiceClient(
 		server.Client(),
@@ -205,7 +205,7 @@ func TestInterceptorFuncAccessingHTTPMethod(t *testing.T) {
 		),
 	)
 	server := httptest.NewServer(mux)
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	client := pingv1connect.NewPingServiceClient(
 		server.Client(),

--- a/recover_ext_test.go
+++ b/recover_ext_test.go
@@ -80,7 +80,7 @@ func TestWithRecover(t *testing.T) {
 	server := httptest.NewUnstartedServer(mux)
 	server.EnableHTTP2 = true
 	server.StartTLS()
-	defer server.Close()
+	t.Cleanup(server.Close)
 	client := pingv1connect.NewPingServiceClient(
 		server.Client(),
 		server.URL,


### PR DESCRIPTION
Since we're requiring all tests to be parallelized, we should use
`t.Cleanup` instead of a simple defer. The latter can execute before the
parallel subtests run.
