### PR TITLE
Replace a Header.Get call with getHeaderCanonical

### DIFF
--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -290,7 +290,7 @@ func (d *duplexHTTPCall) makeRequest() {
 	defer close(d.responseReady)
 
 	// Promote the header Host to the request object.
-	if host := d.request.Header.Get(headerHost); len(host) > 0 {
+	if host := getHeaderCanonical(d.request.Header, headerHost); len(host) > 0 {
 		d.request.Host = host
 	}
 	if d.onRequestSend != nil {


### PR DESCRIPTION
This is the only one I see left, and this is one is in the hot path for every request.