### PR TITLE
In connect unary protocol, fallback to code based on HTTP status if unable to deserialize it

### DIFF
--- a/internal/conformance/known-failing.txt
+++ b/internal/conformance/known-failing.txt
@@ -1,0 +1,14 @@
+# The current v1.0.0-rc3 of conformance suite wants to see "unknown"
+# as the status for Connect unary responses where the JSON error body
+# is missing the 'code' property. But we instead want clients to
+# synthesize an error code from the HTTP status code. That way, if
+# a proxy or middle-box happens to reply with a JSON error, but not
+# a valid *Connect* error, we can use the HTTP status to derive an
+# error code, just like we do when the response has an unexpected
+# content type.
+#
+# So after we fix the tests in the conformance suite, we can remove
+# these lines below.
+Connect Error and End-Stream/**/error/missing-code
+Connect Error and End-Stream/**/error/null
+Connect Error and End-Stream/**/error/null-code

--- a/internal/conformance/runconformance.sh
+++ b/internal/conformance/runconformance.sh
@@ -15,7 +15,7 @@ $GO build -o $BINDIR/referenceclient connectrpc.com/conformance/cmd/referencecli
 $GO build -o $BINDIR/referenceserver connectrpc.com/conformance/cmd/referenceserver
 
 echo "Running conformance tests against client..."
-$BINDIR/connectconformance --mode client --conf config.yaml -v --trace -- $BINDIR/referenceclient
+$BINDIR/connectconformance --mode client --conf config.yaml --known-failing @known-failing.txt -v --trace -- $BINDIR/referenceclient
 
 echo "Running conformance tests against server..."
 $BINDIR/connectconformance --mode server --conf config.yaml -v --trace -- $BINDIR/referenceserver

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -1255,8 +1255,8 @@ func (e *connectWireError) UnmarshalJSON(data []byte) error {
 	// the other fields from the input JSON.
 	var wireError struct {
 		Code    string               `json:"code"`
-		Message string               `json:"message,omitempty"`
-		Details []*connectWireDetail `json:"details,omitempty"`
+		Message string               `json:"message"`
+		Details []*connectWireDetail `json:"details"`
 	}
 	err := json.Unmarshal(data, &wireError)
 	if err != nil {

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -559,6 +559,10 @@ func (cc *connectUnaryClientConn) validateResponse(response *http.Response) *Err
 				errors.New(response.Status),
 			)
 		}
+		if wireErr.Code == 0 {
+			// code not set? default to one implied by HTTP status
+			wireErr.Code = connectHTTPToCode(response.StatusCode)
+		}
 		serverErr := wireErr.asError()
 		if serverErr == nil {
 			return nil
@@ -1243,6 +1247,26 @@ func (e *connectWireError) asError() *Error {
 		}
 	}
 	return err
+}
+
+func (e *connectWireError) UnmarshalJSON(data []byte) error {
+	// We want to be lenient if the JSON has an unrecognized or invalid code.
+	// So if that occurs, we leave the code unset but can still de-serialize
+	// the other fields from the input JSON.
+	var wireError struct {
+		Code    string               `json:"code"`
+		Message string               `json:"message,omitempty"`
+		Details []*connectWireDetail `json:"details,omitempty"`
+	}
+	err := json.Unmarshal(data, &wireError)
+	if err != nil {
+		return err
+	}
+	e.Message = wireError.Message
+	e.Details = wireError.Details
+	// This will leave e.Code unset if we can't unmarshal the given string.
+	_ = e.Code.UnmarshalText([]byte(wireError.Code))
+	return nil
 }
 
 type connectEndStreamMessage struct {


### PR DESCRIPTION
The conformance tests, as of v1.0.0-rc3, currently require behavior that matches the current behavior of connect-go: if the error JSON body in a Connect unary response can be unmarshaled but is missing the code, it defaults to using "unknown" as the code.

However, in the Connect unary format (and not any of the others), we also have a non-200 HTTP status that could be used to determine a potentially better default than "unknown". So this PR changes it so that connect-go uses the HTTP status in this case, instead of always using "unknown". (Also see https://github.com/connectrpc/conformance/issues/810.)

It _also_ updates the JSON unmarshaling of the error body so it accepts a `"code"` property with an invalid value. In this case, the invalid value is discarded, and due to the change described above, the code will instead be computed from the HTTP status. But this lenience allows us to capture the message and details, in the event that the JSON contains these other properties but with (for example) a misspelled code string.