### PR TITLE
Reduce scope of `err` var in response content-type checks

### DIFF
--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -511,14 +511,13 @@ func (cc *connectUnaryClientConn) validateResponse(response *http.Response) *Err
 		}
 		cc.responseTrailer[strings.TrimPrefix(k, connectUnaryTrailerPrefix)] = v
 	}
-	err := connectValidateUnaryResponseContentType(
+	if err := connectValidateUnaryResponseContentType(
 		cc.marshaler.codec.Name(),
 		cc.duplexCall.Method(),
 		response.StatusCode,
 		response.Status,
 		getHeaderCanonical(response.Header, headerContentType),
-	)
-	if err != nil {
+	); err != nil {
 		if IsNotModifiedError(err) {
 			// Allow access to response headers for this kind of error.
 			// RFC 9110 doesn't allow trailers on 304s, so we only need to include headers.
@@ -653,12 +652,11 @@ func (cc *connectStreamingClientConn) validateResponse(response *http.Response) 
 	if response.StatusCode != http.StatusOK {
 		return errorf(connectHTTPToCode(response.StatusCode), "HTTP status %v", response.Status)
 	}
-	err := connectValidateStreamResponseContentType(
+	if err := connectValidateStreamResponseContentType(
 		cc.codec.Name(),
 		cc.spec.StreamType,
 		getHeaderCanonical(response.Header, headerContentType),
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
 	compression := getHeaderCanonical(response.Header, connectStreamingHeaderCompression)

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -653,7 +653,11 @@ func grpcValidateResponse(
 	if response.StatusCode != http.StatusOK {
 		return errorf(grpcHTTPToCode(response.StatusCode), "HTTP status %v", response.Status)
 	}
-	if err := grpcValidateResponseContentType(web, codecName, getHeaderCanonical(response.Header, headerContentType)); err != nil {
+	if err := grpcValidateResponseContentType(
+		web,
+		codecName,
+		getHeaderCanonical(response.Header, headerContentType),
+	); err != nil {
 		return err
 	}
 	if compression := getHeaderCanonical(response.Header, grpcHeaderCompression); compression != "" &&


### PR DESCRIPTION
This also formats the grpc version of the check so it is consistent with the other two.

Addresses comment in prior PR: https://github.com/connectrpc/connect-go/pull/679#discussion_r1483403176