### PR TITLE
Prepare for v1.17.0 release

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Version is the semantic version of the connect module.
-const Version = "1.17.0-dev"
+const Version = "1.17.0"
 
 // These constants are used in compile-time handshakes with connect's generated
 // code.


### PR DESCRIPTION
Below are draft release notes for this release. I decided to make it a minor version instead of a point release because:

* Supporting editions source files (#754) could be seen as an enhancement (even though it makes no real changes to the code and doesn't add any features or new API -- it just toggles something in the code gen response to allow it).
* Updating to require Go 1.21 (#770) seems like something worthy of a minor version instead of a point release.

----

# v1.17.0

## What's Changed
### Enhancements
* Enable `protoc-gen-connect-go` usage with Protobuf source files that use Editions by @jchadwick-buf in #754
### Bugfixes
* Prevent incorrect propagation of protocol-specific metadata by @emcfarlane in #748
* Fix error message about unexpected content-type by @jhump in #775
* Calls should return "unavailable" instead of "unimplemented" or "unknown" when the transport fails to produce an HTTP response and returns `io.EOF` errors by @jhump in #776
### Other changes
* Now requires Go 1.21 by @jhump in #770

## New Contributors
* @perezd made their first contribution in #739
 
**Full Changelog**: https://github.com/connectrpc/connect-go/compare/v1.16.2...v1.17.0