### PR TITLE
Restrict handler metadata headers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -132,3 +132,6 @@ issues:
     # We want to show examples with http.Get
     - linters: [noctx]
       path: internal/memhttp/memhttp_test.go
+    # We need to initialize a map of all protocol headers
+    - linters: [gochecknoglobals]
+      path: header.go

--- a/error_writer.go
+++ b/error_writer.go
@@ -128,7 +128,7 @@ func (w *ErrorWriter) Write(response http.ResponseWriter, request *http.Request,
 
 func (w *ErrorWriter) writeConnectUnary(response http.ResponseWriter, err error) error {
 	if connectErr, ok := asError(err); ok && !connectErr.wireErr {
-		mergeMetadataHeaders(response.Header(), connectErr.meta)
+		mergeNonProtocolHeaders(response.Header(), connectErr.meta)
 	}
 	response.WriteHeader(connectCodeToHTTP(CodeOf(err)))
 	data, marshalErr := json.Marshal(newConnectWireError(err))

--- a/handler.go
+++ b/handler.go
@@ -71,8 +71,8 @@ func NewUnaryHandler[Req, Res any](
 		if err != nil {
 			return err
 		}
-		mergeMetadataHeaders(conn.ResponseHeader(), response.Header())
-		mergeMetadataHeaders(conn.ResponseTrailer(), response.Trailer())
+		mergeNonProtocolHeaders(conn.ResponseHeader(), response.Header())
+		mergeNonProtocolHeaders(conn.ResponseTrailer(), response.Trailer())
 		return conn.Send(response.Any())
 	}
 

--- a/handler.go
+++ b/handler.go
@@ -71,8 +71,8 @@ func NewUnaryHandler[Req, Res any](
 		if err != nil {
 			return err
 		}
-		mergeHeaders(conn.ResponseHeader(), response.Header())
-		mergeHeaders(conn.ResponseTrailer(), response.Trailer())
+		mergeMetadataHeaders(conn.ResponseHeader(), response.Header())
+		mergeMetadataHeaders(conn.ResponseTrailer(), response.Trailer())
 		return conn.Send(response.Any())
 	}
 

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -765,7 +765,7 @@ func (hc *connectUnaryHandlerConn) mergeResponseHeader(err error) {
 	}
 	if err != nil {
 		if connectErr, ok := asError(err); ok && !connectErr.wireErr {
-			mergeMetadataHeaders(header, connectErr.meta)
+			mergeNonProtocolHeaders(header, connectErr.meta)
 		}
 	}
 	for k, v := range hc.responseTrailer {
@@ -850,7 +850,7 @@ func (m *connectStreamingMarshaler) MarshalEndStream(err error, trailer http.Hea
 	if err != nil {
 		end.Error = newConnectWireError(err)
 		if connectErr, ok := asError(err); ok && !connectErr.wireErr {
-			mergeMetadataHeaders(end.Trailer, connectErr.meta)
+			mergeNonProtocolHeaders(end.Trailer, connectErr.meta)
 		}
 	}
 	data, marshalErr := json.Marshal(end)

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -841,7 +841,7 @@ func grpcErrorToTrailer(trailer http.Header, protobuf Codec, err error) {
 		return
 	}
 	if connectErr, ok := asError(err); ok && !connectErr.wireErr {
-		mergeMetadataHeaders(trailer, connectErr.meta)
+		mergeNonProtocolHeaders(trailer, connectErr.meta)
 	}
 	var (
 		status  = grpcStatusFromError(err)


### PR DESCRIPTION
This PR fixes the setting of protocol headers to avoid multiple value headers when providing metadata to a handler. The metadata headers are further restricted to avoid setting protocol headers like "Content-Type". This restriction allows the user to pass the response of a proxy call to a handler without having to filter the response headers themselves. This enforces the protocol headers are set by the handler and that they are unaffected from any user provided metadata.

Previously, returning the response of a client request to a handler would merge the headers together leading to protocol errors from invalid headers such as "Content-Type" having multiple values.

<!--
Before submitting your PR, please read through the contribution guide!

https://github.com/connectrpc/connect-go/blob/main/.github/CONTRIBUTING.md
-->
