### PR TITLE
Implement unary HTTP calls with retry support

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -455,13 +455,18 @@ func TestServer(t *testing.T) {
 		case pingv1connect.PingServicePingProcedure,
 			pingv1connect.PingServiceFailProcedure,
 			pingv1connect.PingServiceCountUpProcedure:
+			// Unary requests set Content-Length to the length of the request body.
 			if request.ContentLength < 0 {
 				t.Errorf("%s: expected Content-Length >= 0, got %d", request.URL.Path, request.ContentLength)
 			}
-		default:
+		case pingv1connect.PingServiceSumProcedure,
+			pingv1connect.PingServiceCumSumProcedure:
+			// Streaming requests set Content-Length to -1 or 0 on empty requests.
 			if request.ContentLength > 0 {
 				t.Errorf("%s: expected Content-Length -1 or 0, got %d", request.URL.Path, request.ContentLength)
 			}
+		default:
+			t.Errorf("unexpected path %q", request.URL.Path)
 		}
 		pingHandler.ServeHTTP(response, request)
 	}))

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -434,8 +434,9 @@ func TestServer(t *testing.T) {
 		pingServer{checkMetadata: true},
 	)
 	errorWriter := connect.NewErrorWriter()
-	// Add some net/http middleware to the ping service so we can also exercise ErrorWriter.
+	// Add net/http middleware to the ping service to evaluate HTTP state.
 	mux.Handle(pingRoute, http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		// Exercise ErrorWriter for HTTP middleware errors.
 		if request.Header.Get(clientMiddlewareErrorHeader) != "" {
 			defer request.Body.Close()
 			if _, err := io.Copy(io.Discard, request.Body); err != nil {
@@ -448,6 +449,19 @@ func TestServer(t *testing.T) {
 				t.Errorf("send RPC error from HTTP middleware: %v", err)
 			}
 			return
+		}
+		// Check Content-Length is set correctly.
+		switch request.URL.Path {
+		case pingv1connect.PingServicePingProcedure,
+			pingv1connect.PingServiceFailProcedure,
+			pingv1connect.PingServiceCountUpProcedure:
+			if request.ContentLength < 0 {
+				t.Errorf("%s: expected Content-Length >= 0, got %d", request.URL.Path, request.ContentLength)
+			}
+		default:
+			if request.ContentLength > 0 {
+				t.Errorf("%s: expected Content-Length -1 or 0, got %d", request.URL.Path, request.ContentLength)
+			}
 		}
 		pingHandler.ServeHTTP(response, request)
 	}))

--- a/duplex_http_call_test.go
+++ b/duplex_http_call_test.go
@@ -1,0 +1,122 @@
+// Copyright 2021-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connect
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"connectrpc.com/connect/internal/assert"
+)
+
+// TestHTTPCallGetBody tests that the client is able to retry requests on
+// connection close errors. It will initialize a closing handler and ensure
+// http.Request.GetBody is successfully called to replay the request.
+func TestHTTPCallGetBody(t *testing.T) {
+	t.Parallel()
+	handler := http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		// The "Connection: close" header is turned into a GOAWAY frame by the http2 server.
+		responseWriter.Header().Add("Connection", "close")
+		_, _ = io.Copy(responseWriter, request.Body)
+		_ = request.Body.Close()
+	})
+	// Must use httptest for this test.
+	server := httptest.NewUnstartedServer(handler)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	bufferPool := newBufferPool()
+	serverURL, _ := url.Parse(server.URL)
+	errGetBodyCalled := errors.New("getBodyCalled") // sentinel error
+	caller := func(size int) error {
+		call := newDuplexHTTPCall(
+			context.Background(),
+			server.Client(),
+			serverURL,
+			Spec{StreamType: StreamTypeUnary},
+			http.Header{},
+		)
+		getBodyCalled := false
+		call.onRequestSend = func(*http.Request) {
+			getBody := call.request.GetBody
+			call.request.GetBody = func() (io.ReadCloser, error) {
+				getBodyCalled = true
+				rdcloser, err := getBody()
+				assert.Nil(t, err)
+				return rdcloser, err
+			}
+		}
+		// SetValidateResponse must be set.
+		call.SetValidateResponse(func(*http.Response) *Error {
+			return nil
+		})
+		buf := bufferPool.Get()
+		defer bufferPool.Put(buf)
+		buf.Write(make([]byte, size))
+		_, err := call.Send(bytes.NewReader(buf.Bytes()))
+		assert.Nil(t, err)
+		assert.Nil(t, call.CloseWrite())
+		buf.Reset()
+		_, err = io.Copy(buf, call)
+		assert.Nil(t, err)
+		assert.Equal(t, buf.Len(), size)
+		if getBodyCalled {
+			return errGetBodyCalled
+		}
+		return nil
+	}
+	type work struct {
+		size int
+		errs chan error
+	}
+	numWorkers := 2
+	workChan := make(chan work)
+	wg := sync.WaitGroup{}
+	wg.Add(numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		go func() {
+			for work := range workChan {
+				work.errs <- caller(work.size)
+			}
+			wg.Done()
+		}()
+	}
+	for i, gotGetBody := 0, false; !gotGetBody; i++ {
+		errs := make([]chan error, numWorkers)
+		for i := 0; i < numWorkers; i++ {
+			errs[i] = make(chan error, 1)
+			workChan <- work{size: 512, errs: errs[i]}
+		}
+		t.Log("waiting", i)
+		for _, errChan := range errs {
+			if err := <-errChan; err != nil {
+				if errors.Is(err, errGetBodyCalled) {
+					gotGetBody = true
+				} else {
+					t.Fatal(err)
+				}
+			}
+		}
+	}
+	close(workChan)
+	wg.Wait()
+}

