### PR TITLE
Fix ErrorWriter to be codec agnostic

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -2423,7 +2423,9 @@ func TestClientDisconnect(t *testing.T) {
 			assert.NotNil(t, err)
 			<-gotResponse
 			assert.NotNil(t, handlerReceiveErr)
-			assert.Equal(t, connect.CodeOf(handlerReceiveErr), connect.CodeCanceled)
+			if !assert.Equal(t, connect.CodeOf(handlerReceiveErr), connect.CodeCanceled) {
+				t.Logf("handlerReceiveErr: %v", handlerReceiveErr)
+			}
 			assert.ErrorIs(t, handlerContextErr, context.Canceled)
 		})
 		t.Run("handler_writes", func(t *testing.T) {
@@ -2434,7 +2436,7 @@ func TestClientDisconnect(t *testing.T) {
 				gotResponse       = make(chan struct{})
 			)
 			pingServer := &pluggablePingServer{
-				countUp: func(ctx context.Context, req *connect.Request[pingv1.CountUpRequest], stream *connect.ServerStream[pingv1.CountUpResponse]) error {
+				countUp: func(ctx context.Context, _ *connect.Request[pingv1.CountUpRequest], stream *connect.ServerStream[pingv1.CountUpResponse]) error {
 					close(gotRequest)
 					var err error
 					for err == nil {

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -2423,9 +2423,7 @@ func TestClientDisconnect(t *testing.T) {
 			assert.NotNil(t, err)
 			<-gotResponse
 			assert.NotNil(t, handlerReceiveErr)
-			if !assert.Equal(t, connect.CodeOf(handlerReceiveErr), connect.CodeCanceled) {
-				t.Logf("handlerReceiveErr: %v", handlerReceiveErr)
-			}
+			assert.Equal(t, connect.CodeOf(handlerReceiveErr), connect.CodeCanceled, assert.Sprintf("got %v", handlerReceiveErr))
 			assert.ErrorIs(t, handlerContextErr, context.Canceled)
 		})
 		t.Run("handler_writes", func(t *testing.T) {

--- a/error_writer.go
+++ b/error_writer.go
@@ -58,8 +58,6 @@ func NewErrorWriter(opts ...HandlerOption) *ErrorWriter {
 	return &ErrorWriter{
 		bufferPool:                   config.BufferPool,
 		protobuf:                     codecs.Protobuf(),
-		handleGRPC:                   config.HandleGRPC,
-		handleGRPCWeb:                config.HandleGRPCWeb,
 		requireConnectProtocolHeader: config.RequireConnectProtocolHeader,
 	}
 }
@@ -69,9 +67,9 @@ func (w *ErrorWriter) classifyRequest(request *http.Request) protocolType {
 	isPost := request.Method == http.MethodPost
 	isGet := request.Method == http.MethodGet
 	switch {
-	case w.handleGRPC && isPost && (ctype == grpcContentTypeDefault || strings.HasPrefix(ctype, grpcContentTypePrefix)):
+	case isPost && (ctype == grpcContentTypeDefault || strings.HasPrefix(ctype, grpcContentTypePrefix)):
 		return grpcProtocol
-	case w.handleGRPCWeb && isPost && (ctype == grpcWebContentTypeDefault || strings.HasPrefix(ctype, grpcWebContentTypePrefix)):
+	case isPost && (ctype == grpcWebContentTypeDefault || strings.HasPrefix(ctype, grpcWebContentTypePrefix)):
 		return grpcWebProtocol
 	case isPost && strings.HasPrefix(ctype, connectStreamingContentTypePrefix):
 		// Streaming ignores the requireConnectProtocolHeader option as the
@@ -80,7 +78,7 @@ func (w *ErrorWriter) classifyRequest(request *http.Request) protocolType {
 			return unknownProtocol
 		}
 		return connectStreamProtocol
-	case isPost && strings.HasPrefix(ctype, connectUnaryContentTypePrefix) && !strings.HasPrefix(ctype, grpcContentTypeDefault):
+	case isPost && strings.HasPrefix(ctype, connectUnaryContentTypePrefix):
 		if err := connectCheckProtocolVersion(request, w.requireConnectProtocolHeader); err != nil {
 			return unknownProtocol
 		}

--- a/error_writer.go
+++ b/error_writer.go
@@ -80,12 +80,12 @@ func (w *ErrorWriter) classifyRequest(request *http.Request) protocolType {
 			return unknownProtocol
 		}
 		return connectStreamProtocol
-	case isPost && strings.HasPrefix(ctype, connectUnaryContentTypePrefix):
+	case isPost && strings.HasPrefix(ctype, connectUnaryContentTypePrefix) && !strings.HasPrefix(ctype, grpcContentTypeDefault):
 		if err := connectCheckProtocolVersion(request, w.requireConnectProtocolHeader); err != nil {
 			return unknownProtocol
 		}
 		return connectUnaryProtocol
-	case isGet && ctype == "":
+	case isGet:
 		if err := connectCheckProtocolVersion(request, w.requireConnectProtocolHeader); err != nil {
 			return unknownProtocol
 		}

--- a/error_writer.go
+++ b/error_writer.go
@@ -41,8 +41,6 @@ const (
 type ErrorWriter struct {
 	bufferPool                   *bufferPool
 	protobuf                     Codec
-	handleGRPC                   bool
-	handleGRPCWeb                bool
 	requireConnectProtocolHeader bool
 }
 

--- a/handler.go
+++ b/handler.go
@@ -274,8 +274,6 @@ type handlerConfig struct {
 	Procedure                    string
 	Schema                       any
 	Initializer                  maybeInitializer
-	HandleGRPC                   bool
-	HandleGRPCWeb                bool
 	RequireConnectProtocolHeader bool
 	IdempotencyLevel             IdempotencyLevel
 	BufferPool                   *bufferPool
@@ -290,8 +288,6 @@ func newHandlerConfig(procedure string, streamType StreamType, options []Handler
 		Procedure:        protoPath,
 		CompressionPools: make(map[string]*compressionPool),
 		Codecs:           make(map[string]Codec),
-		HandleGRPC:       true,
-		HandleGRPCWeb:    true,
 		BufferPool:       newBufferPool(),
 		StreamType:       streamType,
 	}
@@ -314,12 +310,10 @@ func (c *handlerConfig) newSpec() Spec {
 }
 
 func (c *handlerConfig) newProtocolHandlers() []protocolHandler {
-	protocols := []protocol{&protocolConnect{}}
-	if c.HandleGRPC {
-		protocols = append(protocols, &protocolGRPC{web: false})
-	}
-	if c.HandleGRPCWeb {
-		protocols = append(protocols, &protocolGRPC{web: true})
+	protocols := []protocol{
+		&protocolConnect{},
+		&protocolGRPC{web: false},
+		&protocolGRPC{web: true},
 	}
 	handlers := make([]protocolHandler, 0, len(protocols))
 	codecs := newReadOnlyCodecs(c.Codecs)


### PR DESCRIPTION
This PR changes the ErrorWriter to be more lenient with classifying protocols. Errors codecs are agnostic to the codec used. Therefore we avoid checking the codec in classifying the request. IsSupported will return true for an unknown codec which allows the server to encode a better error message to the client. If not supported a 415 error response could be used to match gRPC server like handling. If not supported and trying to write an error the ErrorWriter will default to connects unary encoding (consistent with current behaviour).

Fixes #689 

<!--
Before submitting your PR, please read through the contribution guide!

https://github.com/connectrpc/connect-go/blob/main/.github/CONTRIBUTING.md
-->
