### PR TITLE
Fix typo in Go docs for example buf configuration

### DIFF
--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -52,7 +52,7 @@
 //	    out: gen
 //	  - local: protoc-gen-connect-go
 //	    out: gen
-//	    opts: package_suffix
+//	    opt: package_suffix
 //
 // This will generate output to:
 //


### PR DESCRIPTION
Change `opts` to `opt` in documentation for buf v2 schema.

<!--
Before submitting your PR, please read through the contribution guide!

https://github.com/connectrpc/connect-go/blob/main/.github/CONTRIBUTING.md
-->
Fix https://github.com/connectrpc/connect-go/issues/815