### PR TITLE
Enforce discard limits

### DIFF
--- a/compression.go
+++ b/compression.go
@@ -93,12 +93,9 @@ func (c *compressionPool) Decompress(dst *bytes.Buffer, src *bytes.Buffer, readM
 		return errorf(CodeInvalidArgument, "decompress: %w", err)
 	}
 	if readMaxBytes > 0 && bytesRead > readMaxBytes {
-		discardedBytes, err := io.Copy(io.Discard, decompressor)
+		err := errMaxReadLimitExceeded(decompressor, bytesRead, readMaxBytes)
 		_ = c.putDecompressor(decompressor)
-		if err != nil {
-			return errorf(CodeResourceExhausted, "message is larger than configured max %d - unable to determine message size: %w", readMaxBytes, err)
-		}
-		return errorf(CodeResourceExhausted, "message size %d is larger than configured max %d", bytesRead+discardedBytes, readMaxBytes)
+		return err
 	}
 	if err := c.putDecompressor(decompressor); err != nil {
 		return errorf(CodeUnknown, "recycle decompressor: %w", err)

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -1038,8 +1038,8 @@ func TestHandlerWithReadMaxBytes(t *testing.T) {
 			if testing.Short() {
 				t.Skipf("skipping %s test in short mode", t.Name())
 			}
-			// Serializes to much larger than readMaxBytes (5 MiB)
-			pingRequest := &pingv1.PingRequest{Text: strings.Repeat("abcde", 1024*1024)}
+			// Serializes to much larger than readMaxBytes (2.5 MiB)
+			pingRequest := &pingv1.PingRequest{Text: strings.Repeat("abcde", 512*1024)}
 			expectedSize := proto.Size(pingRequest)
 			// With gzip request compression, the error should indicate the envelope size (before decompression) is too large.
 			if compressed {
@@ -1233,9 +1233,10 @@ func TestClientWithReadMaxBytes(t *testing.T) {
 			if testing.Short() {
 				t.Skipf("skipping %s test in short mode", t.Name())
 			}
-			// Serializes to much larger than readMaxBytes (5 MiB)
-			pingRequest := &pingv1.PingRequest{Text: strings.Repeat("abcde", 1024*1024)}
+			// Serializes to much larger than readMaxBytes (2.5 MiB)
+			pingRequest := &pingv1.PingRequest{Text: strings.Repeat("abcde", 512*1024)}
 			expectedSize := proto.Size(pingRequest)
+			t.Log("expectedSize", expectedSize)
 			// With gzip response compression, the error should indicate the envelope size (before decompression) is too large.
 			if compressed {
 				expectedSize = gzipCompressedSize(t, pingRequest)

--- a/envelope.go
+++ b/envelope.go
@@ -259,11 +259,8 @@ func (r *envelopeReader) Read(env *envelope) *Error {
 		return errorf(CodeInvalidArgument, "message size %d overflowed uint32", size)
 	}
 	if r.readMaxBytes > 0 && size > r.readMaxBytes {
-		_, err := io.CopyN(io.Discard, r.reader, int64(size))
-		if err != nil && !errors.Is(err, io.EOF) {
-			return errorf(CodeUnknown, "read enveloped message: %w", err)
-		}
-		return errorf(CodeResourceExhausted, "message size %d is larger than configured max %d", size, r.readMaxBytes)
+		src := io.LimitReader(r.reader, int64(size))
+		return errMaxReadLimitExceeded(src, 0, int64(r.readMaxBytes))
 	}
 	if size > 0 {
 		// At layer 7, we don't know exactly what's happening down in L4. Large

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -1083,12 +1083,8 @@ func (u *connectUnaryUnmarshaler) UnmarshalFunc(message any, unmarshal func([]by
 		return errorf(CodeUnknown, "read message: %w", err)
 	}
 	if u.readMaxBytes > 0 && bytesRead > int64(u.readMaxBytes) {
-		// Attempt to read to end in order to allow connection re-use
-		discardedBytes, err := io.Copy(io.Discard, u.reader)
-		if err != nil {
-			return errorf(CodeResourceExhausted, "message is larger than configured max %d - unable to determine message size: %w", u.readMaxBytes, err)
-		}
-		return errorf(CodeResourceExhausted, "message size %d is larger than configured max %d", bytesRead+discardedBytes, u.readMaxBytes)
+		// Attempt to read to end in order to allow connection re-use.
+		return errMaxReadLimitExceeded(u.reader, bytesRead, int64(u.readMaxBytes))
 	}
 	if data.Len() > 0 && u.compressionPool != nil {
 		decompressed := u.bufferPool.Get()


### PR DESCRIPTION
I'm not sure if this is the correct solution but raising as a PR to get feedback. Currently enveloped messages can cause a large discard call as if the size is above the message size, which is above the the discard limit, then we always discard the next N bytes which could be 4Gb (max uint32).

Connect clients will discard when they've read as much input as the max message size, plus the discard limit.

Should the discard size be greater than the message size? For enveloped payloads should we discard the message limit? And for connect payloads should we count the message size read into the discard limit? 

Another option could be to move the discard calls to occur after the error return,  try discard for TCP reuse as a cleanup routine.