### PR TITLE
Add Read and WriterTo methods to envelopes

### DIFF
--- a/error_writer.go
+++ b/error_writer.go
@@ -133,12 +133,11 @@ func (w *ErrorWriter) writeConnectStreaming(response http.ResponseWriter, err er
 	response.WriteHeader(http.StatusOK)
 	marshaler := &connectStreamingMarshaler{
 		envelopeWriter: envelopeWriter{
-			writer:     response,
 			bufferPool: w.bufferPool,
 		},
 	}
 	// MarshalEndStream returns *Error: check return value to avoid typed nils.
-	if marshalErr := marshaler.MarshalEndStream(err, make(http.Header)); marshalErr != nil {
+	if marshalErr := marshaler.MarshalEndStream(response, err, make(http.Header)); marshalErr != nil {
 		return marshalErr
 	}
 	return nil

--- a/protocol_connect_test.go
+++ b/protocol_connect_test.go
@@ -72,10 +72,10 @@ func TestConnectEndOfResponseCanonicalTrailers(t *testing.T) {
 	assert.Nil(t, err)
 
 	writer := envelopeWriter{
-		writer:     &buffer,
 		bufferPool: bufferPool,
 	}
-	err = writer.Write(&envelope{
+	dst := &buffer
+	err = writer.Write(dst, &envelope{
 		Flags: connectFlagEnvelopeEndStream,
 		Data:  bytes.NewBuffer(endStreamData),
 	})
@@ -83,11 +83,11 @@ func TestConnectEndOfResponseCanonicalTrailers(t *testing.T) {
 
 	unmarshaler := connectStreamingUnmarshaler{
 		envelopeReader: envelopeReader{
-			reader:     &buffer,
 			bufferPool: bufferPool,
 		},
 	}
-	err = unmarshaler.Unmarshal(nil) // parameter won't be used
+	src := &buffer
+	err = unmarshaler.Unmarshal(nil /* message unused */, src)
 	assert.ErrorIs(t, err, errSpecialEnvelope)
 	assert.Equal(t, unmarshaler.Trailer().Values("Not-Canonical-Header"), []string{"a"})
 	assert.Equal(t, unmarshaler.Trailer().Values("Mixed-Canonical"), []string{"b", "b"})

--- a/protocol_grpc_test.go
+++ b/protocol_grpc_test.go
@@ -48,7 +48,6 @@ func TestGRPCHandlerSender(t *testing.T) {
 			protobuf:   protobufCodec,
 			marshaler: grpcMarshaler{
 				envelopeWriter: envelopeWriter{
-					writer:     responseWriter,
 					codec:      protobufCodec,
 					bufferPool: bufferPool,
 				},
@@ -59,7 +58,6 @@ func TestGRPCHandlerSender(t *testing.T) {
 			request:         request,
 			unmarshaler: grpcUnmarshaler{
 				envelopeReader: envelopeReader{
-					reader:     request.Body,
 					codec:      protobufCodec,
 					bufferPool: bufferPool,
 				},
@@ -181,7 +179,6 @@ func TestGRPCWebTrailerMarshalling(t *testing.T) {
 	responseWriter := httptest.NewRecorder()
 	marshaler := grpcMarshaler{
 		envelopeWriter: envelopeWriter{
-			writer:     responseWriter,
 			bufferPool: newBufferPool(),
 		},
 	}
@@ -189,7 +186,7 @@ func TestGRPCWebTrailerMarshalling(t *testing.T) {
 	trailer.Add("grpc-status", "0")
 	trailer.Add("Grpc-Message", "Foo")
 	trailer.Add("User-Provided", "bar")
-	err := marshaler.MarshalWebTrailers(trailer)
+	err := marshaler.MarshalWebTrailers(responseWriter, trailer)
 	assert.Nil(t, err)
 	responseWriter.Body.Next(5) // skip flags and message length
 	marshalled := responseWriter.Body.String()


### PR DESCRIPTION
Allow `src` and `dst` to be set for envelope read/writers. Envelopes also implement `io.Reader` and `io.WriterTo` methods to allow passing envelopes as a message payload.

Requirement for #611 to avoid copying the buffers. See #609 
