### PR TITLE
Silence TestClientDeadlineHandling server logs

### DIFF
--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -448,6 +449,7 @@ func TestClientDeadlineHandling(t *testing.T) {
 		}
 		handler.ServeHTTP(respWriter, req)
 	}))
+	svr.Config.ErrorLog = log.New(io.Discard, "", 0) //nolint:forbidigo
 	svr.EnableHTTP2 = true
 	svr.StartTLS()
 	t.Cleanup(svr.Close)


### PR DESCRIPTION
Test case emits extremely noisy logs from TLS handshake errors due to closing many connection. Avoid logging server logs for this test case as they impact readability of others.

```
2023/12/11 15:57:19 http: TLS handshake error from 127.0.0.1:61647: read tcp 127.0.0.1:60080->127.0.0.1:61647: read: connection reset by peer
2023/12/11 15:57:19 http: TLS handshake error from 127.0.0.1:61683: EOF
...
```
