### PR TITLE
Restrict metadata headers in error propagation

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -558,7 +558,10 @@ func TestErrorHeaderPropagation(t *testing.T) {
 			err.Meta().Set("Content-Type", "application/xml")
 			err.Meta().Set("Accept-Encoding", "bogus")
 			err.Meta().Set("Date", "Thu, 01 Jan 1970 00:00:00 GMT")
-			err.Meta().Set("X-Test", "test") // Allow custom headers.
+			err.Meta().Set("Grpc-Status", "0")
+			// Allow custom headers.
+			err.Meta()["x-test-case"] = []string{"test"}
+			err.Meta().Set("X-Test", request.Header().Get("X-Test"))
 			return nil, err
 		},
 	}
@@ -599,9 +602,77 @@ func TestErrorHeaderPropagation(t *testing.T) {
 		assert.NotEqual(t, meta.Values("Content-Type"), []string{"application/xml"})
 		assert.NotEqual(t, meta.Values("Content-Length"), []string{"1337"})
 		assert.NotEqual(t, meta.Values("Date"), []string{"Thu, 01 Jan 1970 00:00:00 GMT"})
-		assert.Equal(t, meta.Values("X-Test"), []string{"test"})
+		assert.Equal(t, meta.Values("x-test-case"), []string{"test"})
+		assert.Equal(t, meta.Values("X-Test"), []string{t.Name()})
 	}
+	t.Run("connect", func(t *testing.T) {
+		t.Parallel()
+		client := pingv1connect.NewPingServiceClient(server.Client(), server.URL())
+		testPing(t, client)
+	})
+	t.Run("grpc", func(t *testing.T) {
+		t.Parallel()
+		client := pingv1connect.NewPingServiceClient(server.Client(), server.URL(), connect.WithGRPC())
+		testPing(t, client)
+	})
+	t.Run("grpc-web", func(t *testing.T) {
+		t.Parallel()
+		client := pingv1connect.NewPingServiceClient(server.Client(), server.URL(), connect.WithGRPCWeb())
+		testPing(t, client)
+	})
+}
 
