### PR TITLE
Remove gRPC error message from envelope error

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -187,7 +187,7 @@ func (r *envelopeReader) Unmarshal(message any) *Error {
 		if r.compressionPool == nil {
 			return errorf(
 				CodeInvalidArgument,
-				"protocol error: sent compressed message without Grpc-Encoding header",
+				"protocol error: sent compressed message without compression support",
 			)
 		}
 		decompressed := r.bufferPool.Get()


### PR DESCRIPTION
Tiny fix to generalized the error message.
