### PR TITLE
Add flags to running golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ install: ## Install all binaries
 .PHONY: lint
 lint: $(BIN)/golangci-lint $(BIN)/buf ## Lint Go and protobuf
 	go vet ./...
-	golangci-lint run
+	golangci-lint run --modules-download-mode=readonly --timeout=3m0s
 	buf lint
 	buf format -d --exit-code
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ lint: $(BIN)/golangci-lint $(BIN)/buf ## Lint Go and protobuf
 
 .PHONY: lintfix
 lintfix: $(BIN)/golangci-lint $(BIN)/buf ## Automatically fix some lint errors
-	golangci-lint run --fix
+	golangci-lint run --fix --modules-download-mode=readonly --timeout=3m0s
 	buf format -w
 
 .PHONY: generate


### PR DESCRIPTION
Add `--modules-download-mode=readonly` and `--timeout=3m0s` to running `golangci-lint`.
