### PR TITLE
Add constructors for streams

### DIFF
--- a/client.go
+++ b/client.go
@@ -133,12 +133,13 @@ func (c *Client[Req, Res]) CallUnary(ctx context.Context, request *Request[Req])
 // CallClientStream calls a client streaming procedure.
 func (c *Client[Req, Res]) CallClientStream(ctx context.Context) *ClientStreamForClient[Req, Res] {
 	if c.err != nil {
-		return &ClientStreamForClient[Req, Res]{err: c.err}
+		stream := NewClientStreamForClient[Req, Res](nil)
+		stream.err = c.err
+		return stream
 	}
-	return &ClientStreamForClient[Req, Res]{
-		conn:        c.newConn(ctx, StreamTypeClient, nil),
-		initializer: c.config.Initializer,
-	}
+	stream := NewClientStreamForClient[Req, Res](c.newConn(ctx, StreamTypeClient, nil))
+	stream.initializer = c.config.Initializer
+	return stream
 }
 
 // CallServerStream calls a server streaming procedure.
@@ -163,21 +164,21 @@ func (c *Client[Req, Res]) CallServerStream(ctx context.Context, request *Reques
 	if err := conn.CloseRequest(); err != nil {
 		return nil, err
 	}
-	return &ServerStreamForClient[Res]{
-		conn:        conn,
-		initializer: c.config.Initializer,
-	}, nil
+	stream := NewServerStreamForClient[Res](conn)
+	stream.initializer = c.config.Initializer
+	return stream, nil
 }
 
 // CallBidiStream calls a bidirectional streaming procedure.
 func (c *Client[Req, Res]) CallBidiStream(ctx context.Context) *BidiStreamForClient[Req, Res] {
 	if c.err != nil {
-		return &BidiStreamForClient[Req, Res]{err: c.err}
+		stream := NewBidiStreamForClient[Req, Res](nil)
+		stream.err = c.err
+		return stream
 	}
-	return &BidiStreamForClient[Req, Res]{
-		conn:        c.newConn(ctx, StreamTypeBidi, nil),
-		initializer: c.config.Initializer,
-	}
+	stream := NewBidiStreamForClient[Req, Res](c.newConn(ctx, StreamTypeBidi, nil))
+	stream.initializer = c.config.Initializer
+	return stream
 }
 
 func (c *Client[Req, Res]) newConn(ctx context.Context, streamType StreamType, onRequestSend func(r *http.Request)) StreamingClientConn {

--- a/client_stream.go
+++ b/client_stream.go
@@ -31,6 +31,14 @@ type ClientStreamForClient[Req, Res any] struct {
 	err error
 }
 
+// NewClientStreamForClient creates a new ClientStream using the given
+// StreamingClientConn.
+func NewClientStreamForClient[Req, Res any](conn StreamingClientConn) *ClientStreamForClient[Req, Res] {
+	return &ClientStreamForClient[Req, Res]{
+		conn: conn,
+	}
+}
+
 // Spec returns the specification for the RPC.
 func (c *ClientStreamForClient[_, _]) Spec() Spec {
 	return c.conn.Spec()
@@ -105,6 +113,14 @@ type ServerStreamForClient[Res any] struct {
 	constructErr error
 	// Error from conn.Receive().
 	receiveErr error
+}
+
+// NewServerStreamForClient creates a new ServerStream using the given
+// StreamingClientConn.
+func NewServerStreamForClient[Res any](conn StreamingClientConn) *ServerStreamForClient[Res] {
+	return &ServerStreamForClient[Res]{
+		conn: conn,
+	}
 }
 
 // Receive advances the stream to the next message, which will then be
@@ -185,6 +201,14 @@ type BidiStreamForClient[Req, Res any] struct {
 	initializer maybeInitializer
 	// Error from client construction. If non-nil, return for all calls.
 	err error
+}
+
+// NewBidiStreamForClient creates a new BidiStream using the given
+// StreamingClientConn.
+func NewBidiStreamForClient[Req, Res any](conn StreamingClientConn) *BidiStreamForClient[Req, Res] {
+	return &BidiStreamForClient[Req, Res]{
+		conn: conn,
+	}
 }
 
 // Spec returns the specification for the RPC.

--- a/client_stream_test.go
+++ b/client_stream_test.go
@@ -27,7 +27,8 @@ import (
 func TestClientStreamForClient_NoPanics(t *testing.T) {
 	t.Parallel()
 	initErr := errors.New("client init failure")
-	clientStream := &ClientStreamForClient[pingv1.PingRequest, pingv1.PingResponse]{err: initErr}
+	clientStream := NewClientStreamForClient[pingv1.PingRequest, pingv1.PingResponse](nil)
+	clientStream.err = initErr
 	assert.ErrorIs(t, clientStream.Send(&pingv1.PingRequest{}), initErr)
 	verifyHeaders(t, clientStream.RequestHeader())
 	res, err := clientStream.CloseAndReceive()
@@ -41,7 +42,8 @@ func TestClientStreamForClient_NoPanics(t *testing.T) {
 func TestServerStreamForClient_NoPanics(t *testing.T) {
 	t.Parallel()
 	initErr := errors.New("client init failure")
-	serverStream := &ServerStreamForClient[pingv1.PingResponse]{constructErr: initErr}
+	serverStream := NewServerStreamForClient[pingv1.PingResponse](nil)
+	serverStream.constructErr = initErr
 	assert.ErrorIs(t, serverStream.Err(), initErr)
 	assert.ErrorIs(t, serverStream.Close(), initErr)
 	assert.NotNil(t, serverStream.Msg())
@@ -55,9 +57,9 @@ func TestServerStreamForClient_NoPanics(t *testing.T) {
 
 func TestServerStreamForClient(t *testing.T) {
 	t.Parallel()
-	stream := &ServerStreamForClient[pingv1.PingResponse]{
-		conn: &nopStreamingClientConn{},
-	}
+	stream := NewServerStreamForClient[pingv1.PingResponse](
+		&nopStreamingClientConn{},
+	)
 	// Ensure that each call to Receive allocates a new message. This helps
 	// vtprotobuf, which doesn't automatically zero messages before unmarshaling
 	// (see https://connectrpc.com/connect/issues/345), and it's also
@@ -75,7 +77,8 @@ func TestServerStreamForClient(t *testing.T) {
 func TestBidiStreamForClient_NoPanics(t *testing.T) {
 	t.Parallel()
 	initErr := errors.New("client init failure")
-	bidiStream := &BidiStreamForClient[pingv1.CumSumRequest, pingv1.CumSumResponse]{err: initErr}
+	bidiStream := NewBidiStreamForClient[pingv1.CumSumRequest, pingv1.CumSumResponse](nil)
+	bidiStream.err = initErr
 	res, err := bidiStream.Receive()
 	assert.Nil(t, res)
 	assert.ErrorIs(t, err, initErr)

--- a/handler.go
+++ b/handler.go
@@ -96,10 +96,8 @@ func NewClientStreamHandler[Req, Res any](
 	return newStreamHandler(
 		config,
 		func(ctx context.Context, conn StreamingHandlerConn) error {
-			stream := &ClientStream[Req]{
-				conn:        conn,
-				initializer: config.Initializer,
-			}
+			stream := NewClientStream[Req](conn)
+			stream.initializer = config.Initializer
 			res, err := implementation(ctx, stream)
 			if err != nil {
 				return err
@@ -130,7 +128,7 @@ func NewServerStreamHandler[Req, Res any](
 			if err != nil {
 				return err
 			}
-			return implementation(ctx, req, &ServerStream[Res]{conn: conn})
+			return implementation(ctx, req, NewServerStream[Res](conn))
 		},
 	)
 }
@@ -145,13 +143,9 @@ func NewBidiStreamHandler[Req, Res any](
 	return newStreamHandler(
 		config,
 		func(ctx context.Context, conn StreamingHandlerConn) error {
-			return implementation(
-				ctx,
-				&BidiStream[Req, Res]{
-					conn:        conn,
-					initializer: config.Initializer,
-				},
-			)
+			stream := NewBidiStream[Req, Res](conn)
+			stream.initializer = config.Initializer
+			return implementation(ctx, stream)
 		},
 	)
 }

--- a/handler_stream.go
+++ b/handler_stream.go
@@ -20,10 +20,19 @@ import (
 	"net/http"
 )
 
+// NewClientStream creates a new ClientStream using the given
+// StreamingHandlerConn.
+func NewClientStream[Req any](conn StreamingHandlerConn) *ClientStream[Req] {
+	return &ClientStream[Req]{
+		conn:        conn,
+		initializer: maybeInitializer{nil},
+	}
+}
+
 // ClientStream is the handler's view of a client streaming RPC.
 //
-// It's constructed as part of [Handler] invocation, but doesn't currently have
-// an exported constructor.
+// It's constructed as part of [Handler] invocation or it can be created using
+// the NewClientStream constructor.
 type ClientStream[Req any] struct {
 	conn        StreamingHandlerConn
 	initializer maybeInitializer
@@ -86,10 +95,18 @@ func (c *ClientStream[Req]) Conn() StreamingHandlerConn {
 	return c.conn
 }
 
-// ServerStream is the handler's view of a server streaming RPC.
+// NewServerStream creates a new ServerStream using the given
+// StreamingHandlerConn.
+func NewServerStream[Res any](conn StreamingHandlerConn) *ServerStream[Res] {
+	return &ServerStream[Res]{
+		conn: conn,
+	}
+}
+
+// ServerStream is the handler's view Client streaming RPC.
 //
-// It's constructed as part of [Handler] invocation, but doesn't currently have
-// an exported constructor.
+// It's constructed as part of [Handler] invocation or it can be created using
+// the NewServerStream constructor.
 type ServerStream[Res any] struct {
 	conn StreamingHandlerConn
 }
@@ -127,10 +144,17 @@ func (s *ServerStream[Res]) Conn() StreamingHandlerConn {
 	return s.conn
 }
 
+// NewBidiStream creates a new BidiStream using the given StreamingHandlerConn.
+func NewBidiStream[Req, Res any](conn StreamingHandlerConn) *BidiStream[Req, Res] {
+	return &BidiStream[Req, Res]{
+		conn: conn,
+	}
+}
+
 // BidiStream is the handler's view of a bidirectional streaming RPC.
 //
-// It's constructed as part of [Handler] invocation, but doesn't currently have
-// an exported constructor.
+// It's constructed as part of [Handler] invocation or it can be created using
+// the NewBidiStream constructor.
 type BidiStream[Req, Res any] struct {
 	conn        StreamingHandlerConn
 	initializer maybeInitializer

--- a/handler_stream_test.go
+++ b/handler_stream_test.go
@@ -27,9 +27,9 @@ func TestClientStreamIterator(t *testing.T) {
 	// The server's view of a client streaming RPC is an iterator. For safety,
 	// and to match grpc-go's behavior, we should allocate a new message for each
 	// iteration.
-	stream := &ClientStream[pingv1.PingRequest]{
-		conn: &nopStreamingHandlerConn{},
-	}
+	stream := NewClientStream[pingv1.PingRequest](
+		&nopStreamingHandlerConn{},
+	)
 	assert.True(t, stream.Receive())
 	first := fmt.Sprintf("%p", stream.Msg())
 	assert.True(t, stream.Receive())


### PR DESCRIPTION
Fixes #719

As discussed in #719, it is currently difficult to unit test streams because there is no way to construct one with a custom/mock implementation of `StreamingHandlerConn` (or `StreamingClientConn` for client-side streams). This PR exposes new constructors for the following types:

- `ServerStream`
- `ServerStreamForClient`
- `ClientStream`
- `ClientStreamForClient`
- `BidiStream`
- `BidiStreamForClient`

This allows us to do something along the lines of this (example using `mockgen` and `gomock`):

```go
//go:generate $GOBIN/mockgen -destination=stream_mock.go -package=mypackage connectrpc.com/connect StreamingHandlerConn

ctrl := gomock.NewController(t)
mockStreamingHandlerConn := NewMockStreamingHandlerConn(ctrl)
mockStreamingHandlerConn.EXPECT().Send(
    // My expected stream message...
).Return(nil)

// New constructor allows us to create a ServerStream using our mock
stream := connect.NewServerStream[controllerv3.Requirements](mockStreamingHandlerConn)

// call service with mock stream
err := myservice.MyRPC(context.Background(), req, stream)
```

As requested [here](https://github.com/connectrpc/connect-go/issues/719#issuecomment-2070257102), I have also updated the internal code to use these new constructors. One thing I wasn't sure about is whether or not we'd want to expose any other parameters. There are a few cases internally where a stream is constructed with additional fields (such as a `maybeInitializer`) and not being able to pass one into the constructor leads to code like this:

```go
stream := NewClientStreamForClient[Req, Res](c.newConn(ctx, StreamTypeClient, nil))
stream.initializer = c.config.Initializer
return stream
```

However, my use case doesn't have a need to pass in any other parameters and it keeps the API nice and clean without. I think the style above is fine for internal code. Happy to discuss this if there is a need for it though.