### PR TITLE
Reconcile trailers-only and misc error behavior with grpc-go

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -222,7 +222,7 @@ func (w *envelopeWriter) write(env *envelope) *Error {
 type envelopeReader struct {
 	ctx             context.Context //nolint:containedctx
 	reader          io.Reader
-	bytesRead       int64
+	bytesRead       int64  // detect trailers-only gRPC responses
 	codec           Codec
 	last            envelope
 	compressionPool *compressionPool

--- a/envelope.go
+++ b/envelope.go
@@ -222,7 +222,7 @@ func (w *envelopeWriter) write(env *envelope) *Error {
 type envelopeReader struct {
 	ctx             context.Context //nolint:containedctx
 	reader          io.Reader
-	bytesRead       int64  // detect trailers-only gRPC responses
+	bytesRead       int64 // detect trailers-only gRPC responses
 	codec           Codec
 	last            envelope
 	compressionPool *compressionPool

--- a/header.go
+++ b/header.go
@@ -46,8 +46,14 @@ func DecodeBinaryHeader(data string) ([]byte, error) {
 }
 
 func mergeHeaders(into, from http.Header) {
-	for k, vals := range from {
-		into[k] = append(into[k], vals...)
+	for key, vals := range from {
+		if len(vals) == 0 {
+			// For response trailers, net/http will pre-populate entries
+			// with nil values based on the "Trailer" header. But if there
+			// are no actual values for those keys, we skip them.
+			continue
+		}
+		into[key] = append(into[key], vals...)
 	}
 }
 

--- a/header_test.go
+++ b/header_test.go
@@ -52,7 +52,6 @@ func TestHeaderMerge(t *testing.T) {
 	expect := http.Header{
 		"Foo": []string{"one", "two"},
 		"Bar": []string{"one"},
-		"Baz": nil,
 	}
 	assert.Equal(t, header, expect)
 }

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -1386,6 +1386,15 @@ func connectValidateUnaryResponseContentType(
 		)
 	}
 	// Normal responses must have valid content-type that indicates same codec as the request.
+	if !strings.HasPrefix(responseContentType, connectUnaryContentTypePrefix) {
+		// Doesn't even look like a Connect response? Use code "unknown".
+		return errorf(
+			CodeUnknown,
+			"invalid content-type: %q; expecting %q",
+			responseContentType,
+			connectUnaryContentTypePrefix+requestCodecName,
+		)
+	}
 	responseCodecName := connectCodecFromContentType(
 		StreamTypeUnary,
 		responseContentType,
@@ -1410,6 +1419,15 @@ func connectValidateUnaryResponseContentType(
 
 func connectValidateStreamResponseContentType(requestCodecName string, streamType StreamType, responseContentType string) *Error {
 	// Responses must have valid content-type that indicates same codec as the request.
+	if !strings.HasPrefix(responseContentType, connectStreamingContentTypePrefix) {
+		// Doesn't even look like a Connect response? Use code "unknown".
+		return errorf(
+			CodeUnknown,
+			"invalid content-type: %q; expecting %q",
+			responseContentType,
+			connectUnaryContentTypePrefix+requestCodecName,
+		)
+	}
 	responseCodecName := connectCodecFromContentType(
 		streamType,
 		responseContentType,

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -724,7 +724,7 @@ func grpcHTTPToCode(httpCode int) Code {
 // use a different codec. Consequently, this function needs a Protobuf codec to
 // unmarshal error information in the headers.
 //
-// A non-nil error is only returned when a grpc-status key IS present, but it
+// A nil error is only returned when a grpc-status key IS present, but it
 // indicates a code of zero (no error). If no grpc-status key is present, this
 // returns a non-nil *Error that wraps errTrailersWithoutGRPCStatus.
 func grpcErrorFromTrailer(protobuf Codec, trailer http.Header) *Error {


### PR DESCRIPTION
This largely undoes a recent change to do more validation of trailers-only responses (#685), which disallows a body or trailers in what appeared to be a trailers-only response. In that change, a trailers-only response was identified by the presence of a "grpc-status" key in the headers.

In this PR, a trailers-only response is instead defined by the lack of body and trailers (not the presence of a "grpc-status" header). This PR also tweaks some other error scenarios:

* If trailers (or an end-stream message) is completely missing from a response, it's considered an `internal` error. But if trailers are present, but the "grpc-status" key is missing, it's considered an issue determining the status, which is an `unknown` error.
* Similarly, if a response content-type doesn't appear to be the right protocol (like it may have come from a non-RPC server), the error code is now `unknown`. But if it looks like the right protocol but uses the wrong sub-format/codec, it's an `internal` error.
   * Note that in grpc-go, this behavior is also seen in the client, but this PR doesn't attempt to address that in the connect-go client. Instead, that change can be made when #689 is addressed.

This PR also now makes connect-go more strict about the "compressed" flag in a streaming protocol when there was no compression algorithm negotiated. Previously, this library was lenient and did not consider it an error if the message in question was empty (zero bytes). But to correctly adhere to gRPC semantics, it MUST report this case as an `internal `error (see bullet 6 in the [test cases section of the gRPC compression docs](https://github.com/grpc/grpc/blob/master/doc/compression.md#test-cases)).
