### PR TITLE
Debug concurrent streams test

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -476,7 +476,7 @@ func TestConcurrentStreams(t *testing.T) {
 	server := memhttptest.NewServer(t, mux)
 	var done, start sync.WaitGroup
 	start.Add(1)
-	for i := 0; i < runtime.NumCPU()*2; i++ {
+	for i := 0; i < runtime.GOMAXPROCS(0)*2; i++ {
 		done.Add(1)
 		go func() {
 			defer done.Done()

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -26,6 +26,7 @@ import (
 	"math"
 	"math/rand"
 	"net/http"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -475,7 +476,7 @@ func TestConcurrentStreams(t *testing.T) {
 	server := memhttptest.NewServer(t, mux)
 	var done, start sync.WaitGroup
 	start.Add(1)
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < runtime.NumCPU()*2; i++ {
 		done.Add(1)
 		go func() {
 			defer done.Done()

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -511,6 +511,8 @@ func TestConcurrentStreams(t *testing.T) {
 	}
 	start.Done()
 	done.Wait()
+	t.Error("NUMCPU", runtime.NumCPU())
+	t.Error("GOMAXPROCS", runtime.GOMAXPROCS(0))
 }
 
 func TestHeaderBasic(t *testing.T) {

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -475,7 +475,7 @@ func TestConcurrentStreams(t *testing.T) {
 	server := memhttptest.NewServer(t, mux)
 	var done, start sync.WaitGroup
 	start.Add(1)
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 1000; i++ {
 		done.Add(1)
 		go func() {
 			defer done.Done()

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -476,7 +476,7 @@ func TestConcurrentStreams(t *testing.T) {
 	server := memhttptest.NewServer(t, mux)
 	var done, start sync.WaitGroup
 	start.Add(1)
-	for i := 0; i < runtime.GOMAXPROCS(0)*2; i++ {
+	for i := 0; i < runtime.GOMAXPROCS(0)*8; i++ {
 		done.Add(1)
 		go func() {
 			defer done.Done()
@@ -511,8 +511,6 @@ func TestConcurrentStreams(t *testing.T) {
 	}
 	start.Done()
 	done.Wait()
-	t.Error("NUMCPU", runtime.NumCPU())
-	t.Error("GOMAXPROCS", runtime.GOMAXPROCS(0))
 }
 
 func TestHeaderBasic(t *testing.T) {

--- a/internal/memhttp/memhttp_test.go
+++ b/internal/memhttp/memhttp_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -30,7 +31,7 @@ import (
 
 func TestServerTransport(t *testing.T) {
 	t.Parallel()
-	const concurrency = 100
+	concurrency := runtime.GOMAXPROCS(0) * 2
 	const greeting = "Hello, world!"
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/memhttp/memhttp_test.go
+++ b/internal/memhttp/memhttp_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestServerTransport(t *testing.T) {
 	t.Parallel()
-	concurrency := runtime.GOMAXPROCS(0) * 2
+	concurrency := runtime.GOMAXPROCS(0) * 8
 	const greeting = "Hello, world!"
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Locally increasing the number of concurrent streams and running with `-race` generates:
```
writeRequest io.ErrClosedPipe
2023/11/03 10:19:46 timeout waiting for SETTINGS frames from pipe
writeRequest io.ErrClosedPipe
--- FAIL: TestConcurrentStreams (35.69s)
    connect_ext_test.go:490: failed to send request: unknown: write envelope: EOF
    connect_ext_test.go:490: failed to send request: unknown: write envelope: EOF
```
Large number of go routines can timeout past the arbitrary limit of 2 seconds in the HTTP2 libraries. See comment [here](https://github.com/golang/go/issues/60359#issuecomment-1560113923).
Bind the concurrency to [`runtime.GOMAXPROCS`](https://pkg.go.dev/runtime#GOMAXPROCS) to reduce resource requirements for testing on different machines.

See https://github.com/golang/go/issues/60359

Occurred in https://github.com/connectrpc/connect-go/actions/runs/6725037978/job/18278596900?pr=611
<!--
Before submitting your PR, please read through the contribution guide!

https://github.com/connectrpc/connect-go/blob/main/.github/CONTRIBUTING.md
-->
