### PR TITLE
Use action vars for go versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,7 @@
 name: ci
+env:
+  go_version: '1.22.x'
+  go_versions: '["1.20.x","1.21.x","1.22.x"]'
 on:
   push:
     branches: [main]
@@ -15,8 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # when editing this list, also update steps and jobs below
-        go-version: [1.20.x, 1.21.x, 1.22.x]
+        go-version: ${{ fromJSON(vars.go_versions) }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -33,13 +35,13 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.22.x'
+        if: matrix.go-version == ${{ vars.go-version }}
         run: make checkgenerate && make lint
   conformance:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x, 1.22.x]
+        go-version: ${{ fromJSON(vars.go_versions) }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -62,6 +64,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           # only the latest
-          go-version: 1.22.x
+          go-version: ${{ vars.go-version }}
       - name: Run Slow Tests
         run: make slowtest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: ci
 env:
   go_version: '1.22.x'
-  go_versions: "[\"1.20.x\",\"1.21.x\",\"1.22.x\"]"
+  go_versions: '["1.20.x","1.21.x","1.22.x"]'
 on:
   push:
     branches: [main]
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ${{ fromJSON(vars.go_versions) }}
+        go-version: ${{ fromJSON(vars.GO_VERSIONS) }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -35,13 +35,13 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == ${{ vars.go-version }}
+        if: matrix.go-version == ${{ vars.GO-VERSION }}
         run: make checkgenerate && make lint
   conformance:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ${{ fromJSON(vars.go_versions) }}
+        go-version: ${{ fromJSON(vars.GO_VERSIONS) }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -64,6 +64,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           # only the latest
-          go-version: ${{ vars.go-version }}
+          go-version: ${{ vars.GO_VERSION }}
       - name: Run Slow Tests
         run: make slowtest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: ci
 env:
   go_version: '1.22.x'
-  go_versions: '["1.20.x","1.21.x","1.22.x"]'
+  go_versions: "[\"1.20.x\",\"1.21.x\",\"1.22.x\"]"
 on:
   push:
     branches: [main]

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,4 +1,6 @@
 name: windows
+env:
+  go_versions: '["1.20.x","1.21.x","1.22.x"]'
 on:
   push:
     branches: [main]
@@ -15,7 +17,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x, 1.22.x]
+        go-version: ${{ fromJSON(vars.go_versions) }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,6 +1,6 @@
 name: windows
 env:
-  go_versions: '["1.20.x","1.21.x","1.22.x"]'
+  go_versions: "[\"1.20.x\",\"1.21.x\",\"1.22.x\"]"
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Switches go version to use workflow variables. Makes it easier to update the go version in workflows.