### PR TITLE
feat: add service struct

### DIFF
--- a/cmd/protoc-gen-connect-go/internal/testdata/defaultpackage/gen/genconnect/defaultpackage.connect.go
+++ b/cmd/protoc-gen-connect-go/internal/testdata/defaultpackage/gen/genconnect/defaultpackage.connect.go
@@ -91,6 +91,17 @@ type TestServiceHandler interface {
 	Method(context.Context, *connect.Request[gen.Request]) (*connect.Response[gen.Response], error)
 }
 
+// TestServiceService provides access to the handlers for the
+// connect.test.default_package.TestService service.
+type TestServiceService struct {
+	MethodFunc connect.HandlerFunc[gen.Request, gen.Response]
+}
+
+// Method calls the MethodFunc handler.
+func (s *TestServiceService) Method(ctx context.Context, req *connect.Request[gen.Request]) (*connect.Response[gen.Response], error) {
+	return s.MethodFunc(ctx, req)
+}
+
 // NewTestServiceHandler builds an HTTP handler from the service implementation. It returns the path
 // on which to mount the handler and the handler itself.
 //

--- a/cmd/protoc-gen-connect-go/internal/testdata/diffpackage/gen/gendiff/diffpackage.connect.go
+++ b/cmd/protoc-gen-connect-go/internal/testdata/diffpackage/gen/gendiff/diffpackage.connect.go
@@ -92,6 +92,17 @@ type TestServiceHandler interface {
 	Method(context.Context, *connect.Request[gen.Request]) (*connect.Response[gen.Response], error)
 }
 
+// TestServiceService provides access to the handlers for the
+// connect.test.different_package.TestService service.
+type TestServiceService struct {
+	MethodFunc connect.HandlerFunc[gen.Request, gen.Response]
+}
+
+// Method calls the MethodFunc handler.
+func (s *TestServiceService) Method(ctx context.Context, req *connect.Request[gen.Request]) (*connect.Response[gen.Response], error) {
+	return s.MethodFunc(ctx, req)
+}
+
 // NewTestServiceHandler builds an HTTP handler from the service implementation. It returns the path
 // on which to mount the handler and the handler itself.
 //

--- a/cmd/protoc-gen-connect-go/internal/testdata/samepackage/gen/samepackage.connect.go
+++ b/cmd/protoc-gen-connect-go/internal/testdata/samepackage/gen/samepackage.connect.go
@@ -90,6 +90,17 @@ type TestServiceHandler interface {
 	Method(context.Context, *connect.Request[Request]) (*connect.Response[Response], error)
 }
 
+// TestServiceService provides access to the handlers for the connect.test.same_package.TestService
+// service.
+type TestServiceService struct {
+	MethodFunc connect.HandlerFunc[Request, Response]
+}
+
+// Method calls the MethodFunc handler.
+func (s *TestServiceService) Method(ctx context.Context, req *connect.Request[Request]) (*connect.Response[Response], error) {
+	return s.MethodFunc(ctx, req)
+}
+
 // NewTestServiceHandler builds an HTTP handler from the service implementation. It returns the path
 // on which to mount the handler and the handler itself.
 //

--- a/cmd/protoc-gen-connect-go/internal/testdata/v1beta1service/gen/v1beta1service.connect.go
+++ b/cmd/protoc-gen-connect-go/internal/testdata/v1beta1service/gen/v1beta1service.connect.go
@@ -92,6 +92,16 @@ type ExampleV1BetaHandler interface {
 	Method(context.Context, *connect.Request[GetExample_Request]) (*connect.Response[Get1ExampleResponse], error)
 }
 
+// ExampleV1BetaService provides access to the handlers for the example.ExampleV1beta service.
+type ExampleV1BetaService struct {
+	MethodFunc connect.HandlerFunc[GetExample_Request, Get1ExampleResponse]
+}
+
+// Method calls the MethodFunc handler.
+func (s *ExampleV1BetaService) Method(ctx context.Context, req *connect.Request[GetExample_Request]) (*connect.Response[Get1ExampleResponse], error) {
+	return s.MethodFunc(ctx, req)
+}
+
 // NewExampleV1BetaHandler builds an HTTP handler from the service implementation. It returns the
 // path on which to mount the handler and the handler itself.
 //

--- a/handler.go
+++ b/handler.go
@@ -19,6 +19,14 @@ import (
 	"net/http"
 )
 
+// HandlerFunc is a function that implements the Handler interface.
+// It is used to create a Handler from a function.
+type HandlerFunc[Req, Res any] func(context.Context, *Request[Req]) (*Response[Res], error)
+
+// BidiStreamFunc is a function that implements the BidiStream interface.
+// It is used to create a BidiStream from a function.
+type BidiStreamFunc[Req, Res any] func(context.Context, *BidiStream[Req, Res]) error
+
 // A Handler is the server-side implementation of a single RPC defined by a
 // service schema.
 //

--- a/internal/gen/connect/collide/v1/collidev1connect/collide.connect.go
+++ b/internal/gen/connect/collide/v1/collidev1connect/collide.connect.go
@@ -91,6 +91,17 @@ type CollideServiceHandler interface {
 	Import(context.Context, *connect.Request[v1.ImportRequest]) (*connect.Response[v1.ImportResponse], error)
 }
 
