### PR TITLE
Fix HTTP Status to Code mapping

### DIFF
--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -1266,10 +1266,14 @@ func connectHTTPToCode(httpCode int) Code {
 		return CodeUnimplemented
 	case 408:
 		return CodeDeadlineExceeded
+	case 409:
+		return CodeAborted
 	case 412:
 		return CodeFailedPrecondition
 	case 413:
 		return CodeResourceExhausted
+	case 415:
+		return CodeInternal
 	case 429:
 		return CodeUnavailable
 	case 431:


### PR DESCRIPTION
Adds two missing conversions 409 and 415 from the spec: https://connectrpc.com/docs/protocol#http-to-error-code

