### PR TITLE
Report assert errors as t.Error

### DIFF
--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -183,7 +183,7 @@ func report(tb testing.TB, got, want any, desc string, showWant bool, options ..
 	if showWant {
 		fmt.Fprintf(buffer, "want:\t%+v\n", want)
 	}
-	tb.Fatal(buffer.String())
+	tb.Error(buffer.String())
 }
 
 func isNil(got any) bool {


### PR DESCRIPTION
Internal assert package returns booleans for allowing conditional behaviour but currently can't be used as `t.Fatal` is called suspending execution. It's also not safe for `t.Fatal` to be called outside of the main go routine running the test. Use `t.Error` to report errors instead.

Example: https://github.com/connectrpc/connect-go/blob/2be1555cbf36879b6b1197cd09bc6e4cbe10290f/client_ext_test.go#L212 under failure would panic the client or server go routines not the test handlers.