### PR TITLE
Upgrade min Go v1.22 and tooling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # when editing this list, also update steps and jobs below
-        go-version: [1.21.x, 1.22.x, 1.23.x]
+        go-version: [1.22.x, 1.23.x, 1.24.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -33,13 +33,13 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.23.x'
+        if: matrix.go-version == '1.24.x'
         run: make checkgenerate && make lint
   conformance:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x, 1.23.x]
+        go-version: [1.22.x, 1.23.x, 1.24.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -62,6 +62,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           # only the latest
-          go-version: 1.23.x
+          go-version: 1.24.x
       - name: Run Slow Tests
         run: make slowtest

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x, 1.23.x]
+        go-version: [1.22.x, 1.23.x, 1.24.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -124,3 +124,7 @@ issues:
     # Allow Code pointer receiver for UnmarshalText method
     - linters: [recvcheck]
       path: code.go
+    # Avoid false positives for int overflow in tests
+    - linters: [gosec]
+      text: "^G115: integer overflow conversion"
+      path: ".*_test.go"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,12 +31,10 @@ linters:
   disable:
     - cyclop            # covered by gocyclo
     - depguard          # unnecessary for small libraries
-    - execinquery       # deprecated since golangci v1.58
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
     - goimports         # rely on gci instead
-    - gomnd             # some unnamed constants are okay
     - inamedparam       # convention is not followed
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
@@ -45,6 +43,7 @@ linters:
     - nlreturn          # generous whitespace violates house style
     - nonamedreturns    # named returns are fine; it's *bare* returns that are bad
     - protogetter       # too many false positives
+    - tenv              # replaced by usetesting
     - testpackage       # internal tests are fine
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
@@ -122,3 +121,6 @@ issues:
     # Allow non-canonical headers in tests
     - linters: [canonicalheader]
       path: '.*_test.go'
+    # Allow Code pointer receiver for UnmarshalText method
+    - linters: [recvcheck]
+      path: code.go

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ export PATH := $(BIN):$(PATH)
 export GOBIN := $(abspath $(BIN))
 COPYRIGHT_YEARS := 2021-2024
 LICENSE_IGNORE := --ignore /testdata/
-BUF_VERSION := 1.47.2
+BUF_VERSION := 1.50.1
 
 .PHONY: help
 help: ## Describe useful make targets
@@ -112,7 +112,7 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.7
 
 $(BIN)/protoc-gen-go: Makefile go.mod
 	@mkdir -p $(@D)

--- a/buf.yaml
+++ b/buf.yaml
@@ -3,7 +3,7 @@ modules:
   - path: internal/proto
 lint:
   use:
-    - DEFAULT
+    - STANDARD
   ignore:
     - internal/proto/connectext/grpc/health/v1/health.proto
     - internal/proto/connectext/grpc/reflection/v1alpha/reflection.proto

--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -578,7 +578,7 @@ func TestClientDeadlineHandling(t *testing.T) {
 				case 1:
 					procedure = pingv1connect.PingServiceSumProcedure
 					stream := client.Sum(ctx)
-					for i := 0; i < 3; i++ {
+					for range 3 {
 						errs.sendErr = stream.Send(addUnrecognizedBytes(&pingv1.SumRequest{Number: 1}, extraField))
 						if errs.sendErr != nil {
 							break
@@ -598,7 +598,7 @@ func TestClientDeadlineHandling(t *testing.T) {
 				case 3:
 					procedure = pingv1connect.PingServiceCumSumProcedure
 					stream := client.CumSum(ctx)
-					for i := 0; i < 3; i++ {
+					for range 3 {
 						errs.sendErr = stream.Send(addUnrecognizedBytes(&pingv1.CumSumRequest{Number: 1}, extraField))
 						_, errs.recvErr = stream.Receive()
 						if errs.recvErr != nil {
@@ -627,8 +627,7 @@ func testClientDeadlineBruteForceLoop(
 	var rpcCount atomic.Int64
 
 	var wg sync.WaitGroup
-	for goroutine := 0; goroutine < parallelism; goroutine++ {
-		goroutine := goroutine
+	for goroutine := range parallelism {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -640,7 +639,7 @@ func testClientDeadlineBruteForceLoop(
 			const maxTimeout = 2 * time.Millisecond
 			for {
 				for timeout := minTimeout; timeout <= maxTimeout; timeout += 10 * time.Microsecond {
-					for i := 0; i < iterationsPerDeadline; i++ {
+					for range iterationsPerDeadline {
 						if testContext.Err() != nil {
 							return
 						}

--- a/code.go
+++ b/code.go
@@ -207,8 +207,8 @@ func (c *Code) UnmarshalText(data []byte) error {
 	// UnmarshalText.
 	if strings.HasPrefix(dataStr, "code_") {
 		dataStr = strings.TrimPrefix(dataStr, "code_")
-		code, err := strconv.ParseInt(dataStr, 10 /* base */, 64 /* bitsize */)
-		if err == nil && (code < int64(minCode) || code > int64(maxCode)) {
+		code, err := strconv.ParseUint(dataStr, 10 /* base */, 32 /* bitsize */)
+		if err == nil && (code < uint64(minCode) || code > uint64(maxCode)) {
 			*c = Code(code)
 			return nil
 		}

--- a/codec_test.go
+++ b/codec_test.go
@@ -100,7 +100,7 @@ func TestStableCodec(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				roundtripProto := &structpb.Struct{}
 				err = codec.Unmarshal(want, roundtripProto)
 				if err != nil {

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/rand"
+	rand "math/rand/v2"
 	"net"
 	"net/http"
 	"runtime"
@@ -515,7 +515,7 @@ func TestConcurrentStreams(t *testing.T) {
 			sum := client.CumSum(context.Background())
 			start.Wait()
 			for range 100 {
-				num := rand.Int63n(1000) //nolint: gosec
+				num := rand.Int64N(1000) //nolint:gosec // No need for cryptographically secure random numbers.
 				total += num
 				if err := sum.Send(&pingv1.CumSumRequest{Number: num}); err != nil {
 					t.Errorf("failed to send request: %v", err)

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -125,7 +125,7 @@ func TestServer(t *testing.T) {
 			stream := client.Sum(context.Background())
 			stream.RequestHeader().Set(clientHeader, headerValue)
 			for i := range upTo {
-				err := stream.Send(&pingv1.SumRequest{Number: int64(i)})
+				err := stream.Send(&pingv1.SumRequest{Number: int64(i + 1)})
 				assert.Nil(t, err, assert.Sprintf("send %d", i))
 			}
 			response, err := stream.CloseAndReceive()
@@ -158,7 +158,7 @@ func TestServer(t *testing.T) {
 			got := make([]int64, 0, upTo)
 			expect := make([]int64, 0, upTo)
 			for i := range upTo {
-				expect = append(expect, int64(i))
+				expect = append(expect, int64(i+1))
 			}
 			request := connect.NewRequest(&pingv1.CountUpRequest{Number: upTo})
 			request.Header().Set(clientHeader, headerValue)
@@ -2911,7 +2911,7 @@ func (p pingServer) CountUp(
 	stream.ResponseHeader().Set(handlerHeader, headerValue)
 	stream.ResponseTrailer().Set(handlerTrailer, trailerValue)
 	for i := range request.Msg.GetNumber() {
-		if err := stream.Send(&pingv1.CountUpResponse{Number: i}); err != nil {
+		if err := stream.Send(&pingv1.CountUpResponse{Number: i + 1}); err != nil {
 			return err
 		}
 	}

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -2032,7 +2032,7 @@ func TestGRPCErrorMetadataIsTrailersOnly(t *testing.T) {
 	// Manually construct a gRPC prefix. Data is uncompressed, so the first byte
 	// is 0. Set the last 4 bytes to the message length.
 	var prefix [5]byte
-	binary.BigEndian.PutUint32(prefix[1:5], uint32(len(protoBytes))) //nolint:gosec // Safe for this test.
+	binary.BigEndian.PutUint32(prefix[1:5], uint32(len(protoBytes)))
 	body := append(prefix[:], protoBytes...)
 	// Manually send off a gRPC request.
 	req, err := http.NewRequestWithContext(
@@ -2253,7 +2253,7 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 
 	head := [5]byte{}
 	payload := []byte(`{"number": 42}`)
-	binary.BigEndian.PutUint32(head[1:], uint32(len(payload))) //nolint:gosec // Safe for this test.
+	binary.BigEndian.PutUint32(head[1:], uint32(len(payload)))
 	testcases := []struct {
 		name       string
 		handler    http.HandlerFunc
@@ -2329,7 +2329,7 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 			assert.Nil(t, err)
 			endStream := "grpc-message: foo\r\n"
 			var length [4]byte
-			binary.BigEndian.PutUint32(length[:], uint32(len(endStream))) //nolint:gosec // Safe for this test.
+			binary.BigEndian.PutUint32(length[:], uint32(len(endStream)))
 			_, err = responseWriter.Write(length[:])
 			assert.Nil(t, err)
 			_, err = responseWriter.Write([]byte(endStream))
@@ -2446,7 +2446,7 @@ func TestStreamUnexpectedEOF(t *testing.T) {
 			assert.Nil(t, trailer.Write(&buf))
 			var head [5]byte
 			head[0] = 1 << 7
-			binary.BigEndian.PutUint32(head[1:], uint32(buf.Len())) //nolint:gosec // Safe for this test.
+			binary.BigEndian.PutUint32(head[1:], uint32(buf.Len()))
 			_, err = responseWriter.Write(head[:])
 			assert.Nil(t, err)
 			_, err = responseWriter.Write(buf.Bytes())
@@ -2845,7 +2845,7 @@ func (p pingServer) Fail(ctx context.Context, request *connect.Request[pingv1.Fa
 		return nil, connect.NewError(connect.CodeInternal, errors.New("no peer protocol"))
 	}
 	err := connect.NewError(
-		connect.Code(request.Msg.GetCode()), //nolint:gosec // No information loss.
+		connect.Code(request.Msg.GetCode()),
 		errors.New(errorMessage),
 	)
 	err.Meta().Set(handlerHeader, headerValue)

--- a/duplex_http_call_test.go
+++ b/duplex_http_call_test.go
@@ -102,7 +102,7 @@ func TestHTTPCallGetBody(t *testing.T) {
 	}
 	for i, gotGetBody := 0, false; !gotGetBody; i++ {
 		errs := make([]chan error, numWorkers)
-		for range numWorkers {
+		for i := range numWorkers {
 			errs[i] = make(chan error, 1)
 			workChan <- work{size: 512, errs: errs[i]}
 		}

--- a/duplex_http_call_test.go
+++ b/duplex_http_call_test.go
@@ -92,7 +92,7 @@ func TestHTTPCallGetBody(t *testing.T) {
 	workChan := make(chan work)
 	wg := sync.WaitGroup{}
 	wg.Add(numWorkers)
-	for i := 0; i < numWorkers; i++ {
+	for range numWorkers {
 		go func() {
 			for work := range workChan {
 				work.errs <- caller(work.size)
@@ -102,7 +102,7 @@ func TestHTTPCallGetBody(t *testing.T) {
 	}
 	for i, gotGetBody := 0, false; !gotGetBody; i++ {
 		errs := make([]chan error, numWorkers)
-		for i := 0; i < numWorkers; i++ {
+		for range numWorkers {
 			errs[i] = make(chan error, 1)
 			workChan <- work{size: 512, errs: errs[i]}
 		}

--- a/envelope.go
+++ b/envelope.go
@@ -19,7 +19,9 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
+	"math"
 )
 
 // flagEnvelopeCompressed indicates that the data is compressed. It has the
@@ -55,7 +57,10 @@ func (e *envelope) IsSet(flag uint8) bool {
 // Read implements [io.Reader].
 func (e *envelope) Read(data []byte) (readN int, err error) {
 	if e.offset < 5 {
-		prefix := makeEnvelopePrefix(e.Flags, e.Data.Len())
+		prefix, err := makeEnvelopePrefix(e.Flags, e.Data.Len())
+		if err != nil {
+			return 0, err
+		}
 		readN = copy(data, prefix[e.offset:])
 		e.offset += int64(readN)
 		if e.offset < 5 {
@@ -75,7 +80,10 @@ func (e *envelope) Read(data []byte) (readN int, err error) {
 // WriteTo implements [io.WriterTo].
 func (e *envelope) WriteTo(dst io.Writer) (wroteN int64, err error) {
 	if e.offset < 5 {
-		prefix := makeEnvelopePrefix(e.Flags, e.Data.Len())
+		prefix, err := makeEnvelopePrefix(e.Flags, e.Data.Len())
+		if err != nil {
+			return 0, err
+		}
 		prefixN, err := dst.Write(prefix[e.offset:])
 		e.offset += int64(prefixN)
 		wroteN += int64(prefixN)
@@ -366,9 +374,12 @@ func (r *envelopeReader) Read(env *envelope) *Error {
 	return nil
 }
 
-func makeEnvelopePrefix(flags uint8, size int) [5]byte {
+func makeEnvelopePrefix(flags uint8, size int) ([5]byte, error) {
+	if size < 0 || size > math.MaxUint32 {
+		return [5]byte{}, fmt.Errorf("connect.makeEnvelopePrefix: size %d out of bounds", size)
+	}
 	prefix := [5]byte{}
 	prefix[0] = flags
 	binary.BigEndian.PutUint32(prefix[1:5], uint32(size))
-	return prefix
+	return prefix, nil
 }

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -26,7 +26,8 @@ import (
 func TestEnvelope(t *testing.T) {
 	t.Parallel()
 	payload := []byte(`{"number": 42}`)
-	head := makeEnvelopePrefix(0, len(payload))
+	head, err := makeEnvelopePrefix(0, len(payload))
+	assert.Nil(t, err)
 	buf := &bytes.Buffer{}
 	buf.Write(head[:])
 	buf.Write(payload)

--- a/error_test.go
+++ b/error_test.go
@@ -142,7 +142,6 @@ func TestTypeNameFromURL(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, typeNameFromURL(testCase.url), testCase.typeName)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module connectrpc.com/connect
 
-go 1.21
+go 1.22
 
 retract (
 	v1.10.0 // module cache poisoned, use v1.10.1

--- a/handler_ext_test.go
+++ b/handler_ext_test.go
@@ -257,7 +257,7 @@ func TestHandlerMaliciousPrefix(t *testing.T) {
 	)
 	var wg sync.WaitGroup
 	start := make(chan struct{})
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		body := make([]byte, 16)
 		// Envelope prefix indicates a large payload which we're not actually
 		// sending.

--- a/internal/memhttp/memhttp_test.go
+++ b/internal/memhttp/memhttp_test.go
@@ -48,7 +48,7 @@ func TestServerTransport(t *testing.T) {
 		t.Run(fmt.Sprintf("%T", transport), func(t *testing.T) {
 			t.Parallel()
 			var wg sync.WaitGroup
-			for i := 0; i < concurrency; i++ {
+			for range concurrency {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()

--- a/protocol_connect_test.go
+++ b/protocol_connect_test.go
@@ -55,7 +55,6 @@ func TestConnectErrorDetailMarshaling(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -259,7 +258,6 @@ func TestConnectValidateUnaryResponseContentType(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		httpMethod := http.MethodPost
 		if testCase.get {
 			httpMethod = http.MethodGet
@@ -346,7 +344,6 @@ func TestConnectValidateStreamResponseContentType(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		testCaseName := fmt.Sprintf("%s->%s", testCase.codecName, testCase.responseContentType)
 		t.Run(testCaseName, func(t *testing.T) {
 			t.Parallel()

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -894,7 +894,7 @@ func grpcStatusFromError(err error) *statusv1.Status {
 //	https://datatracker.ietf.org/doc/html/rfc3986#section-2.1
 func grpcPercentEncode(msg string) string {
 	var hexCount int
-	for i := range msg {
+	for i := range len(msg) {
 		if grpcShouldEscape(msg[i]) {
 			hexCount++
 		}
@@ -905,7 +905,7 @@ func grpcPercentEncode(msg string) string {
 	// We need to escape some characters, so we'll need to allocate a new string.
 	var out strings.Builder
 	out.Grow(len(msg) + 2*hexCount)
-	for i := range msg {
+	for i := range len(msg) {
 		switch char := msg[i]; {
 		case grpcShouldEscape(char):
 			out.WriteByte('%')

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -729,7 +729,7 @@ func grpcErrorFromTrailer(protobuf Codec, trailer http.Header) *Error {
 			retErr.details = append(retErr.details, &ErrorDetail{pbAny: d})
 		}
 		// Prefer the Protobuf-encoded data to the headers (grpc-go does this too).
-		retErr.code = Code(status.GetCode())
+		retErr.code = Code(status.GetCode()) //nolint:gosec // No information loss
 		retErr.err = errors.New(status.GetMessage())
 	}
 
@@ -873,7 +873,7 @@ func grpcStatusFromError(err error) *statusv1.Status {
 		Message: err.Error(),
 	}
 	if connectErr, ok := asError(err); ok {
-		status.Code = int32(connectErr.Code())
+		status.Code = int32(connectErr.Code()) //nolint:gosec // No information loss
 		status.Message = connectErr.Message()
 		status.Details = connectErr.detailsAsAny()
 	}
@@ -894,7 +894,7 @@ func grpcStatusFromError(err error) *statusv1.Status {
 //	https://datatracker.ietf.org/doc/html/rfc3986#section-2.1
 func grpcPercentEncode(msg string) string {
 	var hexCount int
-	for i := 0; i < len(msg); i++ {
+	for i := range msg {
 		if grpcShouldEscape(msg[i]) {
 			hexCount++
 		}
@@ -905,7 +905,7 @@ func grpcPercentEncode(msg string) string {
 	// We need to escape some characters, so we'll need to allocate a new string.
 	var out strings.Builder
 	out.Grow(len(msg) + 2*hexCount)
-	for i := 0; i < len(msg); i++ {
+	for i := range msg {
 		switch char := msg[i]; {
 		case grpcShouldEscape(char):
 			out.WriteByte('%')

--- a/protocol_grpc_test.go
+++ b/protocol_grpc_test.go
@@ -200,7 +200,7 @@ func BenchmarkGRPCPercentEncoding(b *testing.B) {
 	input := "Hello, 世界"
 	want := "Hello, %E4%B8%96%E7%95%8C"
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		got := grpcPercentEncode(input)
 		if got != want {
 			b.Fatalf("grpcPercentEncode(%q) = %s, want %s", input, got, want)
@@ -212,7 +212,7 @@ func BenchmarkGRPCPercentDecoding(b *testing.B) {
 	input := "Hello, %E4%B8%96%E7%95%8C"
 	want := "Hello, 世界"
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		got, _ := grpcPercentDecode(input)
 		if got != want {
 			b.Fatalf("grpcPercentDecode(%q) = %s, want %s", input, got, want)
@@ -224,7 +224,7 @@ func BenchmarkGRPCTimeoutEncoding(b *testing.B) {
 	input := time.Second * 45
 	want := "45000000u"
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		got := grpcEncodeTimeout(input)
 		if got != want {
 			b.Fatalf("grpcEncodeTimeout(%q) = %s, want %s", input, got, want)
@@ -365,7 +365,6 @@ func TestGRPCValidateResponseContentType(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		protocol := ProtocolGRPC
 		if testCase.web {
 			protocol = ProtocolGRPCWeb

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -33,7 +33,6 @@ func TestCanonicalizeContentType(t *testing.T) {
 		{name: "no parameters should be normalized", arg: "APPLICATION/json;  ", want: "application/json"},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, canonicalizeContentType(tt.arg), tt.want)
@@ -43,21 +42,21 @@ func TestCanonicalizeContentType(t *testing.T) {
 
 func BenchmarkCanonicalizeContentType(b *testing.B) {
 	b.Run("simple", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = canonicalizeContentType("application/json")
 		}
 		b.ReportAllocs()
 	})
 
 	b.Run("with charset", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = canonicalizeContentType("application/json; charset=utf-8")
 		}
 		b.ReportAllocs()
 	})
 
 	b.Run("with other param", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = canonicalizeContentType("application/json; foo=utf-8")
 		}
 		b.ReportAllocs()


### PR DESCRIPTION
This upgrades the min Go support to v1.22 and the tools buf and golangci-lint, fixing any found lint issues.

<!--
Before submitting your PR, please read through the contribution guide!

https://github.com/connectrpc/connect-go/blob/main/.github/CONTRIBUTING.md
-->
