### PR TITLE
Debug flaky `TestStreamForServer` test

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -1511,6 +1511,7 @@ func TestBidiStreamServerSendsFirstMessage(t *testing.T) {
 func TestStreamForServer(t *testing.T) {
 	t.Parallel()
 	newPingClient := func(t *testing.T, pingServer pingv1connect.PingServiceHandler) pingv1connect.PingServiceClient {
+		t.Helper()
 		mux := http.NewServeMux()
 		mux.Handle(pingv1connect.NewPingServiceHandler(pingServer))
 		server := memhttptest.NewServer(t, mux)

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -1510,7 +1510,7 @@ func TestBidiStreamServerSendsFirstMessage(t *testing.T) {
 
 func TestStreamForServer(t *testing.T) {
 	t.Parallel()
-	newPingClient := func(pingServer pingv1connect.PingServiceHandler) pingv1connect.PingServiceClient {
+	newPingClient := func(t *testing.T, pingServer pingv1connect.PingServiceHandler) pingv1connect.PingServiceClient {
 		mux := http.NewServeMux()
 		mux.Handle(pingv1connect.NewPingServiceHandler(pingServer))
 		server := memhttptest.NewServer(t, mux)
@@ -1522,7 +1522,7 @@ func TestStreamForServer(t *testing.T) {
 	}
 	t.Run("not-proto-message", func(t *testing.T) {
 		t.Parallel()
-		client := newPingClient(&pluggablePingServer{
+		client := newPingClient(t, &pluggablePingServer{
 			cumSum: func(ctx context.Context, stream *connect.BidiStream[pingv1.CumSumRequest, pingv1.CumSumResponse]) error {
 				return stream.Conn().Send("foobar")
 			},
@@ -1536,7 +1536,7 @@ func TestStreamForServer(t *testing.T) {
 	})
 	t.Run("nil-message", func(t *testing.T) {
 		t.Parallel()
-		client := newPingClient(&pluggablePingServer{
+		client := newPingClient(t, &pluggablePingServer{
 			cumSum: func(ctx context.Context, stream *connect.BidiStream[pingv1.CumSumRequest, pingv1.CumSumResponse]) error {
 				return stream.Send(nil)
 			},
@@ -1550,7 +1550,7 @@ func TestStreamForServer(t *testing.T) {
 	})
 	t.Run("get-spec", func(t *testing.T) {
 		t.Parallel()
-		client := newPingClient(&pluggablePingServer{
+		client := newPingClient(t, &pluggablePingServer{
 			cumSum: func(ctx context.Context, stream *connect.BidiStream[pingv1.CumSumRequest, pingv1.CumSumResponse]) error {
 				assert.Equal(t, stream.Spec().StreamType, connect.StreamTypeBidi)
 				assert.Equal(t, stream.Spec().Procedure, pingv1connect.PingServiceCumSumProcedure)
@@ -1564,7 +1564,7 @@ func TestStreamForServer(t *testing.T) {
 	})
 	t.Run("server-stream", func(t *testing.T) {
 		t.Parallel()
-		client := newPingClient(&pluggablePingServer{
+		client := newPingClient(t, &pluggablePingServer{
 			countUp: func(ctx context.Context, req *connect.Request[pingv1.CountUpRequest], stream *connect.ServerStream[pingv1.CountUpResponse]) error {
 				assert.Equal(t, stream.Conn().Spec().StreamType, connect.StreamTypeServer)
 				assert.Equal(t, stream.Conn().Spec().Procedure, pingv1connect.PingServiceCountUpProcedure)
@@ -1580,7 +1580,7 @@ func TestStreamForServer(t *testing.T) {
 	})
 	t.Run("server-stream-send", func(t *testing.T) {
 		t.Parallel()
-		client := newPingClient(&pluggablePingServer{
+		client := newPingClient(t, &pluggablePingServer{
 			countUp: func(ctx context.Context, req *connect.Request[pingv1.CountUpRequest], stream *connect.ServerStream[pingv1.CountUpResponse]) error {
 				assert.Nil(t, stream.Send(&pingv1.CountUpResponse{Number: 1}))
 				return nil
@@ -1596,7 +1596,7 @@ func TestStreamForServer(t *testing.T) {
 	})
 	t.Run("server-stream-send-nil", func(t *testing.T) {
 		t.Parallel()
-		client := newPingClient(&pluggablePingServer{
+		client := newPingClient(t, &pluggablePingServer{
 			countUp: func(ctx context.Context, req *connect.Request[pingv1.CountUpRequest], stream *connect.ServerStream[pingv1.CountUpResponse]) error {
 				stream.ResponseHeader().Set("foo", "bar")
 				stream.ResponseTrailer().Set("bas", "blah")
@@ -1617,7 +1617,7 @@ func TestStreamForServer(t *testing.T) {
 	})
 	t.Run("client-stream", func(t *testing.T) {
 		t.Parallel()
-		client := newPingClient(&pluggablePingServer{
+		client := newPingClient(t, &pluggablePingServer{
 			sum: func(ctx context.Context, stream *connect.ClientStream[pingv1.SumRequest]) (*connect.Response[pingv1.SumResponse], error) {
 				assert.Equal(t, stream.Spec().StreamType, connect.StreamTypeClient)
 				assert.Equal(t, stream.Spec().Procedure, pingv1connect.PingServiceSumProcedure)
@@ -1638,8 +1638,9 @@ func TestStreamForServer(t *testing.T) {
 	})
 	t.Run("client-stream-conn", func(t *testing.T) {
 		t.Parallel()
-		client := newPingClient(&pluggablePingServer{
+		client := newPingClient(t, &pluggablePingServer{
 			sum: func(ctx context.Context, stream *connect.ClientStream[pingv1.SumRequest]) (*connect.Response[pingv1.SumResponse], error) {
+				assert.True(t, stream.Receive())
 				assert.NotNil(t, stream.Conn().Send("not-proto"))
 				return connect.NewResponse(&pingv1.SumResponse{}), nil
 			},
@@ -1652,8 +1653,9 @@ func TestStreamForServer(t *testing.T) {
 	})
 	t.Run("client-stream-send-msg", func(t *testing.T) {
 		t.Parallel()
-		client := newPingClient(&pluggablePingServer{
+		client := newPingClient(t, &pluggablePingServer{
 			sum: func(ctx context.Context, stream *connect.ClientStream[pingv1.SumRequest]) (*connect.Response[pingv1.SumResponse], error) {
+				assert.True(t, stream.Receive())
 				assert.Nil(t, stream.Conn().Send(&pingv1.SumResponse{Sum: 2}))
 				return connect.NewResponse(&pingv1.SumResponse{}), nil
 			},

--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -42,7 +42,7 @@ type duplexHTTPCall struct {
 	requestBodyReader *io.PipeReader
 	requestBodyWriter *io.PipeWriter
 
-	// sendRequestOnce ensures we only send the request once.
+	// requestSent ensures we only send the request once.
 	requestSent atomic.Bool
 	request     *http.Request
 


### PR DESCRIPTION
`TestStreamForServer` can fail on `Send(nil)` returning `io.EOF`. This occurs because `Send(nil)` will try to `Write(nil)` to the request body pipe. In almost all cases this will be read (and therefore succeed) when buffering the request body. However, on the server returning quickly, the request can be closed causing the `Send` to fail with `io.EOF` error. 

To ensure a `Send` succeeds we need to match it with a correlating `Receive` in the server. Nil writes will never be guaranteed unless the server tries to `Receive` a message, which would read the request body and therefore enforce the successful drain. This is a problem for `Send(nil)` as the intended behaviour is to ensure the request headers are sent, which does complete but returns with an unexpected error.

To solve for `Send(nil)` we now check if this write caused the request to send and avoid triggering a body write if so. Any other cases and later if `Send(nil)` is called we `Write(nil)` which keeps the same behaviour.

Tests `client-stream-conn` and `client-stream-send-msg` write a message `Send(msg)`. For these I've modified the test cases to `Receive()` the message to ensure that the write completes and doesn't otherwise affect the test case.

Fixes https://github.com/connectrpc/connect-go/issues/626