### PR TITLE
Add limited support for bidi streams over HTTP/1

### DIFF
--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -332,16 +332,9 @@ func (d *duplexHTTPCall) makeRequest() {
 		_ = d.CloseWrite()
 		return
 	}
-	if (d.streamType&StreamTypeBidi) == StreamTypeBidi && response.ProtoMajor < 2 {
-		// If we somehow dialed an HTTP/1.x server, fail with an explicit message
-		// rather than returning a more cryptic error later on.
-		d.responseErr = errorf(
-			CodeUnimplemented,
-			"response from %v is HTTP/%d.%d: bidi streams require at least HTTP/2",
-			d.request.URL,
-			response.ProtoMajor,
-			response.ProtoMinor,
-		)
+	if response.ProtoMajor < 2 {
+		// HTTP/1.x doesn't support bidirectional streaming. We need to close the
+		// write side of the stream before we can read from the response body.
 		_ = d.CloseWrite()
 	}
 }

--- a/handler.go
+++ b/handler.go
@@ -161,15 +161,6 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 	// EOF: the stream we construct later on already does that, and we only
 	// return early when dealing with misbehaving clients. In those cases, it's
 	// okay if we can't re-use the connection.
-	isBidi := (h.spec.StreamType & StreamTypeBidi) == StreamTypeBidi
-	if isBidi && request.ProtoMajor < 2 {
-		// Clients coded to expect full-duplex connections may hang if they've
-		// mistakenly negotiated HTTP/1.1. To unblock them, we must close the
-		// underlying TCP connection.
-		responseWriter.Header().Set("Connection", "close")
-		responseWriter.WriteHeader(http.StatusHTTPVersionNotSupported)
-		return
-	}
 
 	protocolHandlers := h.protocolHandlers[request.Method]
 	if len(protocolHandlers) == 0 {


### PR DESCRIPTION
This adds limited support for bidirectional streams over HTTP/1.x transports. It removes the explicit error response which disabled this behavior based on the protocol stream type. Bidi streams may now be used in half-duplex mode. This does not enable full-duplex streaming. All requests must be sent before responses are received.

This removes the workarounds in the conformance test suite to fake a HTTP/2 request/response in order to allow for this behavior. In doing so a deadlock on writing to a closed requests was fixed. See https://github.com/connectrpc/conformance/pull/942.

Edit: Will look at improving the error messages on trying to do a full-duplex stream over HTTP/1.x. It should fail noting this isn't possible. 

<!--
Before submitting your PR, please read through the contribution guide!

https://github.com/connectrpc/connect-go/blob/main/.github/CONTRIBUTING.md
-->
