### PR TITLE
Support latest two versions of Go instead of latest three

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,11 +12,15 @@ permissions:
   contents: read
 jobs:
   ci:
+    name: ci (go:${{ matrix.go-version.name }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # when editing this list, also update steps and jobs below
-        go-version: [1.23.x, 1.24.x]
+        go-version:
+        - name: latest
+          version: 1.24.x
+        - name: previous
+          version: 1.23.x
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -25,7 +29,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ matrix.go-version.version }}
       - name: Unit Test
         run: make shorttest
       - name: Lint
@@ -33,13 +37,18 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.24.x'
+        if: matrix.go-version.name == 'latest'
         run: make checkgenerate && make lint
   conformance:
+    name: ci (go:${{ matrix.go-version.name }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x, 1.24.x]
+        go-version:
+        - name: latest
+          version: 1.24.x
+        - name: previous
+          version: 1.23.x
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -48,7 +57,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ matrix.go-version.version }}
       - name: Run Conformance Tests
         run: make runconformance
   slowtest:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         if: matrix.go-version.name == 'latest'
         run: make checkgenerate && make lint
   conformance:
-    name: ci (go:${{ matrix.go-version.name }})
+    name: conformance (go:${{ matrix.go-version.name }})
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # when editing this list, also update steps and jobs below
-        go-version: [1.22.x, 1.23.x, 1.24.x]
+        go-version: [1.23.x, 1.24.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x, 1.24.x]
+        go-version: [1.23.x, 1.24.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -12,10 +12,14 @@ permissions:
   contents: read
 jobs:
   ci:
+    name: ci (go:${{ matrix.go-version.name }})
     runs-on: windows-latest
     strategy:
-      matrix:
-        go-version: [1.23.x, 1.24.x]
+      go-version:
+        - name: latest
+          version: 1.24.x
+        - name: previous
+          version: 1.23.x
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -24,7 +28,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ matrix.go-version.version }}
       - name: Test
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ configuring timeouts, connection pools, observability, and h2c.
 
 This module is stable. It supports:
 
-* The three most recent major releases of Go. Keep in mind that [only the last
-  two releases receive security patches][go-support-policy].
+* The two most recent major releases of Go (the same versions of Go that continue
+  to [receive security patches][go-support-policy]).
 * [APIv2] of Protocol Buffers in Go (`google.golang.org/protobuf`).
 
 Within those parameters, `connect` follows semantic versioning. We will

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module connectrpc.com/connect
 
-go 1.22
+go 1.23.0
 
 retract (
 	v1.10.0 // module cache poisoned, use v1.10.1

--- a/internal/conformance/go.mod
+++ b/internal/conformance/go.mod
@@ -1,8 +1,6 @@
 module connectrpc.com/connect/internal/conformance
 
-go 1.22
-
-toolchain go1.23.5
+go 1.23.0
 
 require connectrpc.com/conformance v1.0.4
 


### PR DESCRIPTION
This changes the support posture for Go runtimes to mirror the Go SDK itself and to also mirror [recent changes](https://github.com/googleapis/google-cloud-go/commit/8a68e456d089e946bec93ffad6edb35eb0d29f93#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R23-R28) in the Google Cloud APIs for Go (starting January 1st, 2025).

The AWS APIs for Go still maintain support for three versions of Go, but they do have [a caveat](https://github.com/aws/aws-sdk-go-v2?tab=readme-ov-file#go-version-support-policy):
> **AWS reserves the right to drop support for unsupported Go versions earlier to address critical security issues.**

This caveat is topical because the reason I'm proposing changing to supporting only two versions is spurred by a security fix: [v0.36.0 of golang.org/x/net](https://github.com/connectrpc/connect-go/pull/830) requires [Go 1.23](https://github.com/golang/net/blob/v0.36.0/go.mod#L3).

I'm opening this PR to gather feedback:
* What do other maintainers think of this change?
* If we deem this change appropriate, is there anything else we should do to communicate the change to users?
* Should we instead take a softer stance, a la the AWS support policy? (In this case, we'd still document support for three versions, but we could technically go ahead and merge the above fix and _temporarily_ only support two versions.)

The impact of this change is fairly broad and will also end up requiring a similar change to seven other Go repos in the connectrpc organization, since they all depend on this one (basically all but otelconnect-go, which already is documented as supporting only two versions of Go).