### PR TITLE
Remove reader allocation for compressors pools

### DIFF
--- a/compression.go
+++ b/compression.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"io"
 	"math"
+	"net/http"
 	"strings"
 	"sync"
 )
@@ -147,7 +148,7 @@ func (c *compressionPool) putDecompressor(decompressor Decompressor) error {
 	// know the compression format, we can't provide a valid header. Since we
 	// also reset the decompressor when it's pulled out of the pool, we can
 	// ignore errors here.
-	_ = decompressor.Reset(strings.NewReader(""))
+	_ = decompressor.Reset(http.NoBody)
 	c.decompressors.Put(decompressor)
 	return nil
 }


### PR DESCRIPTION
Small optimization to avoid allocating a new reader when recycling compressors by using `http.NoBody`.