+func TestWireErrorHeaderPropagation(t *testing.T) {
+	t.Parallel()
+	pingServer := &pluggablePingServer{
+		ping: func(ctx context.Context, request *connect.Request[pingv1.PingRequest]) (*connect.Response[pingv1.PingResponse], error) {
+			err := connect.NewWireError(connect.CodeInvalidArgument, errors.New("ping error"))
+			msgDetail := &wrapperspb.StringValue{Value: "server details"}
+			errDetail, derr := connect.NewErrorDetail(msgDetail)
+			if derr != nil {
+				return nil, derr
+			}
+			err.AddDetail(errDetail)
+			err.Meta().Set("X-Test", request.Header().Get("X-Test"))
+			return nil, err
+		},
+	}
+	mux := http.NewServeMux()
+	mux.Handle(pingv1connect.NewPingServiceHandler(pingServer))
+	server := memhttptest.NewServer(t, mux)
+
+	testPing := func(t *testing.T, client pingv1connect.PingServiceClient) {
+		t.Helper()
+		request := connect.NewRequest(&pingv1.PingRequest{})
+		request.Header().Set("X-Test", t.Name())
+		_, err := client.Ping(context.Background(), request)
+		if !assert.NotNil(t, err) {
+			return
+		}
+		assert.Equal(t, connect.CodeOf(err), connect.CodeInvalidArgument)
+		var connectErr *connect.Error
+		if !assert.True(t, errors.As(err, &connectErr)) {
+			return
+		}
+		assert.Equal(t, connectErr.Message(), "ping error")
+
+		details := connectErr.Details()
+		if assert.Equal(t, len(details), 1) {
+			detailMsg, err := details[0].Value()
+			if !assert.Nil(t, err) {
+				return
+			}
+			serverDetails, ok := detailMsg.(*wrapperspb.StringValue)
+			if !assert.True(t, ok) {
+				return
+			}
+			assert.Equal(t, serverDetails.Value, "server details")
+		}
+		meta := connectErr.Meta()
+		assert.NotNil(t, meta.Values("Content-Type"))
+		assert.NotNil(t, meta.Values("Date"))
+		assert.Equal(t, meta.Values("X-Test"), nil) // Wire errors don't propagate meta.
+	}
 	t.Run("connect", func(t *testing.T) {
 		t.Parallel()
 		client := pingv1connect.NewPingServiceClient(server.Client(), server.URL())

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -618,7 +618,7 @@ func TestErrorHeaderPropagation(t *testing.T) {
 		t.Run("bidi", func(t *testing.T) {
 			stream := client.CumSum(context.Background())
 			stream.RequestHeader().Set("X-Test", t.Name())
-			if err := stream.Send(&pingv1.CumSumRequest{Number: 42}); err != nil {
+			if err := stream.Send(nil); err != nil {
 				t.Fatal(err)
 			}
 			_, err := stream.Receive()

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -544,6 +544,7 @@ func TestConcurrentStreams(t *testing.T) {
 }
 
 func TestErrorHeaderPropagation(t *testing.T) {
+	t.Parallel()
 	pingServer := &pluggablePingServer{
 		ping: func(ctx context.Context, request *connect.Request[pingv1.PingRequest]) (*connect.Response[pingv1.PingResponse], error) {
 			err := connect.NewError(connect.CodeInvalidArgument, errors.New("ping error"))

--- a/error.go
+++ b/error.go
@@ -158,6 +158,10 @@ func NewWireError(c Code, underlying error) *Error {
 // Clients may find this useful when deciding how to propagate errors. For
 // example, an RPC-to-HTTP proxy might expose a server-sent CodeUnknown as an
 // HTTP 500 but a client-synthesized CodeUnknown as a 503.
+//
+// Handlers will strip [Meta] headers propagated from wire errors to avoid
+// leaking response headers. To propagate headers recreate the error as a
+// non-wire error.
 func IsWireError(err error) bool {
 	se := new(Error)
 	if !errors.As(err, &se) {
@@ -228,6 +232,11 @@ func (e *Error) AddDetail(d *ErrorDetail) {
 // returned by streaming handlers may be sent as HTTP headers, HTTP trailers,
 // or a block of in-body metadata, depending on the protocol in use and whether
 // or not the handler has already written messages to the stream.
+//
+// Protocol-specific headers and trailers may be removed to avoid breaking
+// protocol semantics. For example, Content-Length and Content-Type headers
+// won't be propagated. See the documentation for each protocol for more
+// datails.
 //
 // When clients receive errors, the metadata contains the union of the HTTP
 // headers and the protocol-specific trailers (either HTTP trailers or in-body

--- a/error.go
+++ b/error.go
@@ -159,7 +159,7 @@ func NewWireError(c Code, underlying error) *Error {
 // example, an RPC-to-HTTP proxy might expose a server-sent CodeUnknown as an
 // HTTP 500 but a client-synthesized CodeUnknown as a 503.
 //
-// Handlers will strip [Meta] headers propagated from wire errors to avoid
+// Handlers will strip [Error.Meta] headers propagated from wire errors to avoid
 // leaking response headers. To propagate headers recreate the error as a
 // non-wire error.
 func IsWireError(err error) bool {

--- a/error_writer.go
+++ b/error_writer.go
@@ -128,7 +128,7 @@ func (w *ErrorWriter) Write(response http.ResponseWriter, request *http.Request,
 
 func (w *ErrorWriter) writeConnectUnary(response http.ResponseWriter, err error) error {
 	if connectErr, ok := asError(err); ok {
-		mergeHeaders(response.Header(), connectErr.meta)
+		mergeMetadataHeaders(response.Header(), connectErr.meta)
 	}
 	response.WriteHeader(connectCodeToHTTP(CodeOf(err)))
 	data, marshalErr := json.Marshal(newConnectWireError(err))

--- a/error_writer.go
+++ b/error_writer.go
@@ -127,7 +127,7 @@ func (w *ErrorWriter) Write(response http.ResponseWriter, request *http.Request,
 }
 
 func (w *ErrorWriter) writeConnectUnary(response http.ResponseWriter, err error) error {
-	if connectErr, ok := asError(err); ok {
+	if connectErr, ok := asError(err); ok && !connectErr.wireErr {
 		mergeMetadataHeaders(response.Header(), connectErr.meta)
 	}
 	response.WriteHeader(connectCodeToHTTP(CodeOf(err)))

--- a/protocol.go
+++ b/protocol.go
@@ -41,6 +41,7 @@ const (
 	headerHost            = "Host"
 	headerUserAgent       = "User-Agent"
 	headerTrailer         = "Trailer"
+	headerDate            = "Date"
 
 	discardLimit = 1024 * 1024 * 4 // 4MiB
 )

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -766,7 +766,7 @@ func (hc *connectUnaryHandlerConn) writeResponseHeader(err error) {
 		header[headerVary] = append(header[headerVary], connectUnaryHeaderAcceptCompression)
 	}
 	if err != nil {
-		if connectErr, ok := asError(err); ok {
+		if connectErr, ok := asError(err); ok && !connectErr.wireErr {
 			mergeMetadataHeaders(header, connectErr.meta)
 		}
 	}

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -852,7 +852,7 @@ func (m *connectStreamingMarshaler) MarshalEndStream(err error, trailer http.Hea
 	if err != nil {
 		end.Error = newConnectWireError(err)
 		if connectErr, ok := asError(err); ok {
-			mergeHeaders(end.Trailer, connectErr.meta)
+			mergeMetadataHeaders(end.Trailer, connectErr.meta)
 		}
 	}
 	data, marshalErr := json.Marshal(end)

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -851,7 +851,7 @@ func (m *connectStreamingMarshaler) MarshalEndStream(err error, trailer http.Hea
 	end := &connectEndStreamMessage{Trailer: trailer}
 	if err != nil {
 		end.Error = newConnectWireError(err)
-		if connectErr, ok := asError(err); ok {
+		if connectErr, ok := asError(err); ok && !connectErr.wireErr {
 			mergeMetadataHeaders(end.Trailer, connectErr.meta)
 		}
 	}

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -859,7 +859,7 @@ func grpcErrorToTrailer(trailer http.Header, protobuf Codec, err error) {
 		)
 		return
 	}
-	if connectErr, ok := asError(err); ok {
+	if connectErr, ok := asError(err); ok && !connectErr.wireErr {
 		mergeMetadataHeaders(trailer, connectErr.meta)
 	}
 	setHeaderCanonical(trailer, grpcHeaderStatus, code)

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -860,7 +860,7 @@ func grpcErrorToTrailer(trailer http.Header, protobuf Codec, err error) {
 		return
 	}
 	if connectErr, ok := asError(err); ok {
-		mergeHeaders(trailer, connectErr.meta)
+		mergeMetadataHeaders(trailer, connectErr.meta)
 	}
 	setHeaderCanonical(trailer, grpcHeaderStatus, code)
 	setHeaderCanonical(trailer, grpcHeaderMessage, grpcPercentEncode(status.GetMessage()))


### PR DESCRIPTION
This PR addresses issues when propagating errors from a client back to a handler. On the client side connect errors will contain all response headers: transport (`Content-Type`, `Content-Length`, etc), protocol and application headers. These could break the transport when trying to re-encode the error or leak sensitive information between services. For any wire errors (errors decoded from a client response) we now disable meta propagation. For other errors we now also restrict the headers propagated.
