### PR TITLE
Rename windows CI jobs

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 jobs:
   ci:
-    name: ci (go:${{ matrix.go-version.name }})
+    name: windows (go:${{ matrix.go-version.name }})
     runs-on: windows-latest
     strategy:
       matrix:


### PR DESCRIPTION
The "required checks" just match by name, and don't include the name of the enclosing workflow. To make sure each required check is enforced distinctly and correctly, these names should differ from the jobs in the "ci.yaml" workflow.