### PR TITLE
Make stream client closers non-blocking

### DIFF
--- a/client_stream.go
+++ b/client_stream.go
@@ -163,6 +163,10 @@ func (s *ServerStreamForClient[Res]) ResponseTrailer() http.Header {
 }
 
 // Close the receive side of the stream.
+//
+// Close is non-blocking. To gracefully close the stream and allow for
+// connection resuse ensure all messages have been received before calling
+// Close. All messages are received when Receive returns false.
 func (s *ServerStreamForClient[Res]) Close() error {
 	if s.constructErr != nil {
 		return s.constructErr
@@ -251,6 +255,11 @@ func (b *BidiStreamForClient[Req, Res]) Receive() (*Res, error) {
 }
 
 // CloseResponse closes the receive side of the stream.
+//
+// CloseResponse is non-blocking. To gracefully close the stream and allow for
+// connection resuse ensure all messages have been received before calling
+// CloseResponse. All messages are received when Receive returns an error
+// wrapping [io.EOF].
 func (b *BidiStreamForClient[Req, Res]) CloseResponse() error {
 	if b.err != nil {
 		return b.err

--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -239,13 +239,7 @@ func (d *duplexHTTPCall) CloseRead() error {
 	if d.response == nil {
 		return nil
 	}
-	_, err := discard(d.response.Body)
-	closeErr := d.response.Body.Close()
-	if err == nil ||
-		errors.Is(err, context.Canceled) ||
-		errors.Is(err, context.DeadlineExceeded) {
-		err = closeErr
-	}
+	err := d.response.Body.Close()
 	err = wrapIfContextDone(d.ctx, err)
 	return wrapIfRSTError(err)
 }


### PR DESCRIPTION
This updates the behavior of the streaming client methods `BidiStreamForClient.CloseResponse` and `ServerStreamForClient.Close` to be non-blocking, aligning it with the standard behavior of `net/http`'s `Request.Body` closure.

Previously, the implementation used a graceful, blocking closure that fully read from the stream before closing. This allows for reuse of the underlying TCP connection. However, this behavior could lead to unexpected client hangs, as users may not anticipate blocking on close.

To address this, the closers no longer drain the stream. Documentation has been updated to clarify the behavior and provide users a workaround to keep the optimization by calling receive until the stream is drained. This avoids unexpected blocking behavior in client applications.

Fixes #789