### PR TITLE
Add Schema field to Spec for introspection

### DIFF
--- a/client.go
+++ b/client.go
@@ -189,6 +189,7 @@ type clientConfig struct {
 	URL                    *url.URL
 	Protocol               protocol
 	Procedure              string
+	Schema                 any
 	CompressMinBytes       int
 	Interceptor            Interceptor
 	CompressionPools       map[string]*compressionPool
@@ -251,6 +252,7 @@ func (c *clientConfig) newSpec(t StreamType) Spec {
 	return Spec{
 		StreamType:       t,
 		Procedure:        c.Procedure,
+		Schema:           c.Schema,
 		IsClient:         true,
 		IdempotencyLevel: c.IdempotencyLevel,
 	}

--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -284,9 +284,10 @@ func (a *assertSchemaInterceptor) WrapUnary(next connect.UnaryFunc) connect.Unar
 			return next(ctx, req)
 		}
 		methodDesc, ok := req.Spec().Schema.(protoreflect.MethodDescriptor)
-		assert.True(a.tb, ok)
-		procedure := fmt.Sprintf("/%s/%s", methodDesc.Parent().FullName(), methodDesc.Name())
-		assert.Equal(a.tb, procedure, req.Spec().Procedure)
+		if assert.True(a.tb, ok) {
+			procedure := fmt.Sprintf("/%s/%s", methodDesc.Parent().FullName(), methodDesc.Name())
+			assert.Equal(a.tb, procedure, req.Spec().Procedure)
+		}
 		return next(ctx, req)
 	}
 }
@@ -298,9 +299,10 @@ func (a *assertSchemaInterceptor) WrapStreamingClient(next connect.StreamingClie
 			return conn
 		}
 		methodDescriptor, ok := spec.Schema.(protoreflect.MethodDescriptor)
-		assert.True(a.tb, ok)
-		procedure := fmt.Sprintf("/%s/%s", methodDescriptor.Parent().FullName(), methodDescriptor.Name())
-		assert.Equal(a.tb, procedure, spec.Procedure)
+		if assert.True(a.tb, ok) {
+			procedure := fmt.Sprintf("/%s/%s", methodDescriptor.Parent().FullName(), methodDescriptor.Name())
+			assert.Equal(a.tb, procedure, spec.Procedure)
+		}
 		return conn
 	}
 }
@@ -311,9 +313,10 @@ func (a *assertSchemaInterceptor) WrapStreamingHandler(next connect.StreamingHan
 			return next(ctx, conn)
 		}
 		methodDesc, ok := conn.Spec().Schema.(protoreflect.MethodDescriptor)
-		assert.True(a.tb, ok)
-		procedure := fmt.Sprintf("/%s/%s", methodDesc.Parent().FullName(), methodDesc.Name())
-		assert.Equal(a.tb, procedure, conn.Spec().Procedure)
+		if assert.True(a.tb, ok) {
+			procedure := fmt.Sprintf("/%s/%s", methodDesc.Parent().FullName(), methodDesc.Name())
+			assert.Equal(a.tb, procedure, conn.Spec().Procedure)
+		}
 		return next(ctx, conn)
 	}
 }

