### PR TITLE
Prepare for v1.15.0

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Version is the semantic version of the connect module.
-const Version = "1.15.0-dev"
+const Version = "1.15.0"
 
 // These constants are used in compile-time handshakes with connect's generated
 // code.


### PR DESCRIPTION
Below is a draft of the release notes that will accompany this release.

----

## What's Changed

Since the last release, we have been significantly increasing coverage of our [conformance suite](https://github.com/connectrpc/conformance). This has identified several inconsistencies with other Connect, gRPC, and gRPC-Web implementations. This release includes several fixes that will help align this implementation with others, behavior that can be verified by the conformance tests going forward. The fixes are backward-compatible with gRPC and Connect clients and servers. They fix some aspects of the wire representation and edge-case handling of spurious requests and responses, and they may affect users directly inspecting HTTP requests and responses.

### Governance
* Add @emcfarlane as a maintainer in #680 🎉

### Enhancements
* Add transport-level retry support for RPCs with unary and server-stream RPCs. This also improves efficiency by eliminating a goroutine and a message copy. By @emcfarlane in #649
* Prefer "application/grpc" over "application/grpc+proto" content-type when issuing gRPC calls. This accommodates Google Cloud Platform servers, which don't fully implement the gRPC specification. By @lrewega in #655
* Small efficiency gains in on all outbound HTTP requests and unary Connect response validation by @mattrobenolt in #682, #683
* Improve efficiency handling gRPC-Web and Connect end-of-stream messages by @jhump in #678

### Bugfixes
* Fix HTTP status to Code mapping by @emcfarlane in #673
* Client should verify response content-type by @jhump in #679
* Omit erroneous `@type` attribute from Connect error detail debug string by @jhump in #688
* Use context to correctly classify some errors with Canceled or DeadlineExceeded code by @emcfarlane in #659
* Fix trailers-only response handling and some gRPC error coding by @jhump in #677, #690

**Full Changelog**: https://github.com/connectrpc/connect-go/compare/v1.14.0...v1.15.0