### PR TITLE
Revise code mappings per latest changes to spec

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -1731,9 +1731,9 @@ func TestConnectHTTPErrorCodes(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Nil(t, connectResp)
 	}
-	t.Run("CodeCanceled-408", func(t *testing.T) {
+	t.Run("CodeCanceled-499", func(t *testing.T) {
 		t.Parallel()
-		checkHTTPStatus(t, connect.CodeCanceled, 408)
+		checkHTTPStatus(t, connect.CodeCanceled, 499)
 	})
 	t.Run("CodeUnknown-500", func(t *testing.T) {
 		t.Parallel()
@@ -1743,9 +1743,9 @@ func TestConnectHTTPErrorCodes(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodeInvalidArgument, 400)
 	})
-	t.Run("CodeDeadlineExceeded-408", func(t *testing.T) {
+	t.Run("CodeDeadlineExceeded-504", func(t *testing.T) {
 		t.Parallel()
-		checkHTTPStatus(t, connect.CodeDeadlineExceeded, 408)
+		checkHTTPStatus(t, connect.CodeDeadlineExceeded, 504)
 	})
 	t.Run("CodeNotFound-404", func(t *testing.T) {
 		t.Parallel()
@@ -1763,9 +1763,9 @@ func TestConnectHTTPErrorCodes(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodeResourceExhausted, 429)
 	})
-	t.Run("CodeFailedPrecondition-412", func(t *testing.T) {
+	t.Run("CodeFailedPrecondition-400", func(t *testing.T) {
 		t.Parallel()
-		checkHTTPStatus(t, connect.CodeFailedPrecondition, 412)
+		checkHTTPStatus(t, connect.CodeFailedPrecondition, 400)
 	})
 	t.Run("CodeAborted-409", func(t *testing.T) {
 		t.Parallel()
@@ -1775,9 +1775,9 @@ func TestConnectHTTPErrorCodes(t *testing.T) {
 		t.Parallel()
 		checkHTTPStatus(t, connect.CodeOutOfRange, 400)
 	})
-	t.Run("CodeUnimplemented-404", func(t *testing.T) {
+	t.Run("CodeUnimplemented-501", func(t *testing.T) {
 		t.Parallel()
-		checkHTTPStatus(t, connect.CodeUnimplemented, 404)
+		checkHTTPStatus(t, connect.CodeUnimplemented, 501)
 	})
 	t.Run("CodeInternal-500", func(t *testing.T) {
 		t.Parallel()

--- a/handler_ext_test.go
+++ b/handler_ext_test.go
@@ -231,7 +231,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		resp, err := client.Do(req)
 		assert.Nil(t, err)
 		defer resp.Body.Close()
-		assert.Equal(t, resp.StatusCode, http.StatusNotFound)
+		assert.Equal(t, resp.StatusCode, http.StatusNotImplemented)
 
 		type errorMessage struct {
 			Code    string `json:"code,omitempty"`

--- a/internal/conformance/known-failing.txt
+++ b/internal/conformance/known-failing.txt
@@ -12,3 +12,16 @@
 Connect Error and End-Stream/**/error/missing-code
 Connect Error and End-Stream/**/error/null
 Connect Error and End-Stream/**/error/null-code
+
+# The current v1.0.0-rc3 of conformance suite has expectations based
+# on the old mappings of HTTP to RPC code. The mappings were revised
+# in the spec (https://github.com/connectrpc/connectrpc.com/pull/130),
+# and this repo implements those new mappings. So test cases based on
+# the old mappings fail for right now.
+Connect Unexpected Responses/**/unexpected-error-body
+HTTP to Connect Code Mapping/**/bad-request
+HTTP to Connect Code Mapping/**/conflict
+HTTP to Connect Code Mapping/**/payload-too-large
+HTTP to Connect Code Mapping/**/precondition-failed
+HTTP to Connect Code Mapping/**/request-header-fields-too-large
+HTTP to Connect Code Mapping/**/request-timeout

--- a/protocol.go
+++ b/protocol.go
@@ -396,3 +396,28 @@ func canonicalizeContentTypeSlow(contentType string) string {
 	}
 	return mime.FormatMediaType(base, params)
 }
+
+func httpToCode(httpCode int) Code {
+	// https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md
+	// Note that this is NOT the inverse of the gRPC-to-HTTP or Connect-to-HTTP
+	// mappings.
+
+	// Literals are easier to compare to the specification (vs named
+	// constants).
+	switch httpCode {
+	case 400:
+		return CodeInternal
+	case 401:
+		return CodeUnauthenticated
+	case 403:
+		return CodePermissionDenied
+	case 404:
+		return CodeUnimplemented
+	case 429:
+		return CodeUnavailable
+	case 502, 503, 504:
+		return CodeUnavailable
+	default:
+		return CodeUnknown
+	}
+}

--- a/protocol_connect_test.go
+++ b/protocol_connect_test.go
@@ -243,19 +243,19 @@ func TestConnectValidateUnaryResponseContentType(t *testing.T) {
 			codecName:           codecNameProto,
 			statusCode:          http.StatusNotFound,
 			responseContentType: "application/proto",
-			expectCode:          connectHTTPToCode(http.StatusNotFound),
+			expectCode:          httpToCode(http.StatusNotFound),
 		},
 		{
 			codecName:           codecNameJSON,
 			statusCode:          http.StatusBadRequest,
 			responseContentType: "some/garbage",
-			expectCode:          connectHTTPToCode(http.StatusBadRequest),
+			expectCode:          httpToCode(http.StatusBadRequest),
 		},
 		{
 			codecName:           codecNameJSON,
 			statusCode:          http.StatusTooManyRequests,
 			responseContentType: "some/garbage",
-			expectCode:          connectHTTPToCode(http.StatusTooManyRequests),
+			expectCode:          httpToCode(http.StatusTooManyRequests),
 		},
 	}
 	for _, testCase := range testCases {

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -651,7 +651,7 @@ func grpcValidateResponse(
 	codecName string,
 ) *Error {
 	if response.StatusCode != http.StatusOK {
-		return errorf(grpcHTTPToCode(response.StatusCode), "HTTP status %v", response.Status)
+		return errorf(httpToCode(response.StatusCode), "HTTP status %v", response.Status)
 	}
 	if err := grpcValidateResponseContentType(
 		web,
@@ -676,27 +676,6 @@ func grpcValidateResponse(
 	// The response is valid, so we should expose the headers.
 	mergeHeaders(header, response.Header)
 	return nil
-}
-
-func grpcHTTPToCode(httpCode int) Code {
-	// https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md
-	// Note that this is not just the inverse of the gRPC-to-HTTP mapping.
-	switch httpCode {
-	case 400:
-		return CodeInternal
-	case 401:
-		return CodeUnauthenticated
-	case 403:
-		return CodePermissionDenied
-	case 404:
-		return CodeUnimplemented
-	case 429:
-		return CodeUnavailable
-	case 502, 503, 504:
-		return CodeUnavailable
-	default:
-		return CodeUnknown
-	}
 }
 
 // The gRPC wire protocol specifies that errors should be serialized using the


### PR DESCRIPTION
This reconciles the implementation in this repo with the recent adjustments to HTTP<->Connect code mappings (https://github.com/connectrpc/connectrpc.com/pull/130).

The gRPC and Connect mappings from HTTP code to RPC code are now aligned, so I've unified them into a single function.