### PR TITLE
Wrap EOF error instead of replacing it

### DIFF
--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -270,8 +270,7 @@ func TestConnectionDropped(t *testing.T) {
 					}
 					err = svrStream.Err()
 				}
-				assert.NotNil(t, err)
-				if !assert.Equal(t, connect.CodeOf(err), connect.CodeUnavailable) {
+				if assert.NotNil(t, err) && !assert.Equal(t, connect.CodeOf(err), connect.CodeUnavailable) {
 					t.Logf("err = %v\n%#v", err, err)
 				}
 			})

--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -306,11 +306,7 @@ func (d *duplexHTTPCall) makeRequest() {
 	// pipe. Write's check for io.ErrClosedPipe and will convert this to io.EOF.
 	response, err := d.httpClient.Do(d.request) //nolint:bodyclose
 	if err != nil {
-		if errors.Is(err, io.EOF) {
-			// We use io.EOF as a sentinel in many places and don't want this
-			// transport error to be confused for those other situations.
-			err = io.ErrUnexpectedEOF
-		}
+		err = wrapIfEOF(err)
 		err = wrapIfContextError(err)
 		err = wrapIfLikelyH2CNotConfiguredError(d.request, err)
 		err = wrapIfLikelyWithGRPCNotUsedError(err)


### PR DESCRIPTION
This achieves the same result as #776, except it does so by wrapping the error instead of replacing it.

If this looks good, I'll merge it into #776 and then merge that PR to main. If this does not look good, I'll close it without merging and then merge #776 to main as-is.
