### PR TITLE
Custom marshal options for protojson (e.g. emitting zero-value fields in JSON)

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -158,7 +158,10 @@ func (c *protoJSONCodec) Marshal(message any) ([]byte, error) {
 	if !ok {
 		return nil, errNotProto(message)
 	}
-	return protojson.MarshalOptions{EmitUnpopulated: true, EmitDefaultValues: true}.Marshal(protoMessage)
+	return protojson.MarshalOptions{
+		EmitDefaultValues: c.emitDefaultValues,
+		EmitUnpopulated:   c.emitUnpopulatedValues,
+	}.Marshal(protoMessage)
 }
 
 func (c *protoJSONCodec) MarshalAppend(dst []byte, message any) ([]byte, error) {

--- a/codec.go
+++ b/codec.go
@@ -144,7 +144,9 @@ func (c *protoBinaryCodec) IsBinary() bool {
 }
 
 type protoJSONCodec struct {
-	name string
+	name                  string
+	emitDefaultValues     bool
+	emitUnpopulatedValues bool
 }
 
 var _ Codec = (*protoJSONCodec)(nil)
@@ -156,7 +158,7 @@ func (c *protoJSONCodec) Marshal(message any) ([]byte, error) {
 	if !ok {
 		return nil, errNotProto(message)
 	}
-	return protojson.MarshalOptions{}.Marshal(protoMessage)
+	return protojson.MarshalOptions{EmitUnpopulated: true, EmitDefaultValues: true}.Marshal(protoMessage)
 }
 
 func (c *protoJSONCodec) MarshalAppend(dst []byte, message any) ([]byte, error) {
@@ -164,7 +166,10 @@ func (c *protoJSONCodec) MarshalAppend(dst []byte, message any) ([]byte, error) 
 	if !ok {
 		return nil, errNotProto(message)
 	}
-	return protojson.MarshalOptions{}.MarshalAppend(dst, protoMessage)
+	return protojson.MarshalOptions{
+		EmitDefaultValues: c.emitDefaultValues,
+		EmitUnpopulated:   c.emitUnpopulatedValues,
+	}.MarshalAppend(dst, protoMessage)
 }
 
 func (c *protoJSONCodec) Unmarshal(binary []byte, message any) error {

--- a/option.go
+++ b/option.go
@@ -77,7 +77,20 @@ func WithGRPCWeb() ClientOption {
 // lowerCamelCase, zero values are omitted, missing required fields are errors,
 // enums are emitted as strings, etc.
 func WithProtoJSON() ClientOption {
-	return WithCodec(&protoJSONCodec{codecNameJSON})
+	return WithCodec(&protoJSONCodec{name: codecNameJSON})
+}
+
+type ProtoJsonOptions struct {
+	EmitDefaultValues     bool
+	EmitUnpopulatedValues bool
+}
+
+func WithCustomProtoJSON(options ProtoJsonOptions) ClientOption {
+	return WithCodec(&protoJSONCodec{
+		name:                  codecNameJSON,
+		emitDefaultValues:     options.EmitDefaultValues,
+		emitUnpopulatedValues: options.EmitUnpopulatedValues,
+	})
 }
 
 // WithSendCompression configures the client to use the specified algorithm to
@@ -627,8 +640,8 @@ func withProtoBinaryCodec() Option {
 
 func withProtoJSONCodecs() HandlerOption {
 	return WithHandlerOptions(
-		WithCodec(&protoJSONCodec{codecNameJSON}),
-		WithCodec(&protoJSONCodec{codecNameJSONCharsetUTF8}),
+		WithCodec(&protoJSONCodec{name: codecNameJSON}),
+		WithCodec(&protoJSONCodec{name: codecNameJSONCharsetUTF8}),
 	)
 }
 

--- a/option.go
+++ b/option.go
@@ -80,12 +80,12 @@ func WithProtoJSON() ClientOption {
 	return WithCodec(&protoJSONCodec{name: codecNameJSON})
 }
 
-type ProtoJsonOptions struct {
+type ProtoJSONOptions struct {
 	EmitDefaultValues     bool
 	EmitUnpopulatedValues bool
 }
 
-func WithCustomProtoJSON(options ProtoJsonOptions) ClientOption {
+func WithCustomProtoJSON(options ProtoJSONOptions) ClientOption {
 	return WithCodec(&protoJSONCodec{
 		name:                  codecNameJSON,
 		emitDefaultValues:     options.EmitDefaultValues,

--- a/option_test.go
+++ b/option_test.go
@@ -1,0 +1,21 @@
+package connect
+
+import (
+	"testing"
+)
+
+func TestWithCustomProtoJSONWhenEmitDefaultValuesSetsConfig(t *testing.T) {
+	config := clientConfig{}
+	option := WithCustomProtoJSON(ProtoJsonOptions{EmitDefaultValues: true, EmitUnpopulatedValues: true})
+	option.applyToClient(&config)
+	codec, ok := config.Codec.(*protoJSONCodec)
+	if !ok {
+		t.Errorf("casting to protoJSONCodec failed, want protoJSONCodec, got: %T", config.Codec)
+	}
+	if codec.emitDefaultValues != true {
+		t.Errorf("emitDefaultValues = %v, want %v", codec.emitDefaultValues, true)
+	}
+	if codec.emitUnpopulatedValues != true {
+		t.Errorf("emitUnpopulatedValues = %v, want %v", codec.emitUnpopulatedValues, true)
+	}
+}

--- a/option_test.go
+++ b/option_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021-2024 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package connect
 
 import (
@@ -5,8 +19,10 @@ import (
 )
 
 func TestWithCustomProtoJSONWhenEmitDefaultValuesSetsConfig(t *testing.T) {
+	t.Parallel()
+
 	config := clientConfig{}
-	option := WithCustomProtoJSON(ProtoJsonOptions{EmitDefaultValues: true, EmitUnpopulatedValues: true})
+	option := WithCustomProtoJSON(ProtoJSONOptions{EmitDefaultValues: true, EmitUnpopulatedValues: true})
 	option.applyToClient(&config)
 	codec, ok := config.Codec.(*protoJSONCodec)
 	if !ok {


### PR DESCRIPTION
This PR adds a new handler option option to customize the Marshaling behavior.

### Motivation
Right now, there is no way to customize the JSON output generated by json handlers. This leads to zero values being always omitted. For some, this behavior is undesirable. 
protobuf users usually tweak `protojson` output by disabling omitting of zero-value fields via EmitDefaults from https://pkg.go.dev/google.golang.org/protobuf/encoding/protojson#MarshalOptions. With this flag enabled, zero-value fields are properly outputted to the resulting json. I'd be good to bring this functionality to `connect` as well

### Usage
`connect-go` users may now use it like this:
```go
path, handler := usersv1connect.NewUsersServiceHandler(
    users,
    connect.WithCustomProtoJSON(connect.ProtoJSONOptions{EmitDefaultValues: true}),
)
```

### Notes on the implementation
I've decided to add a new option instead of adding a new parameter to `connect.WithProtoJSON` to not break any clients.

What do you guys think?