### PR TITLE
Type URLs can have any host and even include URI scheme

### DIFF
--- a/error.go
+++ b/error.go
@@ -74,11 +74,11 @@ func (d *ErrorDetail) Type() string {
 	// than plain type names, but there aren't any descriptor registries
 	// deployed. With the current state of the `Any` code, it's not possible to
 	// build a useful type registry either. To hide this from users, we should
-	// trim the static hostname that `Any` adds to the type name.
+	// trim the URL prefix is added to the type name.
 	//
 	// If we ever want to support remote registries, we can add an explicit
 	// `TypeURL` method.
-	return strings.TrimPrefix(d.pb.GetTypeUrl(), defaultAnyResolverPrefix)
+	return typeNameFromURL(d.pb.GetTypeUrl())
 }
 
 // Bytes returns a copy of the Protobuf-serialized detail.
@@ -408,4 +408,8 @@ func asMaxBytesError(err error, tmpl string, args ...any) *Error {
 	}
 	prefix := fmt.Sprintf(tmpl, args...)
 	return errorf(CodeResourceExhausted, "%s: exceeded %d byte http.MaxBytesReader limit", prefix, maxBytesErr.Limit)
+}
+
+func typeNameFromURL(url string) string {
+	return url[strings.LastIndexByte(url, '/')+1:]
 }

--- a/error_test.go
+++ b/error_test.go
@@ -107,3 +107,45 @@ func TestErrorIs(t *testing.T) {
 	assert.False(t, errors.Is(connectErr, NewError(CodeUnavailable, err)))
 	assert.True(t, errors.Is(connectErr, connectErr))
 }
+
+func TestTypeNameFromURL(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name     string
+		url      string
+		typeName string
+	}{
+		{
+			name:     "no-prefix",
+			url:      "foo.bar.Baz",
+			typeName: "foo.bar.Baz",
+		},
+		{
+			name:     "standard-prefix",
+			url:      defaultAnyResolverPrefix + "foo.bar.Baz",
+			typeName: "foo.bar.Baz",
+		},
+		{
+			name:     "different-hostname",
+			url:      "abc.com/foo.bar.Baz",
+			typeName: "foo.bar.Baz",
+		},
+		{
+			name:     "additional-path-elements",
+			url:      defaultAnyResolverPrefix + "abc/def/foo.bar.Baz",
+			typeName: "foo.bar.Baz",
+		},
+		{
+			name:     "full-url",
+			url:      "https://abc.com/abc/def/foo.bar.Baz",
+			typeName: "foo.bar.Baz",
+		},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, typeNameFromURL(testCase.url), testCase.typeName)
+		})
+	}
+}

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -1121,7 +1121,7 @@ func (d *connectWireDetail) MarshalJSON() ([]byte, error) {
 		Value string          `json:"value"`
 		Debug json.RawMessage `json:"debug,omitempty"`
 	}{
-		Type:  strings.TrimPrefix(d.pb.GetTypeUrl(), defaultAnyResolverPrefix),
+		Type:  typeNameFromURL(d.pb.GetTypeUrl()),
 		Value: base64.RawStdEncoding.EncodeToString(d.pb.GetValue()),
 	}
 	// Try to produce debug info, but expect failure when we don't have


### PR DESCRIPTION
The previous implementation _assumed_ that the `type_url` field in an `Any` would _always_ have a `type.googleapis.com/` prefix. Though that is typical in practice, it is not actually required per the spec for that field. In fact, `protoc` allows the use of `Any` messages (inside message literals for complex option values) that contain a prefix of `type.googleprod.com/` (therefore, so does the `buf` CLI).

The way all protobuf runtimes handle `Any` is to instead look at the last path element and ignore the prefix (which is also mentioned in the spec for the `type_url` field). So this makes the code more resilient to unexpected values for type URLs. Previously, the `ErrorDetail.Type()` method would return the full URL, instead of the type name, in the event that the URL had an unexpected prefix.