### PR TITLE
Improve GET request handling: clients should not include content headers, servers should disallow a body

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -222,6 +222,23 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 		return
 	}
 
+	if request.Method == http.MethodGet {
+		// A body must not be present.
+		hasBody := request.ContentLength > 0
+		if request.ContentLength < 0 {
+			// No content-length header.
+			// Test if body is empty by trying to read a single byte.
+			var b [1]byte
+			n, _ := request.Body.Read(b[:])
+			hasBody = n > 0
+		}
+		if hasBody {
+			responseWriter.WriteHeader(http.StatusUnsupportedMediaType)
+			return
+		}
+		_ = request.Body.Close()
+	}
+
 	// Establish a stream and serve the RPC.
 	setHeaderCanonical(request.Header, headerContentType, contentType)
 	setHeaderCanonical(request.Header, headerHost, request.Host)

--- a/handler_ext_test.go
+++ b/handler_ext_test.go
@@ -80,6 +80,36 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		assert.Equal(t, resp.StatusCode, http.StatusUnsupportedMediaType)
 	})
 
+	t.Run("get_method_body_not_allowed", func(t *testing.T) {
+		t.Parallel()
+		const queryStringSuffix = `?encoding=json&message={}`
+		request, err := http.NewRequestWithContext(
+			context.Background(),
+			http.MethodGet,
+			server.URL()+pingProcedure+queryStringSuffix,
+			strings.NewReader("!"), // non-empty body
+		)
+		assert.Nil(t, err)
+		resp, err := client.Do(request)
+		assert.Nil(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, resp.StatusCode, http.StatusUnsupportedMediaType)
+
+		// Same thing, but this time w/ a content-length header
+		request, err = http.NewRequestWithContext(
+			context.Background(),
+			http.MethodGet,
+			server.URL()+pingProcedure+queryStringSuffix,
+			strings.NewReader("!"), // non-empty body
+		)
+		assert.Nil(t, err)
+		request.Header.Set("content-length", "1")
+		resp, err = client.Do(request)
+		assert.Nil(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, resp.StatusCode, http.StatusUnsupportedMediaType)
+	})
+
 	t.Run("idempotent_get_method", func(t *testing.T) {
 		t.Parallel()
 		request, err := http.NewRequestWithContext(

--- a/protocol.go
+++ b/protocol.go
@@ -35,10 +35,12 @@ const (
 )
 
 const (
-	headerContentType = "Content-Type"
-	headerHost        = "Host"
-	headerUserAgent   = "User-Agent"
-	headerTrailer     = "Trailer"
+	headerContentType     = "Content-Type"
+	headerContentEncoding = "Content-Encoding"
+	headerContentLength   = "Content-Length"
+	headerHost            = "Host"
+	headerUserAgent       = "User-Agent"
+	headerTrailer         = "Trailer"
 
 	discardLimit = 1024 * 1024 * 4 // 4MiB
 )

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -874,7 +874,7 @@ func (u *connectStreamingUnmarshaler) Unmarshal(message any) *Error {
 	for name, value := range end.Trailer {
 		canonical := http.CanonicalHeaderKey(name)
 		if name != canonical {
-			delete(end.Trailer, name)
+			delHeaderCanonical(end.Trailer, name)
 			end.Trailer[canonical] = append(end.Trailer[canonical], value...)
 		}
 	}
@@ -1045,7 +1045,10 @@ func (m *connectUnaryRequestMarshaler) buildGetURL(data []byte, compressed bool)
 }
 
 func (m *connectUnaryRequestMarshaler) writeWithGet(url *url.URL) *Error {
-	delete(m.header, connectHeaderProtocolVersion)
+	delHeaderCanonical(m.header, connectHeaderProtocolVersion)
+	delHeaderCanonical(m.header, headerContentType)
+	delHeaderCanonical(m.header, headerContentEncoding)
+	delHeaderCanonical(m.header, headerContentLength)
 	m.duplexCall.SetMethod(http.MethodGet)
 	*m.duplexCall.URL() = *url
 	return nil


### PR DESCRIPTION
More stuff that @smaye81 found when developing conformance test cases, FTW!

The client should not include content headers ("content-type", "content-encoding", "content-length") since there is no body and everything is in the query string.

And the server should explicitly disallow a request body. It accepts content headers, but they are ignored and allowed as long as there is no body content.