### PR TITLE
WIP: Prototype simple flag

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -10,5 +10,5 @@ plugins:
     opt: paths=source_relative
   - local: protoc-gen-connect-go
     out: internal/gen
-    opt: paths=source_relative
+    opt: paths=source_relative,simple=true
 clean: true

--- a/client.go
+++ b/client.go
@@ -130,6 +130,15 @@ func (c *Client[Req, Res]) CallUnary(ctx context.Context, request *Request[Req])
 	return c.callUnary(ctx, request)
 }
 
+// CallUnarySimple calls a request-response procedure.
+func (c *Client[Req, Res]) CallUnarySimple(ctx context.Context, requestMsg *Req) (*Res, error) {
+	response, err := c.CallUnary(ctx, requestFromContext(ctx, requestMsg))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
+}
+
 // CallClientStream calls a client streaming procedure.
 func (c *Client[Req, Res]) CallClientStream(ctx context.Context) *ClientStreamForClient[Req, Res] {
 	if c.err != nil {
@@ -167,6 +176,11 @@ func (c *Client[Req, Res]) CallServerStream(ctx context.Context, request *Reques
 		conn:        conn,
 		initializer: c.config.Initializer,
 	}, nil
+}
+
+// CallServerStreamSimple calls a server streaming procedure.
+func (c *Client[Req, Res]) CallServerStreamSimple(ctx context.Context, requestMsg *Req) (*ServerStreamForClient[Res], error) {
+	return c.CallServerStream(ctx, requestFromContext(ctx, requestMsg))
 }
 
 // CallBidiStream calls a bidirectional streaming procedure.

--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -90,6 +90,7 @@ const (
 	generatedFilenameExtension = ".connect.go"
 	defaultPackageSuffix       = "connect"
 	packageSuffixFlagName      = "package_suffix"
+	simpleFlagName             = "simple"
 
 	usage = "See https://connectrpc.com/docs/go/getting-started to learn how to use this plugin.\n\nFlags:\n  -h, --help\tPrint this help and exit.\n      --version\tPrint the version and exit."
 
@@ -120,6 +121,11 @@ func main() {
 		defaultPackageSuffix,
 		"Generate files into a sub-package of the package containing the base .pb.go files using the given suffix. An empty suffix denotes to generate into the same package as the base pb.go files.",
 	)
+	simple := flagSet.Bool(
+		simpleFlagName,
+		false,
+		"Generate clients and servers without *connect.Requests and *connect.Responses.",
+	)
 	protogen.Options{
 		ParamFunc: flagSet.Set,
 	}.Run(
@@ -129,7 +135,7 @@ func main() {
 			plugin.SupportedEditionsMaximum = descriptorpb.Edition_EDITION_2023
 			for _, file := range plugin.Files {
 				if file.Generate {
-					generate(plugin, file, *packageSuffix)
+					generate(plugin, file, *packageSuffix, *simple)
 				}
 			}
 			return nil
@@ -137,7 +143,7 @@ func main() {
 	)
 }
 
-func generate(plugin *protogen.Plugin, file *protogen.File, packageSuffix string) {
+func generate(plugin *protogen.Plugin, file *protogen.File, packageSuffix string, simple bool) {
 	if len(file.Services) == 0 {
 		return
 	}
@@ -170,7 +176,7 @@ func generate(plugin *protogen.Plugin, file *protogen.File, packageSuffix string
 	generatePreamble(generatedFile, file)
 	generateServiceNameConstants(generatedFile, file.Services)
 	for _, service := range file.Services {
-		generateService(generatedFile, file, service)
+		generateService(generatedFile, file, service, simple)
 	}
 }
 
@@ -265,16 +271,16 @@ func generateServiceMethodsVar(g *protogen.GeneratedFile, file *protogen.File, s
 		`.Services().ByName("`, service.Desc.Name(), `").Methods()`)
 }
 
-func generateService(g *protogen.GeneratedFile, file *protogen.File, service *protogen.Service) {
+func generateService(g *protogen.GeneratedFile, file *protogen.File, service *protogen.Service, simple bool) {
 	names := newNames(service)
-	generateClientInterface(g, service, names)
-	generateClientImplementation(g, file, service, names)
-	generateServerInterface(g, service, names)
-	generateServerConstructor(g, file, service, names)
-	generateUnimplementedServerImplementation(g, service, names)
+	generateClientInterface(g, service, names, simple)
+	generateClientImplementation(g, file, service, names, simple)
+	generateServerInterface(g, service, names, simple)
+	generateServerConstructor(g, file, service, names, simple)
+	generateUnimplementedServerImplementation(g, service, names, simple)
 }
 
-func generateClientInterface(g *protogen.GeneratedFile, service *protogen.Service, names names) {
+func generateClientInterface(g *protogen.GeneratedFile, service *protogen.Service, names names, simple bool) {
 	wrapComments(g, names.Client, " is a client for the ", service.Desc.FullName(), " service.")
 	if isDeprecatedService(service) {
 		g.P("//")
@@ -289,13 +295,13 @@ func generateClientInterface(g *protogen.GeneratedFile, service *protogen.Servic
 			method.Comments.Leading,
 			isDeprecatedMethod(method),
 		)
-		g.P(clientSignature(g, method, false /* named */))
+		g.P(clientSignature(g, method, false /* named */, simple))
 	}
 	g.P("}")
 	g.P()
 }
 
-func generateClientImplementation(g *protogen.GeneratedFile, file *protogen.File, service *protogen.Service, names names) {
+func generateClientImplementation(g *protogen.GeneratedFile, file *protogen.File, service *protogen.Service, names names, simple bool) {
 	clientOption := connectPackage.Ident("ClientOption")
 
 	// Client constructor.
@@ -352,11 +358,11 @@ func generateClientImplementation(g *protogen.GeneratedFile, file *protogen.File
 	g.P("}")
 	g.P()
 	for _, method := range service.Methods {
-		generateClientMethod(g, method, names)
+		generateClientMethod(g, method, names, simple)
 	}
 }
 
-func generateClientMethod(g *protogen.GeneratedFile, method *protogen.Method, names names) {
+func generateClientMethod(g *protogen.GeneratedFile, method *protogen.Method, names names, simple bool) {
 	receiver := names.ClientImpl
 	isStreamingClient := method.Desc.IsStreamingClient()
 	isStreamingServer := method.Desc.IsStreamingServer()
@@ -365,23 +371,31 @@ func generateClientMethod(g *protogen.GeneratedFile, method *protogen.Method, na
 		g.P("//")
 		deprecated(g)
 	}
-	g.P("func (c *", receiver, ") ", clientSignature(g, method, true /* named */), " {")
+	g.P("func (c *", receiver, ") ", clientSignature(g, method, true /* named */, simple), " {")
 
 	switch {
 	case isStreamingClient && !isStreamingServer:
 		g.P("return c.", unexport(method.GoName), ".CallClientStream(ctx)")
 	case !isStreamingClient && isStreamingServer:
-		g.P("return c.", unexport(method.GoName), ".CallServerStream(ctx, req)")
+		if simple {
+			g.P("return c.", unexport(method.GoName), ".CallServerStreamSimple(ctx, req)")
+		} else {
+			g.P("return c.", unexport(method.GoName), ".CallServerStream(ctx, req)")
+		}
 	case isStreamingClient && isStreamingServer:
 		g.P("return c.", unexport(method.GoName), ".CallBidiStream(ctx)")
 	default:
-		g.P("return c.", unexport(method.GoName), ".CallUnary(ctx, req)")
+		if simple {
+			g.P("return c.", unexport(method.GoName), ".CallUnarySimple(ctx, req)")
+		} else {
+			g.P("return c.", unexport(method.GoName), ".CallUnary(ctx, req)")
+		}
 	}
 	g.P("}")
 	g.P()
 }
 
-func clientSignature(g *protogen.GeneratedFile, method *protogen.Method, named bool) string {
+func clientSignature(g *protogen.GeneratedFile, method *protogen.Method, named bool, simple bool) string {
 	reqName := "req"
 	ctxName := "ctx"
 	if !named {
@@ -400,6 +414,14 @@ func clientSignature(g *protogen.GeneratedFile, method *protogen.Method, named b
 			"[" + g.QualifiedGoIdent(method.Input.GoIdent) + ", " + g.QualifiedGoIdent(method.Output.GoIdent) + "]"
 	}
 	if method.Desc.IsStreamingServer() {
+		if simple {
+			return method.GoName + "(" + ctxName + " " + g.QualifiedGoIdent(contextPackage.Ident("Context")) +
+				", " + reqName + " *" +
+				g.QualifiedGoIdent(method.Input.GoIdent) + ") " +
+				"(*" + g.QualifiedGoIdent(connectPackage.Ident("ServerStreamForClient")) +
+				"[" + g.QualifiedGoIdent(method.Output.GoIdent) + "]" +
+				", error)"
+		}
 		return method.GoName + "(" + ctxName + " " + g.QualifiedGoIdent(contextPackage.Ident("Context")) +
 			", " + reqName + " *" + g.QualifiedGoIdent(connectPackage.Ident("Request")) + "[" +
 			g.QualifiedGoIdent(method.Input.GoIdent) + "]) " +
@@ -408,10 +430,10 @@ func clientSignature(g *protogen.GeneratedFile, method *protogen.Method, named b
 			", error)"
 	}
 	// unary; symmetric so we can re-use server templating
-	return method.GoName + serverSignatureParams(g, method, named)
+	return method.GoName + serverSignatureParams(g, method, named, simple)
 }
 
-func generateServerInterface(g *protogen.GeneratedFile, service *protogen.Service, names names) {
+func generateServerInterface(g *protogen.GeneratedFile, service *protogen.Service, names names, simple bool) {
 	wrapComments(g, names.Server, " is an implementation of the ", service.Desc.FullName(), " service.")
 	if isDeprecatedService(service) {
 		g.P("//")
@@ -426,13 +448,13 @@ func generateServerInterface(g *protogen.GeneratedFile, service *protogen.Servic
 			isDeprecatedMethod(method),
 		)
 		g.AnnotateSymbol(names.Server+"."+method.GoName, protogen.Annotation{Location: method.Location})
-		g.P(serverSignature(g, method))
+		g.P(serverSignature(g, method, simple))
 	}
 	g.P("}")
 	g.P()
 }
 
-func generateServerConstructor(g *protogen.GeneratedFile, file *protogen.File, service *protogen.Service, names names) {
+func generateServerConstructor(g *protogen.GeneratedFile, file *protogen.File, service *protogen.Service, names names, simple bool) {
 	wrapComments(g, names.ServerConstructor, " builds an HTTP handler from the service implementation.",
 		" It returns the path on which to mount the handler and the handler itself.")
 	g.P("//")
@@ -454,11 +476,19 @@ func generateServerConstructor(g *protogen.GeneratedFile, file *protogen.File, s
 		case isStreamingClient && !isStreamingServer:
 			g.P(procedureHandlerName(method), ` := `, connectPackage.Ident("NewClientStreamHandler"), "(")
 		case !isStreamingClient && isStreamingServer:
-			g.P(procedureHandlerName(method), ` := `, connectPackage.Ident("NewServerStreamHandler"), "(")
+			if simple {
+				g.P(procedureHandlerName(method), ` := `, connectPackage.Ident("NewServerStreamHandlerSimple"), "(")
+			} else {
+				g.P(procedureHandlerName(method), ` := `, connectPackage.Ident("NewServerStreamHandler"), "(")
+			}
 		case isStreamingClient && isStreamingServer:
 			g.P(procedureHandlerName(method), ` := `, connectPackage.Ident("NewBidiStreamHandler"), "(")
 		default:
-			g.P(procedureHandlerName(method), ` := `, connectPackage.Ident("NewUnaryHandler"), "(")
+			if simple {
+				g.P(procedureHandlerName(method), ` := `, connectPackage.Ident("NewUnaryHandlerSimple"), "(")
+			} else {
+				g.P(procedureHandlerName(method), ` := `, connectPackage.Ident("NewUnaryHandler"), "(")
+			}
 		}
 		g.P(procedureConstName(method), `,`)
 		g.P("svc.", method.GoName, ",")
@@ -487,12 +517,12 @@ func generateServerConstructor(g *protogen.GeneratedFile, file *protogen.File, s
 	g.P()
 }
 
-func generateUnimplementedServerImplementation(g *protogen.GeneratedFile, service *protogen.Service, names names) {
+func generateUnimplementedServerImplementation(g *protogen.GeneratedFile, service *protogen.Service, names names, simple bool) {
 	wrapComments(g, names.UnimplementedServer, " returns CodeUnimplemented from all methods.")
 	g.P("type ", names.UnimplementedServer, " struct {}")
 	g.P()
 	for _, method := range service.Methods {
-		g.P("func (", names.UnimplementedServer, ") ", serverSignature(g, method), "{")
+		g.P("func (", names.UnimplementedServer, ") ", serverSignature(g, method, simple), "{")
 		if method.Desc.IsStreamingServer() {
 			g.P("return ", connectPackage.Ident("NewError"), "(",
 				connectPackage.Ident("CodeUnimplemented"), ", ", errorsPackage.Ident("New"),
@@ -508,11 +538,11 @@ func generateUnimplementedServerImplementation(g *protogen.GeneratedFile, servic
 	g.P()
 }
 
-func serverSignature(g *protogen.GeneratedFile, method *protogen.Method) string {
-	return method.GoName + serverSignatureParams(g, method, false /* named */)
+func serverSignature(g *protogen.GeneratedFile, method *protogen.Method, simple bool) string {
+	return method.GoName + serverSignatureParams(g, method, false /* named */, simple)
 }
 
-func serverSignatureParams(g *protogen.GeneratedFile, method *protogen.Method, named bool) string {
+func serverSignatureParams(g *protogen.GeneratedFile, method *protogen.Method, named bool, simple bool) string {
 	ctxName := "ctx "
 	reqName := "req "
 	streamName := "stream "
@@ -535,6 +565,14 @@ func serverSignatureParams(g *protogen.GeneratedFile, method *protogen.Method, n
 	}
 	if method.Desc.IsStreamingServer() {
 		// server streaming
+		if simple {
+			return "(" + ctxName + g.QualifiedGoIdent(contextPackage.Ident("Context")) +
+				", " + reqName + " *" +
+				g.QualifiedGoIdent(method.Input.GoIdent) + ", " +
+				streamName + "*" + g.QualifiedGoIdent(connectPackage.Ident("ServerStream")) +
+				"[" + g.QualifiedGoIdent(method.Output.GoIdent) + "]" +
+				") error"
+		}
 		return "(" + ctxName + g.QualifiedGoIdent(contextPackage.Ident("Context")) +
 			", " + reqName + "*" + g.QualifiedGoIdent(connectPackage.Ident("Request")) + "[" +
 			g.QualifiedGoIdent(method.Input.GoIdent) + "], " +
@@ -543,8 +581,15 @@ func serverSignatureParams(g *protogen.GeneratedFile, method *protogen.Method, n
 			") error"
 	}
 	// unary
+	if simple {
+		return "(" + ctxName + g.QualifiedGoIdent(contextPackage.Ident("Context")) +
+			", " + reqName + " *" +
+			g.QualifiedGoIdent(method.Input.GoIdent) + ") " +
+			"(*" +
+			g.QualifiedGoIdent(method.Output.GoIdent) + ", error)"
+	}
 	return "(" + ctxName + g.QualifiedGoIdent(contextPackage.Ident("Context")) +
-		", " + reqName + "*" + g.QualifiedGoIdent(connectPackage.Ident("Request")) + "[" +
+		", " + reqName + " *" + g.QualifiedGoIdent(connectPackage.Ident("Request")) + "[" +
 		g.QualifiedGoIdent(method.Input.GoIdent) + "]) " +
 		"(*" + g.QualifiedGoIdent(connectPackage.Ident("Response")) + "[" +
 		g.QualifiedGoIdent(method.Output.GoIdent) + "], error)"

--- a/connect.go
+++ b/connect.go
@@ -211,6 +211,11 @@ func (r *Request[_]) setRequestMethod(method string) {
 	r.method = method
 }
 
+// setHeader sets the request header to the given value.
+func (r *Request[_]) setHeader(header http.Header) {
+	r.header = header
+}
+
 // AnyRequest is the common method set of every [Request], regardless of type
 // parameter. It's used in unary interceptors.
 //
@@ -280,6 +285,16 @@ func (r *Response[_]) Trailer() http.Header {
 		r.trailer = make(http.Header)
 	}
 	return r.trailer
+}
+
+// setHeader sets the response header.
+func (r *Response[_]) setHeader(header http.Header) {
+	r.header = header
+}
+
+// setTrailer sets the response trailer.
+func (r *Response[_]) setTrailer(trailer http.Header) {
+	r.trailer = trailer
 }
 
 // internalOnly implements AnyResponse.

--- a/context.go
+++ b/context.go
@@ -1,0 +1,57 @@
+// Copyright 2021-2025 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connect
+
+import (
+	"context"
+	"net/http"
+)
+
+func HeaderFromIncomingContext(ctx context.Context) (http.Header, bool) {
+	panic("TODO")
+}
+
+func HeaderFromOutgoingContext(ctx context.Context) (http.Header, bool) {
+	panic("TODO")
+}
+
+func WithIncomingHeader(ctx context.Context, header http.Header) context.Context {
+	panic("TODO")
+}
+
+func WithOutgoingHeader(ctx context.Context, header http.Header) context.Context {
+	panic("TODO")
+}
+
+// WithGetResponseHeader returns a new context to be given to a client when making a request
+// that will result in the header pointer being set to the response header.
+func WithGetResponseHeader(ctx context.Context, header *http.Header) context.Context {
+	panic("TODO")
+}
+
+// WithGetResponseTrailer returns a new context to be given to a client when making a request
+// that will result in the trailer pointer being set to the response trailer.
+func WithGetResponseTrailer(ctx context.Context, trailer *http.Header) context.Context {
+	panic("TODO")
+}
+
+func requestFromContext[T any](ctx context.Context, message *T) *Request[T] {
+	request := NewRequest[T](message)
+	header, ok := HeaderFromOutgoingContext(ctx)
+	if ok {
+		request.setHeader(header)
+	}
+	return request
+}

--- a/handler.go
+++ b/handler.go
@@ -85,6 +85,40 @@ func NewUnaryHandler[Req, Res any](
 	}
 }
 
+// NewUnaryHandlerSimple constructs a [Handler] for a request-response procedure.
+func NewUnaryHandlerSimple[Req, Res any](
+	procedure string,
+	unary func(context.Context, *Req) (*Res, error),
+	options ...HandlerOption,
+) *Handler {
+	return NewUnaryHandler(
+		procedure,
+		func(ctx context.Context, request *Request[Req]) (*Response[Res], error) {
+			var responseHeader http.Header
+			var responseTrailer http.Header
+			ctx = WithIncomingHeader(
+				WithGetResponseHeader(
+					WithGetResponseTrailer(
+						ctx,
+						&responseTrailer,
+					),
+					&responseHeader,
+				),
+				request.Header(),
+			)
+			responseMsg, err := unary(ctx, request.Msg)
+			if responseMsg != nil {
+				response := NewResponse(responseMsg)
+				response.setHeader(responseHeader)
+				response.setTrailer(responseHeader)
+				return response, err
+			}
+			return nil, err
+		},
+		options...,
+	)
+}
+
 // NewClientStreamHandler constructs a [Handler] for a client streaming procedure.
 func NewClientStreamHandler[Req, Res any](
 	procedure string,
@@ -131,6 +165,25 @@ func NewServerStreamHandler[Req, Res any](
 			}
 			return implementation(ctx, req, &ServerStream[Res]{conn: conn})
 		},
+	)
+}
+
+// NewServerStreamHandlerSimple constructs a [Handler] for a server streaming procedure.
+func NewServerStreamHandlerSimple[Req, Res any](
+	procedure string,
+	implementation func(context.Context, *Req, *ServerStream[Res]) error,
+	options ...HandlerOption,
+) *Handler {
+	return NewServerStreamHandler(
+		procedure,
+		func(ctx context.Context, request *Request[Req], serverStream *ServerStream[Res]) error {
+			ctx = WithIncomingHeader(
+				ctx,
+				request.Header(),
+			)
+			return implementation(ctx, request.Msg, serverStream)
+		},
+		options...,
 	)
 }
 

--- a/internal/gen/connect/collide/v1/collidev1connect/collide.connect.go
+++ b/internal/gen/connect/collide/v1/collidev1connect/collide.connect.go
@@ -53,7 +53,7 @@ const (
 
 // CollideServiceClient is a client for the connect.collide.v1.CollideService service.
 type CollideServiceClient interface {
-	Import(context.Context, *connect.Request[v1.ImportRequest]) (*connect.Response[v1.ImportResponse], error)
+	Import(context.Context, *v1.ImportRequest) (*v1.ImportResponse, error)
 }
 
 // NewCollideServiceClient constructs a client for the connect.collide.v1.CollideService service. By
@@ -82,13 +82,13 @@ type collideServiceClient struct {
 }
 
 // Import calls connect.collide.v1.CollideService.Import.
-func (c *collideServiceClient) Import(ctx context.Context, req *connect.Request[v1.ImportRequest]) (*connect.Response[v1.ImportResponse], error) {
-	return c._import.CallUnary(ctx, req)
+func (c *collideServiceClient) Import(ctx context.Context, req *v1.ImportRequest) (*v1.ImportResponse, error) {
+	return c._import.CallUnarySimple(ctx, req)
 }
 
 // CollideServiceHandler is an implementation of the connect.collide.v1.CollideService service.
 type CollideServiceHandler interface {
-	Import(context.Context, *connect.Request[v1.ImportRequest]) (*connect.Response[v1.ImportResponse], error)
+	Import(context.Context, *v1.ImportRequest) (*v1.ImportResponse, error)
 }
 
 // NewCollideServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -98,7 +98,7 @@ type CollideServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewCollideServiceHandler(svc CollideServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	collideServiceMethods := v1.File_connect_collide_v1_collide_proto.Services().ByName("CollideService").Methods()
-	collideServiceImportHandler := connect.NewUnaryHandler(
+	collideServiceImportHandler := connect.NewUnaryHandlerSimple(
 		CollideServiceImportProcedure,
 		svc.Import,
 		connect.WithSchema(collideServiceMethods.ByName("Import")),
@@ -117,6 +117,6 @@ func NewCollideServiceHandler(svc CollideServiceHandler, opts ...connect.Handler
 // UnimplementedCollideServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedCollideServiceHandler struct{}
 
-func (UnimplementedCollideServiceHandler) Import(context.Context, *connect.Request[v1.ImportRequest]) (*connect.Response[v1.ImportResponse], error) {
+func (UnimplementedCollideServiceHandler) Import(context.Context, *v1.ImportRequest) (*v1.ImportResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.collide.v1.CollideService.Import is not implemented"))
 }

--- a/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
@@ -67,13 +67,13 @@ const (
 // PingServiceClient is a client for the connect.ping.v1.PingService service.
 type PingServiceClient interface {
 	// Ping sends a ping to the server to determine if it's reachable.
-	Ping(context.Context, *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error)
+	Ping(context.Context, *v1.PingRequest) (*v1.PingResponse, error)
 	// Fail always fails.
-	Fail(context.Context, *connect.Request[v1.FailRequest]) (*connect.Response[v1.FailResponse], error)
+	Fail(context.Context, *v1.FailRequest) (*v1.FailResponse, error)
 	// Sum calculates the sum of the numbers sent on the stream.
 	Sum(context.Context) *connect.ClientStreamForClient[v1.SumRequest, v1.SumResponse]
 	// CountUp returns a stream of the numbers up to the given request.
-	CountUp(context.Context, *connect.Request[v1.CountUpRequest]) (*connect.ServerStreamForClient[v1.CountUpResponse], error)
+	CountUp(context.Context, *v1.CountUpRequest) (*connect.ServerStreamForClient[v1.CountUpResponse], error)
 	// CumSum determines the cumulative sum of all the numbers sent on the stream.
 	CumSum(context.Context) *connect.BidiStreamForClient[v1.CumSumRequest, v1.CumSumResponse]
 }
@@ -133,13 +133,13 @@ type pingServiceClient struct {
 }
 
 // Ping calls connect.ping.v1.PingService.Ping.
-func (c *pingServiceClient) Ping(ctx context.Context, req *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error) {
-	return c.ping.CallUnary(ctx, req)
+func (c *pingServiceClient) Ping(ctx context.Context, req *v1.PingRequest) (*v1.PingResponse, error) {
+	return c.ping.CallUnarySimple(ctx, req)
 }
 
 // Fail calls connect.ping.v1.PingService.Fail.
-func (c *pingServiceClient) Fail(ctx context.Context, req *connect.Request[v1.FailRequest]) (*connect.Response[v1.FailResponse], error) {
-	return c.fail.CallUnary(ctx, req)
+func (c *pingServiceClient) Fail(ctx context.Context, req *v1.FailRequest) (*v1.FailResponse, error) {
+	return c.fail.CallUnarySimple(ctx, req)
 }
 
 // Sum calls connect.ping.v1.PingService.Sum.
@@ -148,8 +148,8 @@ func (c *pingServiceClient) Sum(ctx context.Context) *connect.ClientStreamForCli
 }
 
 // CountUp calls connect.ping.v1.PingService.CountUp.
-func (c *pingServiceClient) CountUp(ctx context.Context, req *connect.Request[v1.CountUpRequest]) (*connect.ServerStreamForClient[v1.CountUpResponse], error) {
-	return c.countUp.CallServerStream(ctx, req)
+func (c *pingServiceClient) CountUp(ctx context.Context, req *v1.CountUpRequest) (*connect.ServerStreamForClient[v1.CountUpResponse], error) {
+	return c.countUp.CallServerStreamSimple(ctx, req)
 }
 
 // CumSum calls connect.ping.v1.PingService.CumSum.
@@ -160,13 +160,13 @@ func (c *pingServiceClient) CumSum(ctx context.Context) *connect.BidiStreamForCl
 // PingServiceHandler is an implementation of the connect.ping.v1.PingService service.
 type PingServiceHandler interface {
 	// Ping sends a ping to the server to determine if it's reachable.
-	Ping(context.Context, *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error)
+	Ping(context.Context, *v1.PingRequest) (*v1.PingResponse, error)
 	// Fail always fails.
-	Fail(context.Context, *connect.Request[v1.FailRequest]) (*connect.Response[v1.FailResponse], error)
+	Fail(context.Context, *v1.FailRequest) (*v1.FailResponse, error)
 	// Sum calculates the sum of the numbers sent on the stream.
 	Sum(context.Context, *connect.ClientStream[v1.SumRequest]) (*connect.Response[v1.SumResponse], error)
 	// CountUp returns a stream of the numbers up to the given request.
-	CountUp(context.Context, *connect.Request[v1.CountUpRequest], *connect.ServerStream[v1.CountUpResponse]) error
+	CountUp(context.Context, *v1.CountUpRequest, *connect.ServerStream[v1.CountUpResponse]) error
 	// CumSum determines the cumulative sum of all the numbers sent on the stream.
 	CumSum(context.Context, *connect.BidiStream[v1.CumSumRequest, v1.CumSumResponse]) error
 }
@@ -178,14 +178,14 @@ type PingServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewPingServiceHandler(svc PingServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	pingServiceMethods := v1.File_connect_ping_v1_ping_proto.Services().ByName("PingService").Methods()
-	pingServicePingHandler := connect.NewUnaryHandler(
+	pingServicePingHandler := connect.NewUnaryHandlerSimple(
 		PingServicePingProcedure,
 		svc.Ping,
 		connect.WithSchema(pingServiceMethods.ByName("Ping")),
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
-	pingServiceFailHandler := connect.NewUnaryHandler(
+	pingServiceFailHandler := connect.NewUnaryHandlerSimple(
 		PingServiceFailProcedure,
 		svc.Fail,
 		connect.WithSchema(pingServiceMethods.ByName("Fail")),
@@ -197,7 +197,7 @@ func NewPingServiceHandler(svc PingServiceHandler, opts ...connect.HandlerOption
 		connect.WithSchema(pingServiceMethods.ByName("Sum")),
 		connect.WithHandlerOptions(opts...),
 	)
-	pingServiceCountUpHandler := connect.NewServerStreamHandler(
+	pingServiceCountUpHandler := connect.NewServerStreamHandlerSimple(
 		PingServiceCountUpProcedure,
 		svc.CountUp,
 		connect.WithSchema(pingServiceMethods.ByName("CountUp")),
@@ -230,11 +230,11 @@ func NewPingServiceHandler(svc PingServiceHandler, opts ...connect.HandlerOption
 // UnimplementedPingServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedPingServiceHandler struct{}
 
-func (UnimplementedPingServiceHandler) Ping(context.Context, *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error) {
+func (UnimplementedPingServiceHandler) Ping(context.Context, *v1.PingRequest) (*v1.PingResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Ping is not implemented"))
 }
 
-func (UnimplementedPingServiceHandler) Fail(context.Context, *connect.Request[v1.FailRequest]) (*connect.Response[v1.FailResponse], error) {
+func (UnimplementedPingServiceHandler) Fail(context.Context, *v1.FailRequest) (*v1.FailResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Fail is not implemented"))
 }
 
@@ -242,7 +242,7 @@ func (UnimplementedPingServiceHandler) Sum(context.Context, *connect.ClientStrea
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Sum is not implemented"))
 }
 
-func (UnimplementedPingServiceHandler) CountUp(context.Context, *connect.Request[v1.CountUpRequest], *connect.ServerStream[v1.CountUpResponse]) error {
+func (UnimplementedPingServiceHandler) CountUp(context.Context, *v1.CountUpRequest, *connect.ServerStream[v1.CountUpResponse]) error {
 	return connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.CountUp is not implemented"))
 }
 


### PR DESCRIPTION
This is re: https://github.com/connectrpc/connect-go/issues/848 https://github.com/connectrpc/connect-go/discussions/421. This is the simplest possible version of this, and is just done as a prototype for discussion.

The general concept is to effectively just model what people know already. The interface is very similar to grpc-go in this case. A final version of this will likely not be flag-based, we'll want to carefully choose how to expose this if we pursue this:

- A new plugin, such as `protoc-gen-connect-gosimple`.
- Generate to a separate package, such as `.*connectsimple`.
- Generate with a new interface name in the same package, such as `.*SimpleClient`.

Whatever we do, we do not want to v2 and will never break existing users.