### PR TITLE
Back to development

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Version is the semantic version of the connect module.
-const Version = "1.11.0"
+const Version = "1.11.1"
 
 // These constants are used in compile-time handshakes with connect's generated
 // code.

--- a/connect.go
+++ b/connect.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Version is the semantic version of the connect module.
-const Version = "1.11.1"
+const Version = "1.12.0-dev"
 
 // These constants are used in compile-time handshakes with connect's generated
 // code.


### PR DESCRIPTION
Amend the version constant to go back to development. For merging after we tag
v1.11.1.
