### PR TITLE
Remove extra protobuf formatting check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,6 @@ install: ## Install all binaries
 
 .PHONY: lint
 lint: $(BIN)/golangci-lint $(BIN)/buf ## Lint Go and protobuf
-	test -z "$$($(BIN)/buf format -d . | tee /dev/stderr)"
 	go vet ./...
 	golangci-lint run
 	buf lint


### PR DESCRIPTION
In `make lint`, we were running `buf format -d` twice. This PR removes
the more awkward invocation - I think it preceded the `--exit-code` flag.
