### PR TITLE
Upgrade to go1.22 and min version go1.20

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # when editing this list, also update steps and jobs below
-        go-version: [1.19.x, 1.20.x, 1.21.x]
+        go-version: [1.20.x, 1.21.x, 1.22.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -33,14 +33,13 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.21.x'
+        if: matrix.go-version == '1.22.x'
         run: make checkgenerate && make lint
   conformance:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # 1.19 is omitted because conformance test runner requires 1.20+
-        go-version: [1.20.x, 1.21.x]
+        go-version: [1.20.x, 1.21.x, 1.22.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -63,6 +62,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           # only the latest
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Run Slow Tests
         run: make slowtest

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        go-version: [1.19.x,1.20.x,1.21.x]
+        go-version: [1.20.x, 1.21.x, 1.22.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module connectrpc.com/connect
 
-go 1.19
+go 1.20
 
 retract (
 	v1.10.0 // module cache poisoned, use v1.10.1
@@ -9,8 +9,8 @@ retract (
 
 require (
 	github.com/google/go-cmp v0.5.9
-	golang.org/x/net v0.17.0
+	golang.org/x/net v0.21.0
 	google.golang.org/protobuf v1.32.0
 )
 
-require golang.org/x/text v0.13.0 // indirect
+require golang.org/x/text v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
-golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
-golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
-golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
+golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 google.golang.org/protobuf v1.32.0 h1:pPC6BG5ex8PDFnkbrGU3EixyhKcQ2aDuBS36lqK/C7I=
 google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=

--- a/header.go
+++ b/header.go
@@ -78,10 +78,3 @@ func setHeaderCanonical(h http.Header, key, value string) {
 func delHeaderCanonical(h http.Header, key string) {
 	delete(h, key)
 }
-
-// addHeaderCanonical is a shortcut for Header.Add() which
-// bypasses the CanonicalMIMEHeaderKey operation when we
-// know the key is already in canonical form.
-func addHeaderCanonical(h http.Header, key, value string) {
-	h[key] = append(h[key], value)
-}

--- a/internal/conformance/go.mod
+++ b/internal/conformance/go.mod
@@ -1,6 +1,6 @@
 module connectrpc.com/connect/internal/conformance
 
-go 1.19
+go 1.20
 
 require connectrpc.com/conformance v1.0.0-rc2
 

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -550,7 +550,7 @@ func (hc *grpcHandlerConn) Close(err error) (retErr error) {
 	for key, values := range mergedTrailers {
 		for _, value := range values {
 			// These are potentially user-supplied, so we can't assume they're in
-			// canonical form. Don't use addHeaderCanonical.
+			// canonical form.
 			hc.responseWriter.Header().Add(http.TrailerPrefix+key, value)
 		}
 	}


### PR DESCRIPTION
This PR bumps the go version to 1.22 and the min version to go1.20. This was prompted by this CI failure: https://github.com/connectrpc/connect-go/actions/runs/7932731168/job/21659863630 which I believe is related to this issue: https://github.com/golang/go/issues/55846.

Also included is a removal of a workaround for 1.19 header handling introduced here: https://github.com/connectrpc/connect-go/pull/406