### PR TITLE
Fix ErrorWriter IsSupportedCheck with required connect protocol option

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,8 +34,8 @@ linters:
   enable-all: true
   disable:
     - cyclop            # covered by gocyclo
-    - depguard          # unnecessary for small libraries
     - deadcode          # abandoned
+    - depguard          # unnecessary for small libraries
     - exhaustivestruct  # replaced by exhaustruct
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification

--- a/codec_test.go
+++ b/codec_test.go
@@ -128,7 +128,7 @@ func TestStableCodec(t *testing.T) {
 func TestJSONCodec(t *testing.T) {
 	t.Parallel()
 
-	codec := &protoJSONCodec{name: "json"}
+	codec := &protoJSONCodec{name: codecNameJSON}
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()

--- a/error_writer.go
+++ b/error_writer.go
@@ -95,7 +95,9 @@ func (w *ErrorWriter) classifyRequest(request *http.Request) protocolType {
 		return connectUnaryProtocol
 	}
 	if _, ok := w.streamingConnectContentTypes[ctype]; ok {
-		if err := connectCheckProtocolVersion(request, w.requireConnectProtocolHeader); err != nil {
+		// Streaming ignores the requireConnectProtocolHeader option as the
+		// Content-Type is enough to determine the protocol.
+		if err := connectCheckProtocolVersion(request, false /* required */); err != nil {
 			return unknownProtocol
 		}
 		return connectStreamProtocol

--- a/error_writer_test.go
+++ b/error_writer_test.go
@@ -47,7 +47,7 @@ func TestErrorWriter(t *testing.T) {
 		t.Run("Stream", func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
 			req.Header.Set("Content-Type", connectStreamingContentTypePrefix+codecNameJSON)
-			assert.False(t, writer.IsSupported(req))
+			assert.True(t, writer.IsSupported(req)) // ignores WithRequireConnectProtocolHeader
 			req.Header.Set(connectHeaderProtocolVersion, connectProtocolVersion)
 			assert.True(t, writer.IsSupported(req))
 		})

--- a/error_writer_test.go
+++ b/error_writer_test.go
@@ -1,0 +1,55 @@
+// Copyright 2021-2024 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connect
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect/internal/assert"
+)
+
+func TestErrorWriter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RequireConnectProtocolHeader", func(t *testing.T) {
+		t.Parallel()
+		writer := NewErrorWriter(WithRequireConnectProtocolHeader())
+
+		t.Run("Unary", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+			req.Header.Set("Content-Type", connectUnaryContentTypePrefix+codecNameJSON)
+			assert.False(t, writer.IsSupported(req))
+			req.Header.Set(connectHeaderProtocolVersion, connectProtocolVersion)
+			assert.True(t, writer.IsSupported(req))
+		})
+		t.Run("UnaryGET", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+			assert.False(t, writer.IsSupported(req))
+			query := req.URL.Query()
+			query.Set(connectUnaryConnectQueryParameter, connectUnaryConnectQueryValue)
+			req.URL.RawQuery = query.Encode()
+			assert.True(t, writer.IsSupported(req))
+		})
+		t.Run("Stream", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+			req.Header.Set("Content-Type", connectStreamingContentTypePrefix+codecNameJSON)
+			assert.False(t, writer.IsSupported(req))
+			req.Header.Set(connectHeaderProtocolVersion, connectProtocolVersion)
+			assert.True(t, writer.IsSupported(req))
+		})
+	})
+}

--- a/option.go
+++ b/option.go
@@ -159,7 +159,7 @@ func WithRecover(handle func(context.Context, Spec, http.Header, any) error) Han
 // header. This ensures that HTTP proxies and net/http middleware can easily
 // identify valid Connect requests, even if they use a common Content-Type like
 // application/json. However, it makes ad-hoc requests with tools like cURL
-// more laborious.
+// more laborious. Streaming requests are not affected by this option.
 //
 // This option has no effect if the client uses the gRPC or gRPC-Web protocols.
 func WithRequireConnectProtocolHeader() HandlerOption {

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -173,7 +173,8 @@ func (h *connectHandler) NewConn(
 		failed = checkServerStreamsCanFlush(h.Spec, responseWriter)
 	}
 	if failed == nil {
-		failed = connectCheckProtocolVersion(request, h.RequireConnectProtocolHeader)
+		required := h.RequireConnectProtocolHeader && (h.Spec.StreamType == StreamTypeUnary)
+		failed = connectCheckProtocolVersion(request, required)
 	}
 
 	var requestBody io.ReadCloser


### PR DESCRIPTION
This PR fixes ErrorWriter to correctly return unsupported protocol if the option `WithRequireConnectProtocolHeader` is set and the header or query value isn't include in the request. It will now correctly return unsupported to ensure fallback options can process the error.

Fixes #699

