### PR TITLE
Add docs for StreamingHandlerConn concurrency constraints

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -89,12 +89,17 @@ func (s StreamType) String() string {
 //
 // StreamingHandlerConn implementations do not need to be safe for concurrent use.
 type StreamingHandlerConn interface {
+	// Spec and Peer must be safe to call concurrently with all other methods.
 	Spec() Spec
 	Peer() Peer
 
+	// Receive, and RequestHeader may race with each other, but must be
+	// safe to call concurrently with all other methods.
 	Receive(any) error
 	RequestHeader() http.Header
 
+	// Send, ResponseHeader, and ResponseTrailer may race with each other,
+	// but must be safe to call concurrently with all other methods.
 	Send(any) error
 	ResponseHeader() http.Header
 	ResponseTrailer() http.Header


### PR DESCRIPTION
Adds docs for the StreamingHandlerConn interface stating the constraints for concurrent use. The grouped methods are similar to the clients StreamingClientConn interface.

Edit: moving to draft to clarify behaviour.
