### PR TITLE
Add Ed McFarlane as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,6 +6,7 @@ Maintainers
 * [Akshay Shah](https://github.com/akshayjshah), [Buf](https://buf.build)
 * [Josh Humphries](https://github.com/jhump), [Buf](https://buf.build)
 * [Matt Robenolt](https://github.com/mattrobenolt), [PlanetScale](https://planetscale.com)
+* [Edward McFarlane](https://github.com/emcfarlane), [Buf](https://buf.build)
 
 ## Former
 * [Alex McKinney](https://github.com/amckinney)


### PR DESCRIPTION
This proposes adding @emcfarlane (from Buf) to the list of maintainers. Per [Connect's governance policy](https://connectrpc.com/docs/governance/project-governance), this also makes Ed one of the handful of maintainers with a vote on Connect RFCs.

Ed has done the lion's share of recent maintenance and improvements in [this codebase](https://github.com/connectrpc/connect-go/pulls?q=is%3Apr+is%3Aclosed+author%3Aemcfarlane) (as well as in [otelconnect](https://github.com/connectrpc/otelconnect-go/pulls?q=is%3Apr+is%3Aclosed+author%3Aemcfarlane)), and he is already a maintainer in several related packages ([authn](https://github.com/connectrpc/authn-go/blob/main/MAINTAINERS.md), [cors](https://github.com/connectrpc/cors-go/blob/main/MAINTAINERS.md), and [vanguard](https://github.com/connectrpc/vanguard-go/blob/main/MAINTAINERS.md)).  He is an expert in all three of the protocols (as well as in RPC<-> REST transcoding), has made numerous high-quality contributions to the code, and is already a valuable resource for answering questions in Slack and in GitHub issues.

I am in support of this. @akshayjshah, @bufdev, @mattrobenolt, what do you think?