### PR TITLE
Refactor http calls to support message payloads

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -110,10 +110,10 @@ func (e *envelope) Seek(offset int64, whence int) (int64, error) {
 
 // Len returns the number of bytes of the unread portion of the envelope.
 func (e *envelope) Len() int {
-	if e.offset >= int64(e.Data.Len()+5) {
-		return 0
+	if length := int64(e.Data.Len()) + 5 - e.offset; length > 0 {
+		return int(length)
 	}
-	return int(int64(e.Data.Len()+5) - e.offset)
+	return 0
 }
 
 type envelopeWriter struct {
@@ -127,8 +127,8 @@ type envelopeWriter struct {
 
 func (w *envelopeWriter) Marshal(message any) *Error {
 	if message == nil {
-		// Send a zero-length message.
-		payload := bytes.NewReader(nil)
+		// Send no-op message to create the request and send headers.
+		payload := nopPayload{}
 		if _, err := w.sender.Send(payload); err != nil {
 			if connectErr, ok := asError(err); ok {
 				return connectErr

--- a/envelope.go
+++ b/envelope.go
@@ -40,16 +40,84 @@ var errSpecialEnvelope = errorf(
 // message length. gRPC and Connect interpret the bitwise flags differently, so
 // envelope leaves their interpretation up to the caller.
 type envelope struct {
-	Data  *bytes.Buffer
-	Flags uint8
+	Data   *bytes.Buffer
+	Flags  uint8
+	offset int64
 }
+
+var _ messsagePayload = (*envelope)(nil)
 
 func (e *envelope) IsSet(flag uint8) bool {
 	return e.Flags&flag == flag
 }
 
+// Read implements [io.Reader].
+func (e *envelope) Read(data []byte) (readN int, err error) {
+	if e.offset < 5 {
+		prefix := makeEnvelopePrefix(e.Flags, e.Data.Len())
+		readN = copy(data, prefix[e.offset:])
+		e.offset += int64(readN)
+		if e.offset < 5 {
+			return readN, nil
+		}
+		data = data[readN:]
+	}
+	n := copy(data, e.Data.Bytes()[e.offset-5:])
+	e.offset += int64(n)
+	readN += n
+	if readN == 0 && e.offset == int64(e.Data.Len()+5) {
+		err = io.EOF
+	}
+	return readN, err
+}
+
+// WriteTo implements [io.WriterTo].
+func (e *envelope) WriteTo(dst io.Writer) (wroteN int64, err error) {
+	if e.offset < 5 {
+		prefix := makeEnvelopePrefix(e.Flags, e.Data.Len())
+		prefixN, err := dst.Write(prefix[e.offset:])
+		e.offset += int64(prefixN)
+		wroteN += int64(prefixN)
+		if e.offset < 5 {
+			return wroteN, err
+		}
+	}
+	n, err := dst.Write(e.Data.Bytes()[e.offset-5:])
+	e.offset += int64(n)
+	wroteN += int64(n)
+	return wroteN, err
+}
+
+// Seek implements [io.Seeker]. Based on the implementation of [bytes.Reader].
+func (e *envelope) Seek(offset int64, whence int) (int64, error) {
+	var abs int64
+	switch whence {
+	case io.SeekStart:
+		abs = offset
+	case io.SeekCurrent:
+		abs = e.offset + offset
+	case io.SeekEnd:
+		abs = int64(e.Data.Len()) + offset
+	default:
+		return 0, errors.New("connect.envelope.Seek: invalid whence")
+	}
+	if abs < 0 {
+		return 0, errors.New("connect.envelope.Seek: negative position")
+	}
+	e.offset = abs
+	return abs, nil
+}
+
+// Len returns the number of bytes of the unread portion of the envelope.
+func (e *envelope) Len() int {
+	if e.offset >= int64(e.Data.Len()+5) {
+		return 0
+	}
+	return int(int64(e.Data.Len()+5) - e.offset)
+}
+
 type envelopeWriter struct {
-	writer           io.Writer
+	sender           messageSender
 	codec            Codec
 	compressMinBytes int
 	compressionPool  *compressionPool
@@ -59,7 +127,9 @@ type envelopeWriter struct {
 
 func (w *envelopeWriter) Marshal(message any) *Error {
 	if message == nil {
-		if _, err := w.writer.Write(nil); err != nil {
+		// Send a zero-length message.
+		payload := bytes.NewReader(nil)
+		if _, err := w.sender.Send(payload); err != nil {
 			if connectErr, ok := asError(err); ok {
 				return connectErr
 			}
@@ -137,17 +207,11 @@ func (w *envelopeWriter) marshal(message any) *Error {
 }
 
 func (w *envelopeWriter) write(env *envelope) *Error {
-	prefix := [5]byte{}
-	prefix[0] = env.Flags
-	binary.BigEndian.PutUint32(prefix[1:5], uint32(env.Data.Len()))
-	if _, err := w.writer.Write(prefix[:]); err != nil {
+	if _, err := w.sender.Send(env); err != nil {
 		if connectErr, ok := asError(err); ok {
 			return connectErr
 		}
 		return errorf(CodeUnknown, "write envelope: %w", err)
-	}
-	if _, err := io.Copy(w.writer, env.Data); err != nil {
-		return errorf(CodeUnknown, "write message: %w", err)
 	}
 	return nil
 }
@@ -278,4 +342,11 @@ func (r *envelopeReader) Read(env *envelope) *Error {
 	}
 	env.Flags = prefixes[0]
 	return nil
+}
+
+func makeEnvelopePrefix(flags uint8, size int) [5]byte {
+	prefix := [5]byte{}
+	prefix[0] = flags
+	binary.BigEndian.PutUint32(prefix[1:5], uint32(size))
+	return prefix
 }

--- a/envelope.go
+++ b/envelope.go
@@ -110,8 +110,8 @@ func (e *envelope) Seek(offset int64, whence int) (int64, error) {
 
 // Len returns the number of bytes of the unread portion of the envelope.
 func (e *envelope) Len() int {
-	if length := int64(e.Data.Len()) + 5 - e.offset; length > 0 {
-		return int(length)
+	if length := int(int64(e.Data.Len()) + 5 - e.offset); length > 0 {
+		return length
 	}
 	return 0
 }

--- a/error_writer.go
+++ b/error_writer.go
@@ -133,7 +133,7 @@ func (w *ErrorWriter) writeConnectStreaming(response http.ResponseWriter, err er
 	response.WriteHeader(http.StatusOK)
 	marshaler := &connectStreamingMarshaler{
 		envelopeWriter: envelopeWriter{
-			writer:     response,
+			sender:     writeSender{writer: response},
 			bufferPool: w.bufferPool,
 		},
 	}

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -254,7 +254,7 @@ func (h *connectHandler) NewConn(
 			request:        request,
 			responseWriter: responseWriter,
 			marshaler: connectUnaryMarshaler{
-				writer:           responseWriter,
+				sender:           writeSender{writer: responseWriter},
 				codec:            codec,
 				compressMinBytes: h.CompressMinBytes,
 				compressionName:  responseCompression,
@@ -280,7 +280,7 @@ func (h *connectHandler) NewConn(
 			responseWriter: responseWriter,
 			marshaler: connectStreamingMarshaler{
 				envelopeWriter: envelopeWriter{
-					writer:           responseWriter,
+					sender:           writeSender{responseWriter},
 					codec:            codec,
 					compressMinBytes: h.CompressMinBytes,
 					compressionPool:  h.CompressionPools.Get(responseCompression),
@@ -375,7 +375,7 @@ func (c *connectClient) NewConn(
 			bufferPool:       c.BufferPool,
 			marshaler: connectUnaryRequestMarshaler{
 				connectUnaryMarshaler: connectUnaryMarshaler{
-					writer:           duplexCall,
+					sender:           duplexCall,
 					codec:            c.Codec,
 					compressMinBytes: c.CompressMinBytes,
 					compressionName:  c.CompressionName,
@@ -415,7 +415,7 @@ func (c *connectClient) NewConn(
 			codec:            c.Codec,
 			marshaler: connectStreamingMarshaler{
 				envelopeWriter: envelopeWriter{
-					writer:           duplexCall,
+					sender:           duplexCall,
 					codec:            c.Codec,
 					compressMinBytes: c.CompressMinBytes,
 					compressionPool:  c.CompressionPools.Get(c.CompressionName),
@@ -892,7 +892,7 @@ func (u *connectStreamingUnmarshaler) EndStreamError() *Error {
 }
 
 type connectUnaryMarshaler struct {
-	writer           io.Writer
+	sender           messageSender
 	codec            Codec
 	compressMinBytes int
 	compressionName  string
@@ -938,7 +938,8 @@ func (m *connectUnaryMarshaler) Marshal(message any) *Error {
 }
 
 func (m *connectUnaryMarshaler) write(data []byte) *Error {
-	if _, err := m.writer.Write(data); err != nil {
+	payload := bytes.NewReader(data)
+	if _, err := m.sender.Send(payload); err != nil {
 		if connectErr, ok := asError(err); ok {
 			return connectErr
 		}

--- a/protocol_connect_test.go
+++ b/protocol_connect_test.go
@@ -72,7 +72,7 @@ func TestConnectEndOfResponseCanonicalTrailers(t *testing.T) {
 	assert.Nil(t, err)
 
 	writer := envelopeWriter{
-		writer:     &buffer,
+		sender:     writeSender{writer: &buffer},
 		bufferPool: bufferPool,
 	}
 	err = writer.Write(&envelope{

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -186,7 +186,7 @@ func (g *grpcHandler) NewConn(
 		protobuf:   g.Codecs.Protobuf(), // for errors
 		marshaler: grpcMarshaler{
 			envelopeWriter: envelopeWriter{
-				writer:           responseWriter,
+				sender:           writeSender{writer: responseWriter},
 				compressionPool:  g.CompressionPools.Get(responseCompression),
 				codec:            codec,
 				compressMinBytes: g.CompressMinBytes,
@@ -284,7 +284,7 @@ func (g *grpcClient) NewConn(
 		protobuf:         g.Protobuf,
 		marshaler: grpcMarshaler{
 			envelopeWriter: envelopeWriter{
-				writer:           duplexCall,
+				sender:           duplexCall,
 				compressionPool:  g.CompressionPools.Get(g.CompressionName),
 				codec:            g.Codec,
 				compressMinBytes: g.CompressMinBytes,

--- a/protocol_grpc_test.go
+++ b/protocol_grpc_test.go
@@ -48,7 +48,7 @@ func TestGRPCHandlerSender(t *testing.T) {
 			protobuf:   protobufCodec,
 			marshaler: grpcMarshaler{
 				envelopeWriter: envelopeWriter{
-					writer:     responseWriter,
+					sender:     writeSender{writer: responseWriter},
 					codec:      protobufCodec,
 					bufferPool: bufferPool,
 				},
@@ -181,7 +181,7 @@ func TestGRPCWebTrailerMarshalling(t *testing.T) {
 	responseWriter := httptest.NewRecorder()
 	marshaler := grpcMarshaler{
 		envelopeWriter: envelopeWriter{
-			writer:     responseWriter,
+			sender:     writeSender{writer: responseWriter},
 			bufferPool: newBufferPool(),
 		},
 	}


### PR DESCRIPTION
To enable client retries, the http calls now operates directly on message payloads instead of relying solely on `io.Writer`s. This refactor replaces write operations with send operations at message boundaries. It introduces a new interface, `messagePayload`, implemented by `*bytes.Reader`s and `*envelopes`, enabling them to adopt sender operations.

### Changes Made:
- A new interface, `messagePayload`, implemented by `*bytes.Reader` and `*envelope`, allowing for adoption of sender operations.
- A new interface, `messageSender`, implemented by `*duplexHTTPCall`, which acts on `messagePayloads` to send the message.
- An adapter `writeSender` for `http.ResponseWriter` to implement `messageSender` via converting send payloads to write operations. 
- Replaced write operations with send operations at message boundaries for handling message payloads.

### Objective:
The goal of this refactor is to facilitate client retries by directly manipulating message payloads rather than relying solely on `io.Writer`s. The `messagePayload` interface is a readable, seekable and sized payload which allows it to be replayed.

This PR is part of the fix for #609 . It implements the groundwork for the handling of message payloads.
