### PR TITLE
Prefer an implicit codec when using the gRPC default

### DIFF
--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -847,7 +847,10 @@ func grpcContentTypeFromCodecName(web bool, name string) string {
 		return grpcWebContentTypePrefix + name
 	}
 	if name == codecNameProto {
-		// for compatibility with some servers prefer an implicit default codec
+		// For compatibility with Google Cloud Platform's frontends, prefer an
+		// implicit default codec. See
+		// https://github.com/connectrpc/connect-go/pull/655#issuecomment-1915754523
+		// for details.
 		return grpcContentTypeDefault
 	}
 	return grpcContentTypePrefix + name

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -846,6 +846,10 @@ func grpcContentTypeFromCodecName(web bool, name string) string {
 	if web {
 		return grpcWebContentTypePrefix + name
 	}
+	if name == codecNameProto {
+		// for compatibility with some servers prefer an implicit default codec
+		return grpcContentTypeDefault
+	}
 	return grpcContentTypePrefix + name
 }
 


### PR DESCRIPTION
Some gRPC servers in the wild appear to only accept requests when the Content-Type subtype codec name is empty, implying the default of "proto". For example Google Cloud API endpoints appear to require Content-Type to be exactly `application/grpc` and disallow the equivalent explicit form `application/grpc+proto`, rejecting requests using the latter form by responding with a 404 and `Content-Type: text/html`.

It's unclear if this is a load balancer (mis)configuration issue, or a lack of support for specifying a codec in the server implementation, but the end result is the same.

Seeing as the subtype qualifier is optional for gRPC, let's try to prefer the implicit form when it is equivalent to the selected codec.

Note that this change only impacts gRPC. Elsewhere we continue to prefer being explicit. This change should not impact servers.
