### PR TITLE
Try tparse for test output formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ clean: ## Delete intermediate build artifacts
 	git clean -Xdf
 
 .PHONY: test
-test: build ## Run unit tests
-	go test -vet=off -race -cover ./...
+test: build $(BIN)/tparse ## Run unit tests
+	go test -vet=off -race -cover -json ./... | tparse
 
 .PHONY: bench
 bench: BENCH ?= .*
@@ -94,4 +94,8 @@ $(BIN)/protoc-gen-go: Makefile go.mod
 	@mkdir -p $(@D)
 	@# The version of protoc-gen-go is determined by the version in go.mod
 	go install google.golang.org/protobuf/cmd/protoc-gen-go
+
+$(BIN)/tparse: Makefile
+	@mkdir -p $(@D)
+	go install github.com/mfridman/tparse@v0.13.1
 


### PR DESCRIPTION
```
$ make test
go build -o .tmp/bin/protoc-gen-connect-go ./cmd/protoc-gen-connect-go
rm -rf internal/gen
PATH="/Users/edward/src/github.com/connectrpc/connect-go/.tmp/bin" buf generate
license-header \
                --license-type apache \
                --copyright-holder "The Connect Authors" \
                --year-range "2021-2023" --ignore /testdata/
go build ./...
go test -vet=off -race -cover -json ./... | tparse
┌───────────────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED  │                PACKAGE                 │ COVER │ PASS │ FAIL │ SKIP  │
│─────────┼──────────┼────────────────────────────────────────┼───────┼──────┼──────┼───────│
│  PASS   │ (cached) │ connectrpc.com/connect                 │ 88.9% │ 670  │  0   │  0    │
│  PASS   │ (cached) │ connectrpc.com/connect/internal/assert │ 50.6% │  8   │  0   │  0    │
└───────────────────────────────────────────────────────────────────────────────────────────┘
```
