### PR TITLE
Prepare for v1.16.1

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Version is the semantic version of the connect module.
-const Version = "1.17.0-dev"
+const Version = "1.16.1"
 
 // These constants are used in compile-time handshakes with connect's generated
 // code.


### PR DESCRIPTION
Draft release notes below.

----

# v1.16.1

This release contains a single bugfix.

## What's Changed
### Bugfixes
* Fix redundant attempts to write headers in certain error cases in Connect unary RPCs by @emcfarlane in #726

**Full Changelog**: https://github.com/connectrpc/connect-go/compare/v1.16.0...v1.16.1