### PR TITLE
test: cancelling a stream

### DIFF
--- a/connect_ext_close_test.go
+++ b/connect_ext_close_test.go
@@ -13,6 +13,7 @@ import (
 	"connectrpc.com/connect/internal/gen/connect/ping/v1/pingv1connect"
 )
 
+// See https://github.com/connectrpc/connect-go/pull/801 for further context
 func TestClientStream_CancelContext(t *testing.T) {
 	t.Run("HTTP2 disabled", func(t *testing.T) {
 		t.Parallel()
@@ -81,10 +82,7 @@ func testClientStream_CancelContext(t *testing.T, enableHTTP2 bool) {
 		t.Error("stream was not done receiving within 1s")
 	}
 
-	// The connection appears to not be properly closed with http2_enabled:
-	// The following line takes 10 seconds and outputs:
-	// httptest.Server blocked in Close after 5 seconds, waiting for connections:
-	//  *tls.Conn 0x0000 127.0.0.1:**** in state active
+	// ensure the connection gets closed quickly
 	startClosing := time.Now()
 	s.Close()
 	assert.True(t, time.Since(startClosing) < time.Second, assert.Sprintf("server.Close took too long: %s", time.Since(startClosing)))

--- a/connect_ext_close_test.go
+++ b/connect_ext_close_test.go
@@ -15,9 +15,11 @@ import (
 
 func TestClientStream_CancelContext(t *testing.T) {
 	t.Run("HTTP2 disabled", func(t *testing.T) {
+		t.Parallel()
 		testClientStream_CancelContext(t, false)
 	})
 	t.Run("HTTP2 enabled", func(t *testing.T) {
+		t.Parallel()
 		testClientStream_CancelContext(t, true)
 	})
 }
@@ -59,8 +61,8 @@ func testClientStream_CancelContext(t *testing.T, enableHTTP2 bool) {
 
 	closed := make(chan struct{})
 	go func() {
-		t.Log("will close stream")
-		t.Log("stream closed:", stream.Close()) // usually something like "read tcp 127.0.0.1:XXX->127.0.0.1:XXX: use of closed network connection"
+		// close stream
+		assert.Nil(t, stream.Close())
 		close(closed)
 	}()
 
@@ -79,8 +81,8 @@ func testClientStream_CancelContext(t *testing.T, enableHTTP2 bool) {
 		t.Error("stream was not done receiving within 1s")
 	}
 
-	// The connection appears to not be properly closed:
-	// The following line takes 5 seconds and outputs:
+	// The connection appears to not be properly closed with http2_enabled:
+	// The following line takes 10 seconds and outputs:
 	// httptest.Server blocked in Close after 5 seconds, waiting for connections:
 	//  *tls.Conn 0x0000 127.0.0.1:**** in state active
 	startClosing := time.Now()

--- a/connect_ext_close_test.go
+++ b/connect_ext_close_test.go
@@ -1,0 +1,81 @@
+package connect_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	connect "connectrpc.com/connect"
+	"connectrpc.com/connect/internal/assert"
+	pingv1 "connectrpc.com/connect/internal/gen/connect/ping/v1"
+	"connectrpc.com/connect/internal/gen/connect/ping/v1/pingv1connect"
+)
+
+func TestClientStream_CancelContext(t *testing.T) {
+	t.Run("HTTP2 disabled", func(t *testing.T) {
+		testClientStream_CancelContext(t, false)
+	})
+	t.Run("HTTP2 enabled", func(t *testing.T) {
+		testClientStream_CancelContext(t, true)
+	})
+}
+
+func testClientStream_CancelContext(t *testing.T, enableHTTP2 bool) {
+	mux := http.NewServeMux()
+	mux.Handle(pingv1connect.NewPingServiceHandler(pingServer{
+		delayCountUp: 3 * time.Second,
+	}))
+
+	s := httptest.NewUnstartedServer(mux)
+	s.EnableHTTP2 = enableHTTP2
+	s.StartTLS()
+
+	client := pingv1connect.NewPingServiceClient(
+		s.Client(),
+		s.URL,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := client.CountUp(ctx, connect.NewRequest(&pingv1.CountUpRequest{
+		Number: 100,
+	}))
+
+	assert.Nil(t, err)
+
+	msg := make(chan int64)
+	go func() {
+		for stream.Receive() {
+			select {
+			case msg <- stream.Msg().Number:
+			default:
+			}
+		}
+		close(msg)
+	}()
+
+	assert.Equal(t, <-msg, 1)
+
+	closed := make(chan struct{})
+	go func() {
+		t.Log("will close stream")
+		t.Log("stream closed:", stream.Close())
+		close(closed)
+	}()
+
+	time.Sleep(10 * time.Millisecond) // delay to ensure that stream.Close has already been called
+	cancel()
+
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Error("stream was not closed within 1s")
+	}
+	select {
+	case _, ok := <-msg:
+		assert.False(t, ok)
+	case <-time.After(time.Second):
+		t.Error("stream was not done receiving within 1s")
+	}
+}

--- a/connect_ext_close_test.go
+++ b/connect_ext_close_test.go
@@ -60,7 +60,7 @@ func testClientStream_CancelContext(t *testing.T, enableHTTP2 bool) {
 	closed := make(chan struct{})
 	go func() {
 		t.Log("will close stream")
-		t.Log("stream closed:", stream.Close())
+		t.Log("stream closed:", stream.Close()) // usually something like "read tcp 127.0.0.1:XXX->127.0.0.1:XXX: use of closed network connection"
 		close(closed)
 	}()
 
@@ -83,5 +83,7 @@ func testClientStream_CancelContext(t *testing.T, enableHTTP2 bool) {
 	// The following line takes 5 seconds and outputs:
 	// httptest.Server blocked in Close after 5 seconds, waiting for connections:
 	//  *tls.Conn 0x0000 127.0.0.1:**** in state active
+	startClosing := time.Now()
 	s.Close()
+	assert.True(t, time.Since(startClosing) < time.Second, assert.Sprintf("server.Close took too long: %s", time.Since(startClosing)))
 }

--- a/connect_ext_close_test.go
+++ b/connect_ext_close_test.go
@@ -78,4 +78,10 @@ func testClientStream_CancelContext(t *testing.T, enableHTTP2 bool) {
 	case <-time.After(time.Second):
 		t.Error("stream was not done receiving within 1s")
 	}
+
+	// The connection appears to not be properly closed:
+	// The following line takes 5 seconds and outputs:
+	// httptest.Server blocked in Close after 5 seconds, waiting for connections:
+	//  *tls.Conn 0x0000 127.0.0.1:**** in state active
+	s.Close()
 }

--- a/connect_ext_close_test.go
+++ b/connect_ext_close_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021-2024 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package connect_test
 
 import (
@@ -73,7 +87,7 @@ func testClientStream_CancelContext(t *testing.T, enableHTTP2 bool) {
 	select {
 	case <-closed:
 	case <-time.After(time.Second):
-		t.Error("stream was not closed within 1s")
+		t.Error("stream was not closed within 1s of context cancellation")
 	}
 	select {
 	case _, ok := <-msg:
@@ -82,7 +96,7 @@ func testClientStream_CancelContext(t *testing.T, enableHTTP2 bool) {
 		t.Error("stream was not done receiving within 1s")
 	}
 
-	// ensure the connection gets closed quickly
+	// ensure the server does not hang for too long when closing
 	startClosing := time.Now()
 	s.Close()
 	assert.True(t, time.Since(startClosing) < time.Second, assert.Sprintf("server.Close took too long: %s", time.Since(startClosing)))

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -2914,7 +2914,11 @@ func (p pingServer) CountUp(
 		if err := stream.Send(&pingv1.CountUpResponse{Number: i}); err != nil {
 			return err
 		}
-		time.Sleep(p.delayCountUp)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(p.delayCountUp):
+		}
 	}
 	return nil
 }

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -2813,6 +2813,7 @@ type pingServer struct {
 
 	checkMetadata       bool
 	includeErrorDetails bool
+	delayCountUp        time.Duration
 }
 
 func (p pingServer) Ping(ctx context.Context, request *connect.Request[pingv1.PingRequest]) (*connect.Response[pingv1.PingResponse], error) {
@@ -2913,6 +2914,7 @@ func (p pingServer) CountUp(
 		if err := stream.Send(&pingv1.CountUpResponse{Number: i}); err != nil {
 			return err
 		}
+		time.Sleep(p.delayCountUp)
 	}
 	return nil
 }


### PR DESCRIPTION
Related to #789 and #791.

According to @jhump in https://github.com/connectrpc/connect-go/issues/789#issuecomment-2413899375
> If you want to abort the RPC before the server's response has been received, one must cancel the context.Context that was used to create the RPC. Cancelling an RPC this way will trigger a cancellation error in the server.

However when http2 is enabled, cancelling the context does not suffice to unblock `stream.Close()`.

The `stream.Close` calltree indicates that it is blocked in `discard(reader io.Reader)` (add a `-timeout 500ms` to `go test` to get a dump).

When http2 is not enabled, it seems to behave correctly.

#791 would fix this.