### PR TITLE
Client should verify response content-type

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -810,6 +810,7 @@ func TestUnavailableIfHostInvalid(t *testing.T) {
 func TestBidiRequiresHTTP2(t *testing.T) {
 	t.Parallel()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/connect+proto")
 		_, err := io.WriteString(w, "hello world")
 		assert.Nil(t, err)
 	})
@@ -841,6 +842,7 @@ func TestCompressMinBytesClient(t *testing.T) {
 		tb.Helper()
 		mux := http.NewServeMux()
 		mux.Handle("/", http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			writer.Header().Set("Content-Type", "application/proto")
 			assert.Equal(tb, request.Header.Get("Content-Encoding"), expect)
 		}))
 		server := memhttptest.NewServer(t, mux)
@@ -2231,6 +2233,7 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 		name:    "connect_excess_eof",
 		options: []connect.ClientOption{connect.WithProtoJSON()},
 		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
+			responseWriter.Header().Set("Content-Type", "application/connect+json")
 			_, err := responseWriter.Write(head[:])
 			assert.Nil(t, err)
 			_, err = responseWriter.Write(payload)
@@ -2252,6 +2255,7 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 		name:    "grpc-web_excess_eof",
 		options: []connect.ClientOption{connect.WithProtoJSON(), connect.WithGRPCWeb()},
 		handler: func(responseWriter http.ResponseWriter, _ *http.Request) {
+			responseWriter.Header().Set("Content-Type", "application/grpc-web+json")
 			_, err := responseWriter.Write(head[:])
 			assert.Nil(t, err)
 			_, err = responseWriter.Write(payload)

--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -203,6 +203,11 @@ func (d *duplexHTTPCall) URL() *url.URL {
 	return d.request.URL
 }
 
+// Method returns the HTTP method for the request (GET or POST).
+func (d *duplexHTTPCall) Method() string {
+	return d.request.Method
+}
+
 // SetMethod changes the method of the request before it is sent.
 func (d *duplexHTTPCall) SetMethod(method string) {
 	d.request.Method = method

--- a/error.go
+++ b/error.go
@@ -133,7 +133,7 @@ func NewError(c Code, underlying error) *Error {
 // This is useful for clients trying to propagate partial failures from
 // streaming RPCs. Often, these RPCs include error information in their
 // response messages (for example, [gRPC server reflection] and
-// OpenTelemtetry's [OTLP]). Clients propagating these errors up the stack
+// OpenTelemetry's [OTLP]). Clients propagating these errors up the stack
 // should use NewWireError to clarify that the error code, message, and details
 // (if any) were explicitly sent by the server rather than inferred from a
 // lower-level networking error or timeout.

--- a/protocol_connect_test.go
+++ b/protocol_connect_test.go
@@ -239,11 +239,12 @@ func TestConnectValidateUnaryResponseContentType(t *testing.T) {
 				assert.Nil(t, err)
 			} else if assert.NotNil(t, err) {
 				assert.Equal(t, CodeOf(err), testCase.expectCode)
-				if testCase.expectNotModified {
+				switch {
+				case testCase.expectNotModified:
 					assert.ErrorIs(t, err, errNotModified)
-				} else if testCase.expectBadContentType {
+				case testCase.expectBadContentType:
 					assert.True(t, strings.Contains(err.Message(), fmt.Sprintf("invalid content-type: %q; expecting", testCase.responseContentType)))
-				} else {
+				default:
 					assert.Equal(t, err.Message(), http.StatusText(testCase.statusCode))
 				}
 			}

--- a/protocol_grpc_test.go
+++ b/protocol_grpc_test.go
@@ -16,6 +16,7 @@ package connect
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -228,5 +229,127 @@ func BenchmarkGRPCTimeoutEncoding(b *testing.B) {
 		if got != want {
 			b.Fatalf("grpcEncodeTimeout(%q) = %s, want %s", input, got, want)
 		}
+	}
+}
+
+func TestGRPCValidateResponseContentType(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		web                 bool
+		codecName           string
+		responseContentType string
+		expectErr           bool
+	}{
+		// Allowed content-types
+		{
+			codecName:           codecNameProto,
+			responseContentType: "application/grpc",
+		},
+		{
+			codecName:           codecNameProto,
+			responseContentType: "application/grpc+proto",
+		},
+		{
+			codecName:           codecNameJSON,
+			responseContentType: "application/grpc+json",
+		},
+		{
+			codecName:           codecNameProto,
+			web:                 true,
+			responseContentType: "application/grpc-web",
+		},
+		{
+			codecName:           codecNameProto,
+			web:                 true,
+			responseContentType: "application/grpc-web+proto",
+		},
+		{
+			codecName:           codecNameJSON,
+			web:                 true,
+			responseContentType: "application/grpc-web+json",
+		},
+		// Disallowed content-types
+		{
+			codecName:           codecNameProto,
+			responseContentType: "application/proto",
+			expectErr:           true,
+		},
+		{
+			codecName:           codecNameProto,
+			responseContentType: "application/grpc-web",
+			expectErr:           true,
+		},
+		{
+			codecName:           codecNameProto,
+			responseContentType: "application/grpc-web+proto",
+			expectErr:           true,
+		},
+		{
+			codecName:           codecNameJSON,
+			responseContentType: "application/json",
+			expectErr:           true,
+		},
+		{
+			codecName:           codecNameJSON,
+			responseContentType: "application/grpc-web+json",
+			expectErr:           true,
+		},
+		{
+			codecName:           codecNameProto,
+			web:                 true,
+			responseContentType: "application/proto",
+			expectErr:           true,
+		},
+		{
+			codecName:           codecNameProto,
+			web:                 true,
+			responseContentType: "application/grpc",
+			expectErr:           true,
+		},
+		{
+			codecName:           codecNameProto,
+			web:                 true,
+			responseContentType: "application/grpc+proto",
+			expectErr:           true,
+		},
+		{
+			codecName:           codecNameJSON,
+			web:                 true,
+			responseContentType: "application/json",
+			expectErr:           true,
+		},
+		{
+			codecName:           codecNameJSON,
+			web:                 true,
+			responseContentType: "application/grpc+json",
+			expectErr:           true,
+		},
+		{
+			codecName:           codecNameProto,
+			responseContentType: "some/garbage",
+			expectErr:           true,
+		},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		protocol := ProtocolGRPC
+		if testCase.web {
+			protocol = ProtocolGRPCWeb
+		}
+		testCaseName := fmt.Sprintf("%s_%s->%s", protocol, testCase.codecName, testCase.responseContentType)
+		t.Run(testCaseName, func(t *testing.T) {
+			t.Parallel()
+			err := grpcValidateResponseContentType(
+				testCase.web,
+				testCase.codecName,
+				testCase.responseContentType,
+			)
+			if !testCase.expectErr {
+				assert.Nil(t, err)
+			} else if assert.NotNil(t, err) {
+				assert.Equal(t, CodeOf(err), CodeInternal)
+				assert.True(t, strings.Contains(err.Message(), fmt.Sprintf("invalid content-type: %q; expecting", testCase.responseContentType)))
+			}
+		})
 	}
 }


### PR DESCRIPTION
@smaye81 found some more bugs with new conformance test cases.

The client is not verifying that the response has the correct content-type. So this change adds that verification.

Some tests, that had simple handlers that weren't setting a valid content-type, had to be updated. Sorry for the large diff stats, but it's not as bad as it looks. This PR adds three new table-driven tests that account for 75% of the lines of code.