### PR TITLE
Prepare for v1.16.2

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Version is the semantic version of the connect module.
-const Version = "1.17.0-dev"
+const Version = "1.16.2"
 
 // These constants are used in compile-time handshakes with connect's generated
 // code.


### PR DESCRIPTION
There have been no real changes other than the dependency update of golang.org/x/net, to address 
[CVE-2023-45288](https://nvd.nist.gov/vuln/detail/CVE-2023-45288). So this will just be a tiny patch release.

Draft release notes:

----

This is a patch release to make sure that consuming modules won't be vulnerable to [CVE-2023-45288](https://nvd.nist.gov/vuln/detail/CVE-2023-45288).

## What's Changed
* Update the golang.org/x/net dependency to v0.23.0 in #729.

**Full Changelog**: https://github.com/connectrpc/connect-go/compare/v1.16.1...v1.16.2