### PR TITLE
Use "unimplemented" code for cardinality violations

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -1689,6 +1689,7 @@ func TestStreamForServer(t *testing.T) {
 		client := newPingClient(t, &pluggablePingServer{
 			sum: func(ctx context.Context, stream *connect.ClientStream[pingv1.SumRequest]) (*connect.Response[pingv1.SumResponse], error) {
 				assert.True(t, stream.Receive())
+				// We end up sending two response messages, but only one is expected.
 				assert.Nil(t, stream.Conn().Send(&pingv1.SumResponse{Sum: 2}))
 				return connect.NewResponse(&pingv1.SumResponse{}), nil
 			},
@@ -1697,7 +1698,7 @@ func TestStreamForServer(t *testing.T) {
 		assert.Nil(t, stream.Send(&pingv1.SumRequest{Number: 1}))
 		res, err := stream.CloseAndReceive()
 		assert.NotNil(t, err)
-		assert.Equal(t, connect.CodeOf(err), connect.CodeUnknown)
+		assert.Equal(t, connect.CodeOf(err), connect.CodeUnimplemented)
 		assert.Nil(t, res)
 	})
 }

--- a/handler.go
+++ b/handler.go
@@ -63,23 +63,9 @@ func NewUnaryHandler[Req, Res any](
 	}
 	// Given a stream, how should we call the unary function?
 	implementation := func(ctx context.Context, conn StreamingHandlerConn) error {
-		var msg Req
-		if err := config.Initializer.maybe(conn.Spec(), &msg); err != nil {
+		request, err := receiveUnaryRequest[Req](conn, config.Initializer)
+		if err != nil {
 			return err
-		}
-		if err := conn.Receive(&msg); err != nil {
-			return err
-		}
-		method := http.MethodPost
-		if hasRequestMethod, ok := conn.(interface{ getHTTPMethod() string }); ok {
-			method = hasRequestMethod.getHTTPMethod()
-		}
-		request := &Request[Req]{
-			Msg:    &msg,
-			spec:   conn.Spec(),
-			peer:   conn.Peer(),
-			header: conn.RequestHeader(),
-			method: method,
 		}
 		response, err := untyped(ctx, request)
 		if err != nil {
@@ -140,24 +126,11 @@ func NewServerStreamHandler[Req, Res any](
 	return newStreamHandler(
 		config,
 		func(ctx context.Context, conn StreamingHandlerConn) error {
-			var msg Req
-			if err := config.Initializer.maybe(conn.Spec(), &msg); err != nil {
+			req, err := receiveUnaryRequest[Req](conn, config.Initializer)
+			if err != nil {
 				return err
 			}
-			if err := conn.Receive(&msg); err != nil {
-				return err
-			}
-			return implementation(
-				ctx,
-				&Request[Req]{
-					Msg:    &msg,
-					spec:   conn.Spec(),
-					peer:   conn.Peer(),
-					header: conn.RequestHeader(),
-					method: http.MethodPost,
-				},
-				&ServerStream[Res]{conn: conn},
-			)
+			return implementation(ctx, req, &ServerStream[Res]{conn: conn})
 		},
 	)
 }

--- a/internal/conformance/known-failing.txt
+++ b/internal/conformance/known-failing.txt
@@ -25,3 +25,15 @@ HTTP to Connect Code Mapping/**/payload-too-large
 HTTP to Connect Code Mapping/**/precondition-failed
 HTTP to Connect Code Mapping/**/request-header-fields-too-large
 HTTP to Connect Code Mapping/**/request-timeout
+
+# The current v1.0.0-rc3 of conformance suite has expectations for these
+# conditions that were based on the behavior of grpc-go (which returns an
+# "unknown" error), with the incorrect idea that was authoritative (and,
+# honestly, that code makes sense). However, the actual correct behavior,
+# per the specification for gRPC error codes, is for these cardinality
+# violations to instead return "unimplemented":
+#    https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+# This library returns the correct code, which (for now) is interpreted
+# as a failure by the conformance suite.
+**/unary-ok-but-no-response
+**/unary-multiple-responses


### PR DESCRIPTION
The table in the [docs for gRPC status codes](https://grpc.github.io/grpc/core/md_doc_statuscodes.html) indicates that a "cardinality violation" -- when a stream is expected to have exactly one message and instead has zero or multiple -- should result in an "unimplemented" error code, both from clients upon observing a malformed response stream and from servers upon observing a malformed request stream.

This library was previously using "unknown" as the error code, fashioned after grpc-go, which apparently does not correctly implement this. Further, this library only validated the response stream, in the client. With this change, it uses the correct code and also validates the request stream, in the server.