--- a/envelope.go
+++ b/envelope.go
@@ -45,7 +45,7 @@ type envelope struct {
 	offset int64
 }
 
-var _ messsagePayload = (*envelope)(nil)
+var _ messagePayload = (*envelope)(nil)
 
 func (e *envelope) IsSet(flag uint8) bool {
 	return e.Flags&flag == flag

--- a/internal/memhttp/memhttptest/http.go
+++ b/internal/memhttp/memhttptest/http.go
@@ -37,7 +37,7 @@ func NewServer(tb testing.TB, handler http.Handler, opts ...memhttp.Option) *mem
 	server := memhttp.NewServer(handler, opts...)
 	tb.Cleanup(func() {
 		if err := server.Cleanup(); err != nil {
-			tb.Error(err)
+			tb.Errorf("shutdown failed: %v", err)
 		}
 	})
 	return server


### PR DESCRIPTION
Internal changes to the HTTP client to remove some of the overhead required for streaming calls but unnecessary for non-streaming client requests. This PR changes both of the non-streaming client request types: unary and server streams. These types will now create the client request with the message payload upfront before calling `client.Do`. This removes the overhead of the `io.Pipe` to convert the body from a reader to a writer and the extra goroutine required to write to the pipe asynchronously. From this we get improved functionality for non-streaming requests by setting the `Content-Length` header and implementing `GetBody` function to enable retries.

### Implementation details

The buffer reuse semantics are kept the same for both unary and stream requests. This allows for simple error handling with a `w.bufferPool.Get()` matched to a `defer w.bufferPool.Put()`. To enforce this behaviour for the new unary calls we must wait for transport to be done with the request body ensuring no reads occur after a return from `Send`. Under testing a `client.Do` will almost always drain the body before returning the response. However, we need to enforce this behaviour.

To safely reuse the payload buffer a new type `payloadCloser` is added to implement the required HTTP body semantics. On receiving a response the request may still be read up and until the response body is closed. See the documentation on [`RoundTripper`](https://pkg.go.dev/net/http#RoundTripper) for details. To ensure the request body is safe to release we need to wait for a `Close` on the body. We can eagerly move this check forward by instead waiting for a complete read and then returning `io.EOF` on subsequent reads. Retries may read, close or rewind the body multiple times before a response is returned and this behaviour is supported. On detecting the payload has been drained or closed the `payloadCloser` releases the reference to the `messagePayload` ensuring it's safe to be reused.

### Changes
- Unary and ServerStreams client requests create the request with the body built from the message payload.
- `Content-Length` header set for single messages client requests.
- Implemented [`GetBody`](https://pkg.go.dev/net/http#Request) function for retries of single message client requests.messages.

### Impact
Benchmarking with `-bench=BenchmarkConnect//unary` shows a small improvement in throughput and memory use for unary calls (~ `-5% sec/op`, `-5% B/op`, `-3% allocs/op`).

Fix for #541 and #609.