+// CollideServiceService provides access to the handlers for the connect.collide.v1.CollideService
+// service.
+type CollideServiceService struct {
+	ImportFunc connect.HandlerFunc[v1.ImportRequest, v1.ImportResponse]
+}
+
+// Import calls the ImportFunc handler.
+func (s *CollideServiceService) Import(ctx context.Context, req *connect.Request[v1.ImportRequest]) (*connect.Response[v1.ImportResponse], error) {
+	return s.ImportFunc(ctx, req)
+}
+
 // NewCollideServiceHandler builds an HTTP handler from the service implementation. It returns the
 // path on which to mount the handler and the handler itself.
 //

--- a/internal/gen/connect/import/v1/importv1connect/import.connect.go
+++ b/internal/gen/connect/import/v1/importv1connect/import.connect.go
@@ -59,6 +59,11 @@ type importServiceClient struct {
 type ImportServiceHandler interface {
 }
 
+// ImportServiceService provides access to the handlers for the connect.import.v1.ImportService
+// service.
+type ImportServiceService struct {
+}
+
 // NewImportServiceHandler builds an HTTP handler from the service implementation. It returns the
 // path on which to mount the handler and the handler itself.
 //

--- a/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
@@ -171,6 +171,45 @@ type PingServiceHandler interface {
 	CumSum(context.Context, *connect.BidiStream[v1.CumSumRequest, v1.CumSumResponse]) error
 }
 
+// PingServiceService provides access to the handlers for the connect.ping.v1.PingService service.
+type PingServiceService struct {
+	// Ping sends a ping to the server to determine if it's reachable.
+	PingFunc connect.HandlerFunc[v1.PingRequest, v1.PingResponse]
+	// Fail always fails.
+	FailFunc connect.HandlerFunc[v1.FailRequest, v1.FailResponse]
+	// Sum calculates the sum of the numbers sent on the stream.
+	SumFunc func(context.Context, *connect.ClientStream[v1.SumRequest]) (*connect.Response[v1.SumResponse], error)
+	// CountUp returns a stream of the numbers up to the given request.
+	CountUpFunc func(context.Context, *connect.Request[v1.CountUpRequest], *connect.ServerStream[v1.CountUpResponse]) error
+	// CumSum determines the cumulative sum of all the numbers sent on the stream.
+	CumSumFunc connect.BidiStreamFunc[v1.CumSumRequest, v1.CumSumResponse]
+}
+
+// Ping calls the PingFunc handler.
+func (s *PingServiceService) Ping(ctx context.Context, req *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error) {
+	return s.PingFunc(ctx, req)
+}
+
+// Fail calls the FailFunc handler.
+func (s *PingServiceService) Fail(ctx context.Context, req *connect.Request[v1.FailRequest]) (*connect.Response[v1.FailResponse], error) {
+	return s.FailFunc(ctx, req)
+}
+
+// Sum calls the SumFunc handler.
+func (s *PingServiceService) Sum(ctx context.Context, stream *connect.ClientStream[v1.SumRequest]) (*connect.Response[v1.SumResponse], error) {
+	return s.SumFunc(ctx, stream)
+}
+
+// CountUp calls the CountUpFunc handler.
+func (s *PingServiceService) CountUp(ctx context.Context, req *connect.Request[v1.CountUpRequest], stream *connect.ServerStream[v1.CountUpResponse]) error {
+	return s.CountUpFunc(ctx, req, stream)
+}
+
+// CumSum calls the CumSumFunc handler.
+func (s *PingServiceService) CumSum(ctx context.Context, stream *connect.BidiStream[v1.CumSumRequest, v1.CumSumResponse]) error {
+	return s.CumSumFunc(ctx, stream)
+}
+
 // NewPingServiceHandler builds an HTTP handler from the service implementation. It returns the path
 // on which to mount the handler and the handler itself.
 //


### PR DESCRIPTION
This PR introduces a simpler way to define `ServiceHandler` implementations using plain functions, closely mirroring Go’s `http.HandleFunc`.

## Context

Today, `connect-go` requires creating structs implementing service interfaces. While idiomatic, this:

* Forces unnecessary boilerplate and indirection (extra structs, vtable lookups). Note, I am still using an interface for backwards compatible and avoid breaking changes. The long-term ideal solution, we could remove the vtable all together. But it is less of a concern right now.
* Complicates dependency injection, especially in codebases favoring functional composition.
* Makes testing harder—requiring mock structs or complex setup, forced to implement the entire interface even when most cases, we only care about one endpoint.

## Why This Matters

By adopting a `HandleFunc`-style API:

* Handlers can be defined as pure functions without struct wrappers.
* Testing becomes trivial—just pass closures, no mocks needed.
* The pattern exactly matches `net/http` practices that Go developers already know.
* The change is **fully backward-compatible**—interfaces remain available unchanged.

**Example:**

```go
type MyService struct {
   DoSomethingFunc connect.HandleFunc[Request, Response]
}
```

This approach requires no new concepts beyond what every Go developer already uses for HTTP servers.