### PR TITLE
Codemod to update syntax

### DIFF
--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -715,7 +715,8 @@ type notModifiedPingServer struct {
 
 func (s *notModifiedPingServer) Ping(
 	_ context.Context,
-	req *connect.Request[pingv1.PingRequest]) (*connect.Response[pingv1.PingResponse], error) {
+	req *connect.Request[pingv1.PingRequest],
+) (*connect.Response[pingv1.PingResponse], error) {
 	if req.HTTPMethod() == http.MethodGet && req.Header().Get("If-None-Match") == s.etag {
 		return nil, connect.NewNotModifiedError(http.Header{"Etag": []string{s.etag}})
 	}

--- a/codec_test.go
+++ b/codec_test.go
@@ -27,8 +27,8 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func convertMapToInterface(stringMap map[string]string) map[string]interface{} {
-	interfaceMap := make(map[string]interface{})
+func convertMapToInterface(stringMap map[string]string) map[string]any {
+	interfaceMap := make(map[string]any)
 	for key, value := range stringMap {
 		interfaceMap[key] = value
 	}

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	rand "math/rand/v2"
 	"net"
@@ -2100,9 +2101,7 @@ func TestConnectProtocolHeaderRequired(t *testing.T) {
 		)
 		assert.Nil(t, err)
 		req.Header.Set("Content-Type", "application/json")
-		for k, v := range tcase.headers {
-			req.Header[k] = v
-		}
+		maps.Copy(req.Header, tcase.headers)
 		response, err := server.Client().Do(req)
 		assert.Nil(t, err)
 		assert.Nil(t, response.Body.Close())

--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -363,12 +363,15 @@ var _ messagePayload = nopPayload{}
 func (nopPayload) Read([]byte) (int, error) {
 	return 0, io.EOF
 }
+
 func (nopPayload) WriteTo(io.Writer) (int64, error) {
 	return 0, nil
 }
+
 func (nopPayload) Seek(int64, int) (int64, error) {
 	return 0, nil
 }
+
 func (nopPayload) Len() int {
 	return 0
 }

--- a/header.go
+++ b/header.go
@@ -19,33 +19,31 @@ import (
 	"net/http"
 )
 
-var (
-	//nolint:gochecknoglobals
-	protocolHeaders = map[string]struct{}{
-		// HTTP headers.
-		headerContentType:     {},
-		headerContentLength:   {},
-		headerContentEncoding: {},
-		headerHost:            {},
-		headerUserAgent:       {},
-		headerTrailer:         {},
-		headerDate:            {},
-		// Connect headers.
-		connectUnaryHeaderAcceptCompression:     {},
-		connectUnaryTrailerPrefix:               {},
-		connectStreamingHeaderCompression:       {},
-		connectStreamingHeaderAcceptCompression: {},
-		connectHeaderTimeout:                    {},
-		connectHeaderProtocolVersion:            {},
-		// gRPC headers.
-		grpcHeaderCompression:       {},
-		grpcHeaderAcceptCompression: {},
-		grpcHeaderTimeout:           {},
-		grpcHeaderStatus:            {},
-		grpcHeaderMessage:           {},
-		grpcHeaderDetails:           {},
-	}
-)
+//nolint:gochecknoglobals
+var protocolHeaders = map[string]struct{}{
+	// HTTP headers.
+	headerContentType:     {},
+	headerContentLength:   {},
+	headerContentEncoding: {},
+	headerHost:            {},
+	headerUserAgent:       {},
+	headerTrailer:         {},
+	headerDate:            {},
+	// Connect headers.
+	connectUnaryHeaderAcceptCompression:     {},
+	connectUnaryTrailerPrefix:               {},
+	connectStreamingHeaderCompression:       {},
+	connectStreamingHeaderAcceptCompression: {},
+	connectHeaderTimeout:                    {},
+	connectHeaderProtocolVersion:            {},
+	// gRPC headers.
+	grpcHeaderCompression:       {},
+	grpcHeaderAcceptCompression: {},
+	grpcHeaderTimeout:           {},
+	grpcHeaderStatus:            {},
+	grpcHeaderMessage:           {},
+	grpcHeaderDetails:           {},
+}
 
 // EncodeBinaryHeader base64-encodes the data. It always emits unpadded values.
 //

--- a/internal/memhttp/listener.go
+++ b/internal/memhttp/listener.go
@@ -21,9 +21,7 @@ import (
 	"sync"
 )
 
-var (
-	errListenerClosed = errors.New("listener closed")
-)
+var errListenerClosed = errors.New("listener closed")
 
 // memoryListener is a net.Listener that listens on an in memory network.
 type memoryListener struct {

--- a/protocol_grpc_test.go
+++ b/protocol_grpc_test.go
@@ -196,6 +196,7 @@ func TestGRPCWebTrailerMarshalling(t *testing.T) {
 	marshalled := responseWriter.Body.String()
 	assert.Equal(t, marshalled, "grpc-message: Foo\r\ngrpc-status: 0\r\nuser-provided: bar\r\n")
 }
+
 func BenchmarkGRPCPercentEncoding(b *testing.B) {
 	input := "Hello, 世界"
 	want := "Hello, %E4%B8%96%E7%95%8C"


### PR DESCRIPTION
This is the result of running:

```
$ go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...
$ gofumpt -w .
````

Basically no substantial change except one update to use `maps.Copy`.

I'd personally recommend this as a nice habit to get into when we bump the minimum versions. I've found this picking up some good changes. It has even auto converted some calls like `strings.Split` into `strings.SplitSeq` in some of my codebases when applicable.