### PR TITLE
Make PR template use a comment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,5 @@
-**Before submitting your PR:** Please read through the contribution guide at https://connectrpc.com/connect/blob/main/.github/CONTRIBUTING.md
+<!--
+Before submitting your PR, please read through the contribution guide!
+
+https://connectrpc.com/connect/blob/main/.github/CONTRIBUTING.md
+-->


### PR DESCRIPTION
Rather than automatically inserting text into PR messages, use an HTML
comment. This is especially helpful when opening PRs with the `gh` tool, which
makes it easy to forget to manually edit the summary.
