### PR TITLE
Fix multiple header writes for connect unary on error

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -431,9 +431,10 @@ func receiveUnaryMessage[T any](conn receiveConn, initializer maybeInitializer, 
 	if err := initializer.maybe(conn.Spec(), &msg2); err != nil {
 		return nil, err
 	}
-	if err := conn.Receive(&msg2); err == nil {
-		return nil, NewError(CodeUnimplemented, fmt.Errorf("unary %s has multiple messages", what))
-	} else if err != nil && !errors.Is(err, io.EOF) {
+	if err := conn.Receive(&msg2); !errors.Is(err, io.EOF) {
+		if err == nil {
+			err = NewError(CodeUnimplemented, fmt.Errorf("unary %s has multiple messages", what))
+		}
 		return nil, err
 	}
 	return &msg, nil


### PR DESCRIPTION
On error a connect unary handler will call `Close(err)` to send the final error. For non-nil errors this will always attempt to encode the header status by calling `WriteHeader`. If the body has already been written this triggers the following log via `http.Server`:
```
http: superfluous response.WriteHeader call from connectrpc.com/connect.(*connectUnaryHandlerConn).Close (protocol_connect.go:743)
```
The common case for this superfluous log is when a message send is interrupted, due to a context cancel or other write error, and the error is then attempting to re-encode the headers and body.

This PR now moves the `wroteBody` check to a `wroteHeader` check on the unmarshaller. When any payload is sent, including a nil field for header only, we now stop attempting to encode any following errors, as it would be superfluous.