### PR TITLE
Fix LICENSE header

### DIFF
--- a/duplex_http_call_test.go
+++ b/duplex_http_call_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 The Connect Authors
+// Copyright 2021-2024 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes the LICENSE header for new test file introduced in https://github.com/connectrpc/connect-go/pull/649 . Causing CI failure on main: https://github.com/connectrpc/connect-go/actions/runs/7616456681/job/20743252336
