### PR TITLE
Only send a serialized Status in the gRPC protocol if it has details

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -700,16 +700,17 @@ func TestGRPCMarshalStatusError(t *testing.T) {
 	server := memhttptest.NewServer(t, mux)
 
 	assertInternalError := func(tb testing.TB, opts ...connect.ClientOption) {
+		tb.Helper()
 		client := pingv1connect.NewPingServiceClient(server.Client(), server.URL(), opts...)
 		request := connect.NewRequest(&pingv1.FailRequest{Code: int32(connect.CodeResourceExhausted)})
 		_, err := client.Fail(context.Background(), request)
 		tb.Log(err)
-		assert.NotNil(t, err)
+		assert.NotNil(t, err, assert.Sprintf("expected an error"))
 		var connectErr *connect.Error
 		ok := errors.As(err, &connectErr)
-		assert.True(t, ok)
+		assert.True(t, ok, assert.Sprintf("expected the error to be a connect.Error"))
 		// This should be Internal, not ResourceExhausted, because we're testing when the Status object itself fails to marshal
-		assert.Equal(t, connectErr.Code(), connect.CodeInternal)
+		assert.Equal(t, connectErr.Code(), connect.CodeInternal, assert.Sprintf("expected the error code to be Internal, was %s", connectErr.Code()))
 		assert.True(
 			t,
 			strings.HasSuffix(connectErr.Message(), ": boom"),

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -838,37 +838,27 @@ func grpcContentTypeFromCodecName(web bool, name string) string {
 func grpcErrorToTrailer(trailer http.Header, protobuf Codec, err error) {
 	if err == nil {
 		setHeaderCanonical(trailer, grpcHeaderStatus, "0") // zero is the gRPC OK status
-		setHeaderCanonical(trailer, grpcHeaderMessage, "")
 		return
-	}
-	status := grpcStatusFromError(err)
-	code := strconv.Itoa(int(status.GetCode()))
-	var bin []byte
-	if len(status.Details) > 0 {
-		// attempt to serialize the Status first, so we can return an error before setting other headers
-		var binErr error
-		bin, binErr = protobuf.Marshal(status)
-		if binErr != nil {
-			setHeaderCanonical(
-				trailer,
-				grpcHeaderStatus,
-				strconv.FormatInt(int64(CodeInternal), 10 /* base */),
-			)
-			setHeaderCanonical(
-				trailer,
-				grpcHeaderMessage,
-				grpcPercentEncode(
-					fmt.Sprintf("marshal protobuf status: %v", binErr),
-				),
-			)
-			return
-		}
 	}
 	if connectErr, ok := asError(err); ok {
 		mergeHeaders(trailer, connectErr.meta)
 	}
-	setHeaderCanonical(trailer, grpcHeaderStatus, code)
-	setHeaderCanonical(trailer, grpcHeaderMessage, grpcPercentEncode(status.GetMessage()))
+	var (
+		status  = grpcStatusFromError(err)
+		code    = status.GetCode()
+		message = status.GetMessage()
+		bin     []byte
+	)
+	if len(status.Details) > 0 {
+		var binErr error
+		bin, binErr = protobuf.Marshal(status)
+		if binErr != nil {
+			code = int32(CodeInternal)
+			message = fmt.Sprintf("marshal protobuf status: %v", binErr)
+		}
+	}
+	setHeaderCanonical(trailer, grpcHeaderStatus, strconv.Itoa(int(code)))
+	setHeaderCanonical(trailer, grpcHeaderMessage, grpcPercentEncode(message))
 	if len(bin) > 0 {
 		setHeaderCanonical(trailer, grpcHeaderDetails, EncodeBinaryHeader(bin))
 	}


### PR DESCRIPTION
Currently, in the gRPC protocol, Connect will always serialize a `Status` proto and return it in the `Grpc-Status-Details-Bin` header. This differs from the [grpc-go](https://github.com/grpc/grpc-go/blob/master/internal/transport/handler_server.go#L247-L256) behavior, which is to only emit that header if the `Status` has a non-empty `Details` list. The remaining properties of `Status` (`message` and `code`) are still returned via dedicated headers, so returning the encoded `Status` message is redundant.

This PR aligns Connect's gRPC protocol with the `grpc-go` behavior, which also reduces the wire size of error responses in the common case that no details are provided. I chose not to match their behavior of `panic`ing when marshalling fails 😉 . 