### PR TITLE
Fix error message about content-types

### DIFF
--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -168,6 +168,8 @@ func (d *duplexHTTPCall) CloseWrite() error {
 	// response to read from.
 	if d.requestSent.CompareAndSwap(false, true) {
 		go d.makeRequest()
+		// We never setup a request body, so it's effectively already closed.
+		// So nothing else to do.
 		return nil
 	}
 	// The user calls CloseWrite to indicate that they're done sending data. It's

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -1408,7 +1408,7 @@ func connectValidateStreamResponseContentType(requestCodecName string, streamTyp
 			CodeUnknown,
 			"invalid content-type: %q; expecting %q",
 			responseContentType,
-			connectUnaryContentTypePrefix+requestCodecName,
+			connectStreamingContentTypePrefix+requestCodecName,
 		)
 	}
 	responseCodecName := connectCodecFromContentType(


### PR DESCRIPTION
The error message had a copy+pasta bug where it was showing the wrong prefix. This resulted in possibly very confusing error message where it complained that the content-type was wrong, but then said it was expecting exactly what it actually got.