### PR TITLE
Add license scan badge

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -1,3 +1,9 @@
+name: fossa
+# Prevent writing to the repository using the CI token.
+# Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
+permissions:
+  pull-requests: read
+on: [pull_request, push]
 jobs:
   fossa-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -1,0 +1,8 @@
+jobs:
+  fossa-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: fossas/fossa-action@v1
+        with:
+          api-key: ${{secrets.CONNECT_FOSSA_API_KEY}}

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ Connect
 [![Build](https://github.com/connectrpc/connect-go/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/connectrpc/connect-go/actions/workflows/ci.yaml)
 [![Report Card](https://goreportcard.com/badge/connectrpc.com/connect)](https://goreportcard.com/report/connectrpc.com/connect)
 [![GoDoc](https://pkg.go.dev/badge/connectrpc.com/connect.svg)](https://pkg.go.dev/connectrpc.com/connect)
-[![Slack](https://img.shields.io/badge/slack-buf-%23e01563)][slack]
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fconnectrpc%2Fconnect-go.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fconnectrpc%2Fconnect-go?ref=badge_shield)
+[slack]
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8972/badge)](https://www.bestpractices.dev/projects/8972)
+[![Slack](https://img.shields.io/badge/slack-buf-%23e01563)]
 
 Connect is a slim library for building browser and gRPC-compatible HTTP APIs.
 You write a short [Protocol Buffer][protobuf] schema and implement your


### PR DESCRIPTION
The CNCF requires that we adopt either Snyk or Fossa for license scanning. We tried Snyk, but it wasn't ideal - it bundles security and license scanning, and both were high-noise.

Fossa is much lower-noise. This project is already onboarded through the Fossa UI, with a clean bill of health. This PR contains some finishing touches:

- Adding a badge to the README
- Adding a license check to PRs
<!--
Before submitting your PR, please read through the contribution guide!

https://github.com/connectrpc/connect-go/blob/main/.github/CONTRIBUTING.md
-->
