### PR TITLE
Prepare for v1.16.0

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Version is the semantic version of the connect module.
-const Version = "1.16.0-dev"
+const Version = "1.16.0"
 
 // These constants are used in compile-time handshakes with connect's generated
 // code.


### PR DESCRIPTION
Below are draft release notes for this release.

----

# v1.16.0

This release is mostly bug fixes but also reconciles connect-go with recent updates to the specification regarding mapping of RPC error codes to/from HTTP status codes (see [connectrpc RFC 003](https://github.com/connectrpc/connectrpc.com/pull/148))

## What's Changed
### Other changes
* Revise RPC error code <-> HTTP status code mappings per latest changes to spec by @jhump in #706
### Enhancements
* Only send a grpc-status-details-bin trailer in the gRPC protocol if the error has details by @bhollis in #713
### Bugfixes
* Fix `ErrorWriter IsSupported` check to report false on ambiguous content-type and options indicate connect protocol version header is required by @emcfarlane in #700
* In Connect unary protocol, fallback to code based on HTTP status if unable to deserialize code from JSON body by @jhump in #702
* Fix `ErrorWriter` to recognize protocols, even if content-type indicates unrecognized codec by @emcfarlane in #701
* Fix some places in the framework that weren't correctly recognizing and returning context-based error code (e.g. "canceled" or "deadline_exceeded") by @jhump in #709
* Use "unimplemented" code for stream cardinality violations by @jhump in #712
* Restrict which metadata in an error can be propagated into response metadata by @emcfarlane in #711

## New Contributors
* @bhollis made their first contribution in #713

**Full Changelog**: https://github.com/connectrpc/connect-go/compare/v1.15.0...v1.16.0