### PR TITLE
Cast size as int64 to remove overflow checks

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -226,6 +226,8 @@ func (r *envelopeReader) Unmarshal(message any) *Error {
 
 func (r *envelopeReader) Read(env *envelope) *Error {
 	prefixes := [5]byte{}
+	// io.ReadFull reads the number of bytes requested, or returns an error.
+	// io.EOF will only be returned if no bytes were read.
 	if _, err := io.ReadFull(r.reader, prefixes[:]); err != nil {
 		if errors.Is(err, io.EOF) {
 			// The stream ended cleanly. That's expected, but we need to propagate an EOF

--- a/envelope.go
+++ b/envelope.go
@@ -228,7 +228,7 @@ func (r *envelopeReader) Read(env *envelope) *Error {
 	prefixes := [5]byte{}
 	if _, err := io.ReadFull(r.reader, prefixes[:]); err != nil {
 		if errors.Is(err, io.EOF) {
-			// The stream ended cleanly. That's expected, but we need to propagate them
+			// The stream ended cleanly. That's expected, but we need to propagate an EOF
 			// to the user so that they know that the stream has ended. We shouldn't
 			// add any alarming text about protocol errors, though.
 			return NewError(CodeUnknown, err)


### PR DESCRIPTION
Three small fixes:
- [`io.ReadFull`](https://pkg.go.dev/io#ReadFull) on prefixes can't return an `io.EOF` if `prefixBytes > 0`
- Cast `size` to `int64` over `int` to avoid the overflow check
- `prefixBytesRead` must equal 5 on success
