### PR TITLE
Move the indication of destination message type into Codec

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -118,7 +118,11 @@ func (c *protoBinaryCodec) Unmarshal(data []byte, message any) error {
 	if !ok {
 		return errNotProto(message)
 	}
-	return proto.Unmarshal(data, protoMessage)
+	err := proto.Unmarshal(data, protoMessage)
+	if err != nil {
+		return fmt.Errorf("unmarshal into %T: %w", message, err)
+	}
+	return nil
 }
 
 func (c *protoBinaryCodec) MarshalStable(message any) ([]byte, error) {
@@ -174,7 +178,11 @@ func (c *protoJSONCodec) Unmarshal(binary []byte, message any) error {
 	// Discard unknown fields so clients and servers aren't forced to always use
 	// exactly the same version of the schema.
 	options := protojson.UnmarshalOptions{DiscardUnknown: true}
-	return options.Unmarshal(binary, protoMessage)
+	err := options.Unmarshal(binary, protoMessage)
+	if err != nil {
+		return fmt.Errorf("unmarshal into %T: %w", message, err)
+	}
+	return nil
 }
 
 func (c *protoJSONCodec) MarshalStable(message any) ([]byte, error) {

--- a/envelope.go
+++ b/envelope.go
@@ -219,7 +219,7 @@ func (r *envelopeReader) Unmarshal(message any) *Error {
 	}
 
 	if err := r.codec.Unmarshal(data.Bytes(), message); err != nil {
-		return errorf(CodeInvalidArgument, "unmarshal into %T: %w", message, err)
+		return errorf(CodeInvalidArgument, "unmarshal message: %w", err)
 	}
 	return nil
 }

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -1099,7 +1099,7 @@ func (u *connectUnaryUnmarshaler) UnmarshalFunc(message any, unmarshal func([]by
 		data = decompressed
 	}
 	if err := unmarshal(data.Bytes(), message); err != nil {
-		return NewError(CodeInvalidArgument, err)
+		return errorf(CodeInvalidArgument, "unmarshal message: %w", err)
 	}
 	return nil
 }

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -1099,7 +1099,7 @@ func (u *connectUnaryUnmarshaler) UnmarshalFunc(message any, unmarshal func([]by
 		data = decompressed
 	}
 	if err := unmarshal(data.Bytes(), message); err != nil {
-		return errorf(CodeInvalidArgument, "unmarshal into %T: %w", message, err)
+		return NewError(CodeInvalidArgument, err)
 	}
 	return nil
 }


### PR DESCRIPTION
This is so that a custom `Codec` can choose what details to reveal to clients, in cases where emitting the destination message type is considered to leak too much information.

See #584 for more context.