### PR TITLE
Fix trailing-slash redirection

### DIFF
--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -473,7 +473,7 @@ func generateServerConstructor(g *protogen.GeneratedFile, file *protogen.File, s
 		g.P(connectPackage.Ident("WithHandlerOptions"), "(opts...),")
 		g.P(")")
 	}
-	g.P(`return "/`, service.Desc.FullName(), `/", `, httpPackage.Ident("HandlerFunc"), `(func(w `, httpPackage.Ident("ResponseWriter"), `, r *`, httpPackage.Ident("Request"), `){`)
+	g.P(`return "/`, service.Desc.FullName(), `/{method}", `, httpPackage.Ident("HandlerFunc"), `(func(w `, httpPackage.Ident("ResponseWriter"), `, r *`, httpPackage.Ident("Request"), `){`)
 	g.P("switch r.URL.Path {")
 	for _, method := range service.Methods {
 		g.P("case ", procedureConstName(method), ":")

--- a/cmd/protoc-gen-connect-go/testdata/defaultpackage/defaultpackageconnect/defaultpackage.connect.go
+++ b/cmd/protoc-gen-connect-go/testdata/defaultpackage/defaultpackageconnect/defaultpackage.connect.go
@@ -104,7 +104,7 @@ func NewTestServiceHandler(svc TestServiceHandler, opts ...connect.HandlerOption
 		connect.WithSchema(testServiceMethods.ByName("Method")),
 		connect.WithHandlerOptions(opts...),
 	)
-	return "/connect.test.default_package.TestService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return "/connect.test.default_package.TestService/{method}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case TestServiceMethodProcedure:
 			testServiceMethodHandler.ServeHTTP(w, r)

--- a/cmd/protoc-gen-connect-go/testdata/diffpackage/diffpackagediff/diffpackage.connect.go
+++ b/cmd/protoc-gen-connect-go/testdata/diffpackage/diffpackagediff/diffpackage.connect.go
@@ -105,7 +105,7 @@ func NewTestServiceHandler(svc TestServiceHandler, opts ...connect.HandlerOption
 		connect.WithSchema(testServiceMethods.ByName("Method")),
 		connect.WithHandlerOptions(opts...),
 	)
-	return "/connect.test.different_package.TestService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return "/connect.test.different_package.TestService/{method}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case TestServiceMethodProcedure:
 			testServiceMethodHandler.ServeHTTP(w, r)

--- a/cmd/protoc-gen-connect-go/testdata/samepackage/samepackage.connect.go
+++ b/cmd/protoc-gen-connect-go/testdata/samepackage/samepackage.connect.go
@@ -103,7 +103,7 @@ func NewTestServiceHandler(svc TestServiceHandler, opts ...connect.HandlerOption
 		connect.WithSchema(testServiceMethods.ByName("Method")),
 		connect.WithHandlerOptions(opts...),
 	)
-	return "/connect.test.same_package.TestService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return "/connect.test.same_package.TestService/{method}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case TestServiceMethodProcedure:
 			testServiceMethodHandler.ServeHTTP(w, r)

--- a/cmd/protoc-gen-connect-go/testdata/v1beta1service/v1beta1service.connect.go
+++ b/cmd/protoc-gen-connect-go/testdata/v1beta1service/v1beta1service.connect.go
@@ -105,7 +105,7 @@ func NewExampleV1BetaHandler(svc ExampleV1BetaHandler, opts ...connect.HandlerOp
 		connect.WithSchema(exampleV1BetaMethods.ByName("Method")),
 		connect.WithHandlerOptions(opts...),
 	)
-	return "/example.ExampleV1beta/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return "/example.ExampleV1beta/{method}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case ExampleV1BetaMethodProcedure:
 			exampleV1BetaMethodHandler.ServeHTTP(w, r)

--- a/internal/gen/connect/collide/v1/collidev1connect/collide.connect.go
+++ b/internal/gen/connect/collide/v1/collidev1connect/collide.connect.go
@@ -104,7 +104,7 @@ func NewCollideServiceHandler(svc CollideServiceHandler, opts ...connect.Handler
 		connect.WithSchema(collideServiceMethods.ByName("Import")),
 		connect.WithHandlerOptions(opts...),
 	)
-	return "/connect.collide.v1.CollideService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return "/connect.collide.v1.CollideService/{method}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case CollideServiceImportProcedure:
 			collideServiceImportHandler.ServeHTTP(w, r)

--- a/internal/gen/connect/import/v1/importv1connect/import.connect.go
+++ b/internal/gen/connect/import/v1/importv1connect/import.connect.go
@@ -65,7 +65,7 @@ type ImportServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewImportServiceHandler(svc ImportServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
-	return "/connect.import.v1.ImportService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return "/connect.import.v1.ImportService/{method}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		default:
 			http.NotFound(w, r)

--- a/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
@@ -209,7 +209,7 @@ func NewPingServiceHandler(svc PingServiceHandler, opts ...connect.HandlerOption
 		connect.WithSchema(pingServiceMethods.ByName("CumSum")),
 		connect.WithHandlerOptions(opts...),
 	)
-	return "/connect.ping.v1.PingService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return "/connect.ping.v1.PingService/{method}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case PingServicePingProcedure:
 			pingServicePingHandler.ServeHTTP(w, r)


### PR DESCRIPTION
This change uses URL parameters (introduced in Go 1.22) to avoid [trailing-slash redirection](https://pkg.go.dev/net/http#hdr-Trailing_slash_redirection-ServeMux) which is getting flagged by our security tooling as an inappropriate response from an API.

Fixes #834.