### PR TITLE
Update a couple of more places where we should return a context error if there is one

### DIFF
--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -161,7 +161,7 @@ func (d *duplexHTTPCall) sendUnary(payload messagePayload) (int64, error) {
 	return payloadLength, nil
 }
 
-// Close the request body. Callers *must* call CloseWrite before Read when
+// CloseWrite closes the request body. Callers *must* call CloseWrite before Read when
 // using HTTP/1.x.
 func (d *duplexHTTPCall) CloseWrite() error {
 	// Even if Write was never called, we need to make an HTTP request. This
@@ -226,6 +226,7 @@ func (d *duplexHTTPCall) Read(data []byte) (int, error) {
 		return 0, wrapIfContextError(err)
 	}
 	n, err := d.response.Body.Read(data)
+	err = wrapIfContextDone(d.ctx, err)
 	return n, wrapIfRSTError(err)
 }
 
@@ -241,7 +242,7 @@ func (d *duplexHTTPCall) CloseRead() error {
 		errors.Is(err, context.DeadlineExceeded) {
 		err = closeErr
 	}
-	err = wrapIfContextError(err)
+	err = wrapIfContextDone(d.ctx, err)
 	return wrapIfRSTError(err)
 }
 

--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -226,8 +226,11 @@ func (d *duplexHTTPCall) Read(data []byte) (int, error) {
 		return 0, wrapIfContextError(err)
 	}
 	n, err := d.response.Body.Read(data)
-	err = wrapIfContextDone(d.ctx, err)
-	return n, wrapIfRSTError(err)
+	if err != nil && !errors.Is(err, io.EOF) {
+		err = wrapIfContextDone(d.ctx, err)
+		err = wrapIfRSTError(err)
+	}
+	return n, err
 }
 
 func (d *duplexHTTPCall) CloseRead() error {


### PR DESCRIPTION
This is effectively a continuation of #659, catching two more places that needed to be instrumented.

This issue was discovered when running conformance tests (https://github.com/connectrpc/conformance/issues/813). It was occurring consistently with full-duplex streams against one particular server implementation. I think that implementation was eagerly doing a server-side cancelation of the stream when the server saw that its deadline had elapsed, and that other implementations generally don't do this. In this particular case, the framework was observing the "RSTStream" frame and returning a "canceled" code even though the operation's context had already elapsed and had a "deadline exceeded" error. So the RPC was returning a "canceled" error code when it ideally would instead return a "deadline exceeded" code. This PR fixes that discrepancy.