### PR TITLE
We don't support 1.20 anymore, so stop testing with it in Windows

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x, 1.22.x]
+        go-version: [1.21.x, 1.22.x, 1.23.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ lintfix: $(BIN)/golangci-lint $(BIN)/buf ## Automatically fix some lint errors
 .PHONY: generate
 generate: $(BIN)/buf $(BIN)/protoc-gen-go $(BIN)/protoc-gen-connect-go $(BIN)/license-header ## Regenerate code and licenses
 	go mod tidy
+	cd internal/conformance && go mod tidy
 	rm -rf internal/gen
 	PATH="$(abspath $(BIN))" buf generate
 	( cd cmd/protoc-gen-connect-go; ./generate.sh )

--- a/internal/conformance/go.mod
+++ b/internal/conformance/go.mod
@@ -1,7 +1,8 @@
 module connectrpc.com/connect/internal/conformance
 
-go 1.21
-toolchain go1.22.5
+go 1.22
+
+toolchain go1.23.5
 
 require connectrpc.com/conformance v1.0.4
 


### PR DESCRIPTION
We just missed this when we updated to Go 1.21. It was passing anyway because releases prior to 1.21 are lenient -- in that they will try to build and run code even if the `go` directive in `go.mod` indicates a newer version. And since none of the code was actually relying on new APIs, features, or semantics in Go 1.21, the tests would pass.

This also commits a change that `go mod tidy` keeps wanting to make to `internal/conformance/go.mod`. Our "checkgenerate" make target was previously catching these only in the main module. This PR includes a small change to `Makefile` so that this kind of thing can be caught in the conformance module, too.