### PR TITLE
Require go 1.21, test with go 1.23

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,8 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.23.x'
+        # TODO: use 1.23 once all linters support that latest Go release.
+        if: matrix.go-version == '1.22.x'
         run: make checkgenerate && make lint
   conformance:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,8 +33,7 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        # TODO: use 1.23 once all linters support that latest Go release.
-        if: matrix.go-version == '1.22.x'
+        if: matrix.go-version == '1.23.x'
         run: make checkgenerate && make lint
   conformance:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # when editing this list, also update steps and jobs below
-        go-version: [1.20.x, 1.21.x, 1.22.x]
+        go-version: [1.21.x, 1.22.x, 1.23.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -33,13 +33,13 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.22.x'
+        if: matrix.go-version == '1.23.x'
         run: make checkgenerate && make lint
   conformance:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x, 1.22.x]
+        go-version: [1.21.x, 1.22.x, 1.23.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -50,7 +50,6 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: Run Conformance Tests
-        if: matrix.go-version != '1.20.x' # Conformance requires Go 1.21+
         run: make runconformance
   slowtest:
     runs-on: ubuntu-latest
@@ -63,6 +62,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           # only the latest
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: Run Slow Tests
         run: make slowtest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-run:
-  skip-dirs-use-default: false
 linters-settings:
   errcheck:
     check-type-assertions: true
@@ -34,34 +32,27 @@ linters:
   enable-all: true
   disable:
     - cyclop            # covered by gocyclo
-    - deadcode          # abandoned
     - depguard          # unnecessary for small libraries
-    - exhaustivestruct  # replaced by exhaustruct
+    - execinquery       # deprecated since golangci v1.58
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
     - goimports         # rely on gci instead
-    - golint            # deprecated by Go team
     - gomnd             # some unnamed constants are okay
-    - ifshort           # deprecated by author
     - inamedparam       # convention is not followed
-    - interfacer        # deprecated by author
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
     - maintidx          # covered by gocyclo
-    - maligned          # readability trumps efficient struct packing
     - mnd               # status codes are clearer than constants
     - nlreturn          # generous whitespace violates house style
     - nonamedreturns    # named returns are fine; it's *bare* returns that are bad
-    - nosnakecase       # deprecated in https://github.com/golangci/golangci-lint/pull/3065
     - protogetter       # too many false positives
-    - scopelint         # deprecated by author
-    - structcheck       # abandoned
     - testpackage       # internal tests are fine
-    - varcheck          # abandoned
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
 issues:
+  exclude-dirs-use-default: false
+
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.0
 
 $(BIN)/protoc-gen-go: Makefile go.mod
 	@mkdir -p $(@D)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module connectrpc.com/connect
 
-go 1.20
+go 1.21
 
 retract (
 	v1.10.0 // module cache poisoned, use v1.10.1

--- a/option.go
+++ b/option.go
@@ -237,8 +237,8 @@ func WithCodec(codec Codec) Option {
 // The default minimum is zero. Setting a minimum compression threshold may
 // improve overall performance, because the CPU cost of compressing very small
 // messages usually isn't worth the small reduction in network I/O.
-func WithCompressMinBytes(min int) Option {
-	return &compressMinBytesOption{Min: min}
+func WithCompressMinBytes(minBytes int) Option {
+	return &compressMinBytesOption{Min: minBytes}
 }
 
 // WithReadMaxBytes limits the performance impact of pathologically large
@@ -254,8 +254,8 @@ func WithCompressMinBytes(min int) Option {
 // HTTP request stream (rather than the per-message size). Connect handles
 // [http.MaxBytesError] specially, so clients still receive errors with the
 // appropriate error code and informative messages.
-func WithReadMaxBytes(max int) Option {
-	return &readMaxBytesOption{Max: max}
+func WithReadMaxBytes(maxBytes int) Option {
+	return &readMaxBytesOption{Max: maxBytes}
 }
 
 // WithSendMaxBytes prevents sending messages too large for the client/handler
@@ -266,8 +266,8 @@ func WithReadMaxBytes(max int) Option {
 //
 // Setting WithSendMaxBytes to zero allows any message size. Both clients and
 // handlers default to allowing any message size.
-func WithSendMaxBytes(max int) Option {
-	return &sendMaxBytesOption{Max: max}
+func WithSendMaxBytes(maxBytes int) Option {
+	return &sendMaxBytesOption{Max: maxBytes}
 }
 
 // WithIdempotency declares the idempotency of the procedure. This can determine


### PR DESCRIPTION
Now that go 1.23 is out, we can update this repo to no longer support go 1.20.