--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -281,7 +281,7 @@ type assertSchemaInterceptor struct {
 func (a *assertSchemaInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 		if !assert.NotNil(a.tb, req.Spec().Schema) {
-			return nil, fmt.Errorf("nil spec")
+			return next(ctx, req)
 		}
 		methodDesc, ok := req.Spec().Schema.(protoreflect.MethodDescriptor)
 		assert.True(a.tb, ok)
@@ -308,7 +308,7 @@ func (a *assertSchemaInterceptor) WrapStreamingClient(next connect.StreamingClie
 func (a *assertSchemaInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
 	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
 		if !assert.NotNil(a.tb, conn.Spec().Schema) {
-			return fmt.Errorf("nil spec")
+			return next(ctx, conn)
 		}
 		methodDesc, ok := conn.Spec().Schema.(protoreflect.MethodDescriptor)
 		assert.True(a.tb, ok)

--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -212,8 +212,7 @@ func generateServiceNameConstants(g *protogen.GeneratedFile, services []*protoge
 }
 
 func generateServiceNameVariables(g *protogen.GeneratedFile, file *protogen.File) {
-	wrapComments(g, "These variables are the protoreflect.Descriptor objects for the ", file.Desc.Name(),
-		" service's methods.")
+	wrapComments(g, "These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.")
 	g.P("var (")
 	for _, service := range file.Services {
 		serviceDescName := unexport(fmt.Sprintf("%sServiceDescriptor", service.Desc.Name()))

--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -124,8 +124,9 @@ func generate(plugin *protogen.Plugin, file *protogen.File) {
 	generatedFile.Import(file.GoImportPath)
 	generatePreamble(generatedFile, file)
 	generateServiceNameConstants(generatedFile, file.Services)
+	generateServiceNameVariables(generatedFile, file)
 	for _, service := range file.Services {
-		generateService(generatedFile, file, service)
+		generateService(generatedFile, service)
 	}
 }
 
@@ -210,12 +211,30 @@ func generateServiceNameConstants(g *protogen.GeneratedFile, services []*protoge
 	g.P()
 }
 
-func generateService(g *protogen.GeneratedFile, file *protogen.File, service *protogen.Service) {
+func generateServiceNameVariables(g *protogen.GeneratedFile, file *protogen.File) {
+	wrapComments(g, "These variables are the protoreflect.Descriptor objects for the ", file.Desc.Name(),
+		" service's methods.")
+	g.P("var (")
+	for _, service := range file.Services {
+		serviceDescName := unexport(fmt.Sprintf("%sServiceDescriptor", service.Desc.Name()))
+		g.P(serviceDescName, ` = `,
+			g.QualifiedGoIdent(file.GoDescriptorIdent),
+			`.Services().ByName("`, service.Desc.Name(), `")`)
+		for _, method := range service.Methods {
+			g.P(procedureVarMethodDescriptor(method), ` = `,
+				serviceDescName,
+				`.Methods().ByName("`, method.Desc.Name(), `")`)
+		}
+	}
+	g.P(")")
+}
+
+func generateService(g *protogen.GeneratedFile, service *protogen.Service) {
 	names := newNames(service)
 	generateClientInterface(g, service, names)
-	generateClientImplementation(g, file, service, names)
+	generateClientImplementation(g, service, names)
 	generateServerInterface(g, service, names)
-	generateServerConstructor(g, file, service, names)
+	generateServerConstructor(g, service, names)
 	generateUnimplementedServerImplementation(g, service, names)
 }
 
@@ -240,7 +259,7 @@ func generateClientInterface(g *protogen.GeneratedFile, service *protogen.Servic
 	g.P()
 }
 
-func generateClientImplementation(g *protogen.GeneratedFile, file *protogen.File, service *protogen.Service, names names) {
+func generateClientImplementation(g *protogen.GeneratedFile, service *protogen.Service, names names) {
 	clientOption := connectPackage.Ident("ClientOption")
 
 	// Client constructor.
@@ -260,8 +279,6 @@ func generateClientImplementation(g *protogen.GeneratedFile, file *protogen.File
 		", baseURL string, opts ...", clientOption, ") ", names.Client, " {")
 	if len(service.Methods) > 0 {
 		g.P("baseURL = ", stringsPackage.Ident("TrimRight"), `(baseURL, "/")`)
-		g.P("serviceDescriptor := ", g.QualifiedGoIdent(file.GoDescriptorIdent),
-			`.Services().ByName("`, service.Desc.Name(), `")`)
 	}
 	g.P("return &", names.ClientImpl, "{")
 	for _, method := range service.Methods {
@@ -272,8 +289,7 @@ func generateClientImplementation(g *protogen.GeneratedFile, file *protogen.File
 		)
 		g.P("httpClient,")
 		g.P(`baseURL + `, procedureConstName(method), `,`)
-		g.P(connectPackage.Ident("WithSchema"), "(",
-			`serviceDescriptor.Methods().ByName("`, method.Desc.Name(), `")),`)
+		g.P(connectPackage.Ident("WithSchema"), "(", procedureVarMethodDescriptor(method), "),")
 		idempotency := methodIdempotency(method)
 		switch idempotency {
 		case connect.IdempotencyNoSideEffects:
@@ -379,7 +395,7 @@ func generateServerInterface(g *protogen.GeneratedFile, service *protogen.Servic
 	g.P()
 }
 
-func generateServerConstructor(g *protogen.GeneratedFile, file *protogen.File, service *protogen.Service, names names) {
+func generateServerConstructor(g *protogen.GeneratedFile, service *protogen.Service, names names) {
 	wrapComments(g, names.ServerConstructor, " builds an HTTP handler from the service implementation.",
 		" It returns the path on which to mount the handler and the handler itself.")
 	g.P("//")
@@ -392,10 +408,6 @@ func generateServerConstructor(g *protogen.GeneratedFile, file *protogen.File, s
 	handlerOption := connectPackage.Ident("HandlerOption")
 	g.P("func ", names.ServerConstructor, "(svc ", names.Server, ", opts ...", handlerOption,
 		") (string, ", httpPackage.Ident("Handler"), ") {")
-	if len(service.Methods) > 0 {
-		g.P("serviceDescriptor := ", g.QualifiedGoIdent(file.GoDescriptorIdent),
-			`.Services().ByName("`, service.Desc.Name(), `")`)
-	}
 	for _, method := range service.Methods {
 		isStreamingServer := method.Desc.IsStreamingServer()
 		isStreamingClient := method.Desc.IsStreamingClient()
@@ -412,8 +424,7 @@ func generateServerConstructor(g *protogen.GeneratedFile, file *protogen.File, s
 		}
 		g.P(procedureConstName(method), `,`)
 		g.P("svc.", method.GoName, ",")
-		g.P(connectPackage.Ident("WithSchema"), "(",
-			`serviceDescriptor.Methods().ByName("`, method.Desc.Name(), `")),`)
+		g.P(connectPackage.Ident("WithSchema"), "(", procedureVarMethodDescriptor(method), "),")
 		switch idempotency {
 		case connect.IdempotencyNoSideEffects:
 			g.P(connectPackage.Ident("WithIdempotency"), "(", connectPackage.Ident("IdempotencyNoSideEffects"), "),")
@@ -507,6 +518,10 @@ func procedureConstName(m *protogen.Method) string {
 
 func procedureHandlerName(m *protogen.Method) string {
 	return fmt.Sprintf("%s%sHandler", unexport(m.Parent.GoName), m.GoName)
+}
+
+func procedureVarMethodDescriptor(m *protogen.Method) string {
+	return unexport(fmt.Sprintf("%s%sMethodDescriptor", m.Parent.GoName, m.GoName))
 }
 
 func isDeprecatedService(service *protogen.Service) bool {

--- a/connect.go
+++ b/connect.go
@@ -38,9 +38,10 @@ const Version = "1.13.0-dev"
 // These constants are used in compile-time handshakes with connect's generated
 // code.
 const (
-	IsAtLeastVersion0_0_1 = true
-	IsAtLeastVersion0_1_0 = true
-	IsAtLeastVersion1_7_0 = true
+	IsAtLeastVersion0_0_1  = true
+	IsAtLeastVersion0_1_0  = true
+	IsAtLeastVersion1_7_0  = true
+	IsAtLeastVersion1_13_0 = true
 )
 
 // StreamType describes whether the client, server, neither, or both is
@@ -314,6 +315,7 @@ type HTTPClient interface {
 // fully-qualified Procedure corresponding to each RPC in your schema.
 type Spec struct {
 	StreamType       StreamType
+	Schema           any    // for protobuf RPCs, a protoreflect.MethodDescriptor
 	Procedure        string // for example, "/acme.foo.v1.FooService/Bar"
 	IsClient         bool   // otherwise we're in a handler
 	IdempotencyLevel IdempotencyLevel

--- a/handler.go
+++ b/handler.go
@@ -246,6 +246,7 @@ type handlerConfig struct {
 	CompressMinBytes             int
 	Interceptor                  Interceptor
 	Procedure                    string
+	Schema                       any
 	HandleGRPC                   bool
 	HandleGRPCWeb                bool
 	RequireConnectProtocolHeader bool
@@ -279,6 +280,7 @@ func newHandlerConfig(procedure string, streamType StreamType, options []Handler
 func (c *handlerConfig) newSpec() Spec {
 	return Spec{
 		Procedure:        c.Procedure,
+		Schema:           c.Schema,
 		StreamType:       c.StreamType,
 		IdempotencyLevel: c.IdempotencyLevel,
 	}

--- a/internal/gen/connect/collide/v1/collidev1connect/collide.connect.go
+++ b/internal/gen/connect/collide/v1/collidev1connect/collide.connect.go
@@ -51,6 +51,12 @@ const (
 	CollideServiceImportProcedure = "/connect.collide.v1.CollideService/Import"
 )
 
+// These variables are the protoreflect.Descriptor objects for the v1 service's methods.
+var (
+	collideServiceServiceDescriptor      = v1.File_connect_collide_v1_collide_proto.Services().ByName("CollideService")
+	collideServiceImportMethodDescriptor = collideServiceServiceDescriptor.Methods().ByName("Import")
+)
+
 // CollideServiceClient is a client for the connect.collide.v1.CollideService service.
 type CollideServiceClient interface {
 	Import(context.Context, *connect.Request[v1.ImportRequest]) (*connect.Response[v1.ImportResponse], error)
@@ -65,12 +71,11 @@ type CollideServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewCollideServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) CollideServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
-	serviceDescriptor := v1.File_connect_collide_v1_collide_proto.Services().ByName("CollideService")
 	return &collideServiceClient{
 		_import: connect.NewClient[v1.ImportRequest, v1.ImportResponse](
 			httpClient,
 			baseURL+CollideServiceImportProcedure,
-			connect.WithSchema(serviceDescriptor.Methods().ByName("Import")),
+			connect.WithSchema(collideServiceImportMethodDescriptor),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -97,11 +102,10 @@ type CollideServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewCollideServiceHandler(svc CollideServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
-	serviceDescriptor := v1.File_connect_collide_v1_collide_proto.Services().ByName("CollideService")
 	collideServiceImportHandler := connect.NewUnaryHandler(
 		CollideServiceImportProcedure,
 		svc.Import,
-		connect.WithSchema(serviceDescriptor.Methods().ByName("Import")),
+		connect.WithSchema(collideServiceImportMethodDescriptor),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/connect.collide.v1.CollideService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/gen/connect/collide/v1/collidev1connect/collide.connect.go
+++ b/internal/gen/connect/collide/v1/collidev1connect/collide.connect.go
@@ -32,7 +32,7 @@ import (
 // generated with a version of connect newer than the one compiled into your binary. You can fix the
 // problem by either regenerating this code with an older version of connect or updating the connect
 // version compiled into your binary.
-const _ = connect.IsAtLeastVersion0_1_0
+const _ = connect.IsAtLeastVersion1_13_0
 
 const (
 	// CollideServiceName is the fully-qualified name of the CollideService service.
@@ -69,7 +69,8 @@ func NewCollideServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 		_import: connect.NewClient[v1.ImportRequest, v1.ImportResponse](
 			httpClient,
 			baseURL+CollideServiceImportProcedure,
-			opts...,
+			connect.WithSchema(v1.File_connect_collide_v1_collide_proto.Services().ByName("CollideService").Methods().ByName("Import")),
+			connect.WithClientOptions(opts...),
 		),
 	}
 }
@@ -98,7 +99,8 @@ func NewCollideServiceHandler(svc CollideServiceHandler, opts ...connect.Handler
 	collideServiceImportHandler := connect.NewUnaryHandler(
 		CollideServiceImportProcedure,
 		svc.Import,
-		opts...,
+		connect.WithSchema(v1.File_connect_collide_v1_collide_proto.Services().ByName("CollideService").Methods().ByName("Import")),
+		connect.WithHandlerOptions(opts...),
 	)
 	return "/connect.collide.v1.CollideService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/internal/gen/connect/collide/v1/collidev1connect/collide.connect.go
+++ b/internal/gen/connect/collide/v1/collidev1connect/collide.connect.go
@@ -65,11 +65,12 @@ type CollideServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewCollideServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) CollideServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	serviceDescriptor := v1.File_connect_collide_v1_collide_proto.Services().ByName("CollideService")
 	return &collideServiceClient{
 		_import: connect.NewClient[v1.ImportRequest, v1.ImportResponse](
 			httpClient,
 			baseURL+CollideServiceImportProcedure,
-			connect.WithSchema(v1.File_connect_collide_v1_collide_proto.Services().ByName("CollideService").Methods().ByName("Import")),
+			connect.WithSchema(serviceDescriptor.Methods().ByName("Import")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -96,10 +97,11 @@ type CollideServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewCollideServiceHandler(svc CollideServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	serviceDescriptor := v1.File_connect_collide_v1_collide_proto.Services().ByName("CollideService")
 	collideServiceImportHandler := connect.NewUnaryHandler(
 		CollideServiceImportProcedure,
 		svc.Import,
-		connect.WithSchema(v1.File_connect_collide_v1_collide_proto.Services().ByName("CollideService").Methods().ByName("Import")),
+		connect.WithSchema(serviceDescriptor.Methods().ByName("Import")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/connect.collide.v1.CollideService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/gen/connect/collide/v1/collidev1connect/collide.connect.go
+++ b/internal/gen/connect/collide/v1/collidev1connect/collide.connect.go
@@ -51,7 +51,7 @@ const (
 	CollideServiceImportProcedure = "/connect.collide.v1.CollideService/Import"
 )
 
-// These variables are the protoreflect.Descriptor objects for the v1 service's methods.
+// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
 var (
 	collideServiceServiceDescriptor      = v1.File_connect_collide_v1_collide_proto.Services().ByName("CollideService")
 	collideServiceImportMethodDescriptor = collideServiceServiceDescriptor.Methods().ByName("Import")

--- a/internal/gen/connect/import/v1/importv1connect/import.connect.go
+++ b/internal/gen/connect/import/v1/importv1connect/import.connect.go
@@ -36,7 +36,7 @@ const (
 	ImportServiceName = "connect.import.v1.ImportService"
 )
 
-// These variables are the protoreflect.Descriptor objects for the v1 service's methods.
+// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
 var (
 	importServiceServiceDescriptor = v1.File_connect_import_v1_import_proto.Services().ByName("ImportService")
 )

--- a/internal/gen/connect/import/v1/importv1connect/import.connect.go
+++ b/internal/gen/connect/import/v1/importv1connect/import.connect.go
@@ -30,7 +30,7 @@ import (
 // generated with a version of connect newer than the one compiled into your binary. You can fix the
 // problem by either regenerating this code with an older version of connect or updating the connect
 // version compiled into your binary.
-const _ = connect.IsAtLeastVersion0_1_0
+const _ = connect.IsAtLeastVersion1_13_0
 
 const (
 	// ImportServiceName is the fully-qualified name of the ImportService service.

--- a/internal/gen/connect/import/v1/importv1connect/import.connect.go
+++ b/internal/gen/connect/import/v1/importv1connect/import.connect.go
@@ -20,7 +20,7 @@ package importv1connect
 
 import (
 	connect "connectrpc.com/connect"
-	_ "connectrpc.com/connect/internal/gen/connect/import/v1"
+	v1 "connectrpc.com/connect/internal/gen/connect/import/v1"
 	http "net/http"
 )
 
@@ -34,6 +34,11 @@ const _ = connect.IsAtLeastVersion1_13_0
 const (
 	// ImportServiceName is the fully-qualified name of the ImportService service.
 	ImportServiceName = "connect.import.v1.ImportService"
+)
+
+// These variables are the protoreflect.Descriptor objects for the v1 service's methods.
+var (
+	importServiceServiceDescriptor = v1.File_connect_import_v1_import_proto.Services().ByName("ImportService")
 )
 
 // ImportServiceClient is a client for the connect.import.v1.ImportService service.

--- a/internal/gen/connect/import/v1/importv1connect/import.connect.go
+++ b/internal/gen/connect/import/v1/importv1connect/import.connect.go
@@ -22,7 +22,6 @@ import (
 	connect "connectrpc.com/connect"
 	_ "connectrpc.com/connect/internal/gen/connect/import/v1"
 	http "net/http"
-	strings "strings"
 )
 
 // This is a compile-time assertion to ensure that this generated file and the connect package are
@@ -49,7 +48,6 @@ type ImportServiceClient interface {
 // The URL supplied here should be the base URL for the Connect or gRPC server (for example,
 // http://api.acme.com or https://acme.com/grpc).
 func NewImportServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) ImportServiceClient {
-	baseURL = strings.TrimRight(baseURL, "/")
 	return &importServiceClient{}
 }
 

--- a/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
@@ -64,6 +64,16 @@ const (
 	PingServiceCumSumProcedure = "/connect.ping.v1.PingService/CumSum"
 )
 
+// These variables are the protoreflect.Descriptor objects for the v1 service's methods.
+var (
+	pingServiceServiceDescriptor       = v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService")
+	pingServicePingMethodDescriptor    = pingServiceServiceDescriptor.Methods().ByName("Ping")
+	pingServiceFailMethodDescriptor    = pingServiceServiceDescriptor.Methods().ByName("Fail")
+	pingServiceSumMethodDescriptor     = pingServiceServiceDescriptor.Methods().ByName("Sum")
+	pingServiceCountUpMethodDescriptor = pingServiceServiceDescriptor.Methods().ByName("CountUp")
+	pingServiceCumSumMethodDescriptor  = pingServiceServiceDescriptor.Methods().ByName("CumSum")
+)
+
 // PingServiceClient is a client for the connect.ping.v1.PingService service.
 type PingServiceClient interface {
 	// Ping sends a ping to the server to determine if it's reachable.
@@ -87,37 +97,36 @@ type PingServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewPingServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) PingServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
-	serviceDescriptor := v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService")
 	return &pingServiceClient{
 		ping: connect.NewClient[v1.PingRequest, v1.PingResponse](
 			httpClient,
 			baseURL+PingServicePingProcedure,
-			connect.WithSchema(serviceDescriptor.Methods().ByName("Ping")),
+			connect.WithSchema(pingServicePingMethodDescriptor),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		fail: connect.NewClient[v1.FailRequest, v1.FailResponse](
 			httpClient,
 			baseURL+PingServiceFailProcedure,
-			connect.WithSchema(serviceDescriptor.Methods().ByName("Fail")),
+			connect.WithSchema(pingServiceFailMethodDescriptor),
 			connect.WithClientOptions(opts...),
 		),
 		sum: connect.NewClient[v1.SumRequest, v1.SumResponse](
 			httpClient,
 			baseURL+PingServiceSumProcedure,
-			connect.WithSchema(serviceDescriptor.Methods().ByName("Sum")),
+			connect.WithSchema(pingServiceSumMethodDescriptor),
 			connect.WithClientOptions(opts...),
 		),
 		countUp: connect.NewClient[v1.CountUpRequest, v1.CountUpResponse](
 			httpClient,
 			baseURL+PingServiceCountUpProcedure,
-			connect.WithSchema(serviceDescriptor.Methods().ByName("CountUp")),
+			connect.WithSchema(pingServiceCountUpMethodDescriptor),
 			connect.WithClientOptions(opts...),
 		),
 		cumSum: connect.NewClient[v1.CumSumRequest, v1.CumSumResponse](
 			httpClient,
 			baseURL+PingServiceCumSumProcedure,
-			connect.WithSchema(serviceDescriptor.Methods().ByName("CumSum")),
+			connect.WithSchema(pingServiceCumSumMethodDescriptor),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -177,36 +186,35 @@ type PingServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewPingServiceHandler(svc PingServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
-	serviceDescriptor := v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService")
 	pingServicePingHandler := connect.NewUnaryHandler(
 		PingServicePingProcedure,
 		svc.Ping,
-		connect.WithSchema(serviceDescriptor.Methods().ByName("Ping")),
+		connect.WithSchema(pingServicePingMethodDescriptor),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	pingServiceFailHandler := connect.NewUnaryHandler(
 		PingServiceFailProcedure,
 		svc.Fail,
-		connect.WithSchema(serviceDescriptor.Methods().ByName("Fail")),
+		connect.WithSchema(pingServiceFailMethodDescriptor),
 		connect.WithHandlerOptions(opts...),
 	)
 	pingServiceSumHandler := connect.NewClientStreamHandler(
 		PingServiceSumProcedure,
 		svc.Sum,
-		connect.WithSchema(serviceDescriptor.Methods().ByName("Sum")),
+		connect.WithSchema(pingServiceSumMethodDescriptor),
 		connect.WithHandlerOptions(opts...),
 	)
 	pingServiceCountUpHandler := connect.NewServerStreamHandler(
 		PingServiceCountUpProcedure,
 		svc.CountUp,
-		connect.WithSchema(serviceDescriptor.Methods().ByName("CountUp")),
+		connect.WithSchema(pingServiceCountUpMethodDescriptor),
 		connect.WithHandlerOptions(opts...),
 	)
 	pingServiceCumSumHandler := connect.NewBidiStreamHandler(
 		PingServiceCumSumProcedure,
 		svc.CumSum,
-		connect.WithSchema(serviceDescriptor.Methods().ByName("CumSum")),
+		connect.WithSchema(pingServiceCumSumMethodDescriptor),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/connect.ping.v1.PingService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
@@ -87,36 +87,37 @@ type PingServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewPingServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) PingServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	serviceDescriptor := v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService")
 	return &pingServiceClient{
 		ping: connect.NewClient[v1.PingRequest, v1.PingResponse](
 			httpClient,
 			baseURL+PingServicePingProcedure,
-			connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("Ping")),
+			connect.WithSchema(serviceDescriptor.Methods().ByName("Ping")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		fail: connect.NewClient[v1.FailRequest, v1.FailResponse](
 			httpClient,
 			baseURL+PingServiceFailProcedure,
-			connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("Fail")),
+			connect.WithSchema(serviceDescriptor.Methods().ByName("Fail")),
 			connect.WithClientOptions(opts...),
 		),
 		sum: connect.NewClient[v1.SumRequest, v1.SumResponse](
 			httpClient,
 			baseURL+PingServiceSumProcedure,
-			connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("Sum")),
+			connect.WithSchema(serviceDescriptor.Methods().ByName("Sum")),
 			connect.WithClientOptions(opts...),
 		),
 		countUp: connect.NewClient[v1.CountUpRequest, v1.CountUpResponse](
 			httpClient,
 			baseURL+PingServiceCountUpProcedure,
-			connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("CountUp")),
+			connect.WithSchema(serviceDescriptor.Methods().ByName("CountUp")),
 			connect.WithClientOptions(opts...),
 		),
 		cumSum: connect.NewClient[v1.CumSumRequest, v1.CumSumResponse](
 			httpClient,
 			baseURL+PingServiceCumSumProcedure,
-			connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("CumSum")),
+			connect.WithSchema(serviceDescriptor.Methods().ByName("CumSum")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -176,35 +177,36 @@ type PingServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewPingServiceHandler(svc PingServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	serviceDescriptor := v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService")
 	pingServicePingHandler := connect.NewUnaryHandler(
 		PingServicePingProcedure,
 		svc.Ping,
-		connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("Ping")),
+		connect.WithSchema(serviceDescriptor.Methods().ByName("Ping")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	pingServiceFailHandler := connect.NewUnaryHandler(
 		PingServiceFailProcedure,
 		svc.Fail,
-		connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("Fail")),
+		connect.WithSchema(serviceDescriptor.Methods().ByName("Fail")),
 		connect.WithHandlerOptions(opts...),
 	)
 	pingServiceSumHandler := connect.NewClientStreamHandler(
 		PingServiceSumProcedure,
 		svc.Sum,
-		connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("Sum")),
+		connect.WithSchema(serviceDescriptor.Methods().ByName("Sum")),
 		connect.WithHandlerOptions(opts...),
 	)
 	pingServiceCountUpHandler := connect.NewServerStreamHandler(
 		PingServiceCountUpProcedure,
 		svc.CountUp,
-		connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("CountUp")),
+		connect.WithSchema(serviceDescriptor.Methods().ByName("CountUp")),
 		connect.WithHandlerOptions(opts...),
 	)
 	pingServiceCumSumHandler := connect.NewBidiStreamHandler(
 		PingServiceCumSumProcedure,
 		svc.CumSum,
-		connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("CumSum")),
+		connect.WithSchema(serviceDescriptor.Methods().ByName("CumSum")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/connect.ping.v1.PingService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
@@ -64,7 +64,7 @@ const (
 	PingServiceCumSumProcedure = "/connect.ping.v1.PingService/CumSum"
 )
 
-// These variables are the protoreflect.Descriptor objects for the v1 service's methods.
+// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
 var (
 	pingServiceServiceDescriptor       = v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService")
 	pingServicePingMethodDescriptor    = pingServiceServiceDescriptor.Methods().ByName("Ping")

--- a/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
@@ -37,7 +37,7 @@ import (
 // generated with a version of connect newer than the one compiled into your binary. You can fix the
 // problem by either regenerating this code with an older version of connect or updating the connect
 // version compiled into your binary.
-const _ = connect.IsAtLeastVersion1_7_0
+const _ = connect.IsAtLeastVersion1_13_0
 
 const (
 	// PingServiceName is the fully-qualified name of the PingService service.
@@ -91,28 +91,33 @@ func NewPingServiceClient(httpClient connect.HTTPClient, baseURL string, opts ..
 		ping: connect.NewClient[v1.PingRequest, v1.PingResponse](
 			httpClient,
 			baseURL+PingServicePingProcedure,
+			connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("Ping")),
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
 		fail: connect.NewClient[v1.FailRequest, v1.FailResponse](
 			httpClient,
 			baseURL+PingServiceFailProcedure,
-			opts...,
+			connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("Fail")),
+			connect.WithClientOptions(opts...),
 		),
 		sum: connect.NewClient[v1.SumRequest, v1.SumResponse](
 			httpClient,
 			baseURL+PingServiceSumProcedure,
-			opts...,
+			connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("Sum")),
+			connect.WithClientOptions(opts...),
 		),
 		countUp: connect.NewClient[v1.CountUpRequest, v1.CountUpResponse](
 			httpClient,
 			baseURL+PingServiceCountUpProcedure,
-			opts...,
+			connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("CountUp")),
+			connect.WithClientOptions(opts...),
 		),
 		cumSum: connect.NewClient[v1.CumSumRequest, v1.CumSumResponse](
 			httpClient,
 			baseURL+PingServiceCumSumProcedure,
-			opts...,
+			connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("CumSum")),
+			connect.WithClientOptions(opts...),
 		),
 	}
 }
@@ -174,28 +179,33 @@ func NewPingServiceHandler(svc PingServiceHandler, opts ...connect.HandlerOption
 	pingServicePingHandler := connect.NewUnaryHandler(
 		PingServicePingProcedure,
 		svc.Ping,
+		connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("Ping")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
 	pingServiceFailHandler := connect.NewUnaryHandler(
 		PingServiceFailProcedure,
 		svc.Fail,
-		opts...,
+		connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("Fail")),
+		connect.WithHandlerOptions(opts...),
 	)
 	pingServiceSumHandler := connect.NewClientStreamHandler(
 		PingServiceSumProcedure,
 		svc.Sum,
-		opts...,
+		connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("Sum")),
+		connect.WithHandlerOptions(opts...),
 	)
 	pingServiceCountUpHandler := connect.NewServerStreamHandler(
 		PingServiceCountUpProcedure,
 		svc.CountUp,
-		opts...,
+		connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("CountUp")),
+		connect.WithHandlerOptions(opts...),
 	)
 	pingServiceCumSumHandler := connect.NewBidiStreamHandler(
 		PingServiceCumSumProcedure,
 		svc.CumSum,
-		opts...,
+		connect.WithSchema(v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods().ByName("CumSum")),
+		connect.WithHandlerOptions(opts...),
 	)
 	return "/connect.ping.v1.PingService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/option.go
+++ b/option.go
@@ -184,6 +184,16 @@ type Option interface {
 	HandlerOption
 }
 
+// WithSchema provides a parsed representation of the schema for an RPC to a
+// client or handler. The supplied schema is exposed as [Spec.Schema]. This
+// option is typically added by generated code.
+//
+// For services using protobuf schemas, the supplied schema should be a
+// [protoreflect.MethodDescriptor].
+func WithSchema(schema any) Option {
+	return &schemaOption{Schema: schema}
+}
+
 // WithCodec registers a serialization method with a client or handler.
 // Handlers may have multiple codecs registered, and use whichever the client
 // chooses. Clients may only have a single codec.
@@ -326,6 +336,18 @@ func WithInterceptors(interceptors ...Interceptor) Option {
 // WithOptions composes multiple Options into one.
 func WithOptions(options ...Option) Option {
 	return &optionsOption{options}
+}
+
+type schemaOption struct {
+	Schema any
+}
+
+func (o *schemaOption) applyToClient(config *clientConfig) {
+	config.Schema = o.Schema
+}
+
+func (o *schemaOption) applyToHandler(config *handlerConfig) {
+	config.Schema = o.Schema
 }
 
 type clientOptionsOption struct {


### PR DESCRIPTION
New field Schema of type `any` on [`Spec`](https://github.com/connectrpc/connect-go/pull/629/files#diff-82f6a0eb10c47bc6590f594adc997b5a12de370dfd735a05c44cf8ff6fbf7a12R318). For proto based schemas the type will be of `protoreflect.MethodDescriptor`. This allows for easy introspection to interceptors.

Updated generated code to add the new `WithSchema` option to both handlers and clients. Schema is fetched from the proto file using the [`file.GoDescriptorIdent`](https://pkg.go.dev/google.golang.org/protobuf/compiler/protogen#File). To ensure generated code is matched with a library that includes the option a new version tag is added for v1.13.

### Example

For a unary request one can access the input and output descriptors by casting the interface and using protoreflect:
```go
methodDesc, ok := req.Spec().Schema.(protoreflect.MethodDescriptor)
if !ok {
	return nil, fmt.Errorf("expected protoreflect.MethodDescriptor got %T", req.Spec().Schema)
}
inputDesc := methodDesc.Input()
outputDesc := methodDesc.Output()
```

Fixes https://github.com/connectrpc/connect-go/issues/571 and https://github.com/connectrpc/connect-go/issues/600