### PR TITLE
Remove redundant work when validating unary Connect response

### DIFF
--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -509,7 +509,7 @@ func (cc *connectUnaryClientConn) validateResponse(response *http.Response) *Err
 			cc.responseHeader[k] = v
 			continue
 		}
-		cc.responseTrailer[strings.TrimPrefix(k, connectUnaryTrailerPrefix)] = v
+		cc.responseTrailer[k[len(connectUnaryTrailerPrefix):]] = v
 	}
 	if err := connectValidateUnaryResponseContentType(
 		cc.marshaler.codec.Name(),


### PR DESCRIPTION
We can swap TrimPrefix for just a string slice here since we're already guarding behind HasPrefix. TrimPrefix internally runs HasPrefix again, so we can just skip the redundant work.
