### PR TITLE
Implement CallInfo usage in context and add integration tests

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -124,7 +124,7 @@ func BenchmarkConnect(b *testing.B) {
 						response, err := stream.CloseAndReceive()
 						if err != nil {
 							b.Error(err)
-						} else if got := response.Msg.GetSum(); got != expect {
+						} else if got := response.GetSum(); got != expect {
 							b.Errorf("expected %d, got %d", expect, got)
 						}
 					}

--- a/bench_test.go
+++ b/bench_test.go
@@ -112,7 +112,10 @@ func BenchmarkConnect(b *testing.B) {
 							upTo   = 1
 							expect = 1
 						)
-						stream := client.Sum(ctx)
+						stream, err := client.Sum(ctx)
+						if err != nil {
+							b.Error(err)
+						}
 						for number := int64(1); number <= upTo; number++ {
 							if err := stream.Send(&pingv1.SumRequest{Number: number}); err != nil {
 								b.Error(err)
@@ -159,7 +162,10 @@ func BenchmarkConnect(b *testing.B) {
 						const (
 							upTo = 1
 						)
-						stream := client.CumSum(ctx)
+						stream, err := client.CumSum(ctx)
+						if err != nil {
+							b.Error(err)
+						}
 						number := int64(1)
 						for ; number <= upTo; number++ {
 							if err := stream.Send(&pingv1.CumSumRequest{Number: number}); err != nil {

--- a/client.go
+++ b/client.go
@@ -116,6 +116,7 @@ func NewClient[Req, Res any](httpClient HTTPClient, url string, options ...Clien
 		ctx, callInfo := newOutgoingContext(ctx)
 		callInfo.peer = request.Peer()
 		callInfo.spec = request.Spec()
+		callInfo.requestHeader = request.Header()
 
 		response, err := unaryFunc(ctx, request)
 		if err != nil {

--- a/client.go
+++ b/client.go
@@ -126,6 +126,7 @@ func NewClient[Req, Res any](httpClient HTTPClient, url string, options ...Clien
 		if !ok {
 			return nil, errorf(CodeInternal, "unexpected client response type %T", response)
 		}
+		// Wrap the response and set it into the context callinfo
 		callInfo.responseSource = &responseWrapper[Res]{
 			response: typed,
 		}
@@ -139,12 +140,7 @@ func (c *Client[Req, Res]) CallUnary(ctx context.Context, request *Request[Req])
 	if c.err != nil {
 		return nil, c.err
 	}
-	resp, err := c.callUnary(ctx, request)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return c.callUnary(ctx, request)
 }
 
 // CallUnarySimple calls a request-response procedure using the function signature

--- a/client.go
+++ b/client.go
@@ -79,7 +79,7 @@ func NewClient[Req, Res any](httpClient HTTPClient, url string, options ...Clien
 		conn := client.protocolClient.NewConn(ctx, unarySpec, request.Header())
 		conn.onRequestSend(func(r *http.Request) {
 			request.setRequestMethod(r.Method)
-			callInfo, ok := getClientCallInfoFromContext(ctx)
+			callInfo, ok := clientCallInfoFromContext(ctx)
 			if ok {
 				callInfo.method = r.Method
 			}
@@ -116,7 +116,7 @@ func NewClient[Req, Res any](httpClient HTTPClient, url string, options ...Clien
 		protocolClient.WriteRequestHeader(StreamTypeUnary, request.Header())
 
 		// Also set them in the context if there's a call info present
-		callInfo, callInfoOk := getClientCallInfoFromContext(ctx)
+		callInfo, callInfoOk := clientCallInfoFromContext(ctx)
 		if callInfoOk {
 			callInfo.peer = request.Peer()
 			callInfo.spec = request.Spec()
@@ -158,19 +158,6 @@ func (c *Client[Req, Res]) CallUnary(ctx context.Context, request *Request[Req])
 	return c.callUnary(ctx, request)
 }
 
-// CallUnarySimple calls a request-response procedure using the function signature
-// associated with the "simple" generation option.
-//
-// This option eliminates the [Request] and [Response] wrappers, and instead uses the
-// context.Context to propagate information such as headers.
-func (c *Client[Req, Res]) CallUnarySimple(ctx context.Context, request *Req) (*Res, error) {
-	response, err := c.CallUnary(ctx, NewRequest(request))
-	if response != nil {
-		return response.Msg, err
-	}
-	return nil, err
-}
-
 // CallClientStream calls a client streaming procedure.
 func (c *Client[Req, Res]) CallClientStream(ctx context.Context) *ClientStreamForClient[Req, Res] {
 	if c.err != nil {
@@ -187,7 +174,7 @@ func (c *Client[Req, Res]) CallServerStream(ctx context.Context, request *Reques
 	if c.err != nil {
 		return nil, c.err
 	}
-	callInfo, callInfoOk := getClientCallInfoFromContext(ctx)
+	callInfo, callInfoOk := clientCallInfoFromContext(ctx)
 	// Set values in the context if there's a call info present
 	if callInfoOk {
 		// Copy the call info into a sentinel value. This is so we can compare
@@ -229,15 +216,6 @@ func (c *Client[Req, Res]) CallServerStream(ctx context.Context, request *Reques
 		conn:        conn,
 		initializer: c.config.Initializer,
 	}, nil
-}
-
-// CallServerStreamSimple calls a server streaming procedure using the function signature
-// associated with the "simple" generation option.
-//
-// This option eliminates the [Request] wrapper, and instead uses the context.Context to
-// propagate information such as headers.
-func (c *Client[Req, Res]) CallServerStreamSimple(ctx context.Context, requestMsg *Req) (*ServerStreamForClient[Res], error) {
-	return c.CallServerStream(ctx, NewRequest(requestMsg))
 }
 
 // CallBidiStream calls a bidirectional streaming procedure.

--- a/client.go
+++ b/client.go
@@ -152,7 +152,11 @@ func (c *Client[Req, Res]) CallUnary(ctx context.Context, request *Request[Req])
 	return resp, nil
 }
 
-// CallUnary calls a request-response procedure.
+// CallUnarySimple calls a request-response procedure using the function signature
+// associated with the "simple" generation option.
+//
+// This option eliminates the [Request] and [Response] wrappers, and instead uses the
+// context.Context to propagate information such as headers.
 func (c *Client[Req, Res]) CallUnarySimple(ctx context.Context, request *Req) (*Res, error) {
 	response, err := c.CallUnary(ctx, requestFromOutgoingContext(ctx, request))
 	if response != nil {

--- a/client.go
+++ b/client.go
@@ -126,24 +126,12 @@ func NewClient[Req, Res any](httpClient HTTPClient, url string, options ...Clien
 		if !ok {
 			return nil, errorf(CodeInternal, "unexpected client response type %T", response)
 		}
-		callInfo.responseSource = &wrapper[Res]{
+		callInfo.responseSource = &responseWrapper[Res]{
 			response: typed,
 		}
 		return typed, nil
 	}
 	return client
-}
-
-type wrapper[Res any] struct {
-	response *Response[Res]
-}
-
-func (w *wrapper[Res]) ResponseHeader() http.Header {
-	return w.response.Header()
-}
-
-func (w *wrapper[Res]) ResponseTrailer() http.Header {
-	return w.response.Trailer()
 }
 
 // CallUnary calls a request-response procedure.

--- a/client.go
+++ b/client.go
@@ -139,9 +139,6 @@ func (c *Client[Req, Res]) CallUnary(ctx context.Context, request *Request[Req])
 	if c.err != nil {
 		return nil, c.err
 	}
-	ctx, callInfo := newOutgoingContext(ctx)
-	callInfo.requestHeader = request.Header()
-
 	resp, err := c.callUnary(ctx, request)
 	if err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -169,6 +169,18 @@ func (c *Client[Req, Res]) CallClientStream(ctx context.Context) *ClientStreamFo
 	}
 }
 
+// CallClientStream calls a client streaming procedure in simple mode.
+func (c *Client[Req, Res]) CallClientStreamSimple(ctx context.Context) (*ClientStreamForClient[Req, Res], error) {
+	stream := c.CallClientStream(ctx)
+	if stream.err != nil {
+		return nil, stream.err
+	}
+	if err := stream.Send(nil); err != nil {
+		return nil, err
+	}
+	return stream, nil
+}
+
 // CallServerStream calls a server streaming procedure.
 func (c *Client[Req, Res]) CallServerStream(ctx context.Context, request *Request[Req]) (*ServerStreamForClient[Res], error) {
 	if c.err != nil {
@@ -227,6 +239,18 @@ func (c *Client[Req, Res]) CallBidiStream(ctx context.Context) *BidiStreamForCli
 		conn:        c.newConn(ctx, StreamTypeBidi, nil),
 		initializer: c.config.Initializer,
 	}
+}
+
+// CallBidiStreamSimple calls a bidirectional streaming procedure in simple mode.
+func (c *Client[Req, Res]) CallBidiStreamSimple(ctx context.Context) (*BidiStreamForClient[Req, Res], error) {
+	stream := c.CallBidiStream(ctx)
+	if stream.err != nil {
+		return nil, stream.err
+	}
+	if err := stream.Send(nil); err != nil {
+		return nil, err
+	}
+	return stream, nil
 }
 
 func (c *Client[Req, Res]) newConn(ctx context.Context, streamType StreamType, onRequestSend func(r *http.Request)) StreamingClientConn {

--- a/client.go
+++ b/client.go
@@ -189,7 +189,7 @@ func (c *Client[Req, Res]) CallServerStream(ctx context.Context, request *Reques
 
 	info.peer = conn.Peer()
 	info.spec = conn.Spec()
-	mergeHeaders(conn.RequestHeader(), info.requestHeader)
+	mergeHeaders(info.RequestHeader(), request.header)
 	// Send always returns an io.EOF unless the error is from the client-side.
 	// We want the user to continue to call Receive in those cases to get the
 	// full error from the server-side.

--- a/client.go
+++ b/client.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"strings"
@@ -127,16 +128,31 @@ func (c *Client[Req, Res]) CallUnary(ctx context.Context, request *Request[Req])
 	if c.err != nil {
 		return nil, c.err
 	}
-	return c.callUnary(ctx, request)
+	ctx, ci := NewOutgoingContext(ctx)
+	call, ok := ci.(*callInfo)
+	if ok {
+		call.requestHeader = request.Header()
+	}
+
+	resp, err := c.callUnary(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	if ok {
+		call.peer = request.Peer()
+		call.spec = request.Spec()
+		call.method = request.HTTPMethod()
+		maps.Copy(call.ResponseHeader(), resp.Header())
+		maps.Copy(call.ResponseTrailer(), resp.Trailer())
+	}
+
+	return resp, nil
 }
 
-// CallUnarySimple calls a request-response procedure using the function signature
-// associated with the "simple" generation option.
-//
-// This option eliminates the [Request] and [Response] wrappers, and instead uses the
-// context.Context to propagate information such as headers.
-func (c *Client[Req, Res]) CallUnarySimple(ctx context.Context, requestMsg *Req) (*Res, error) {
-	response, err := c.CallUnary(ctx, requestFromContext(ctx, requestMsg))
+// CallUnary calls a request-response procedure.
+func (c *Client[Req, Res]) CallUnarySimple(ctx context.Context, request *Req) (*Res, error) {
+	response, err := c.CallUnary(ctx, requestFromContext(ctx, request))
 	if response != nil {
 		return response.Msg, err
 	}
@@ -159,12 +175,21 @@ func (c *Client[Req, Res]) CallServerStream(ctx context.Context, request *Reques
 	if c.err != nil {
 		return nil, c.err
 	}
+	ctx, ctxCallInfo := NewOutgoingContext(ctx)
+	// Note we don't need to check ok here because it should always be in context
+	// because of the above call to NewOutgoingContext
+	info, _ := ctxCallInfo.(*callInfo)
 	conn := c.newConn(ctx, StreamTypeServer, func(r *http.Request) {
 		request.method = r.Method
+		info.method = r.Method
 	})
 	request.spec = conn.Spec()
 	request.peer = conn.Peer()
 	mergeHeaders(conn.RequestHeader(), request.header)
+
+	info.peer = conn.Peer()
+	info.spec = conn.Spec()
+	mergeHeaders(conn.RequestHeader(), info.requestHeader)
 	// Send always returns an io.EOF unless the error is from the client-side.
 	// We want the user to continue to call Receive in those cases to get the
 	// full error from the server-side.
@@ -182,11 +207,6 @@ func (c *Client[Req, Res]) CallServerStream(ctx context.Context, request *Reques
 	}, nil
 }
 
-// CallServerStreamSimple calls a server streaming procedure using the function signature
-// associated with the "simple" generation option.
-//
-// This option eliminates the [Request] wrapper, and instead uses the context.Context to
-// propagate information such as headers.
 func (c *Client[Req, Res]) CallServerStreamSimple(ctx context.Context, requestMsg *Req) (*ServerStreamForClient[Res], error) {
 	return c.CallServerStream(ctx, requestFromContext(ctx, requestMsg))
 }

--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -89,7 +89,7 @@ func TestNewClient_InitFailure(t *testing.T) {
 func TestClientPeer(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()
-	mux.Handle(pingv1connect.NewPingServiceHandler(pingServerGenerics{}))
+	mux.Handle(pingv1connect.NewPingServiceHandler(pingServer{}))
 	server := memhttptest.NewServer(t, mux)
 
 	run := func(t *testing.T, unaryHTTPMethod string, opts ...connect.ClientOption) {
@@ -205,7 +205,7 @@ func TestGetNoContentHeaders(t *testing.T) {
 	t.Parallel()
 
 	mux := http.NewServeMux()
-	mux.Handle(pingv1connect.NewPingServiceHandler(&pingServerGenerics{}))
+	mux.Handle(pingv1connect.NewPingServiceHandler(&pingServer{}))
 	server := memhttptest.NewServer(t, http.HandlerFunc(func(respWriter http.ResponseWriter, req *http.Request) {
 		if len(req.Header.Values("content-type")) > 0 ||
 			len(req.Header.Values("content-encoding")) > 0 ||
@@ -283,7 +283,7 @@ func TestSpecSchema(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()
 	mux.Handle(pingv1connect.NewPingServiceHandler(
-		pingServerGenerics{},
+		pingServer{},
 		connect.WithInterceptors(&assertSchemaInterceptor{t}),
 	))
 	server := memhttptest.NewServer(t, mux)
@@ -320,7 +320,7 @@ func TestSpecSchema(t *testing.T) {
 func TestDynamicClient(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()
-	mux.Handle(pingv1connect.NewPingServiceHandler(pingServerGenerics{}))
+	mux.Handle(pingv1connect.NewPingServiceHandler(pingServer{}))
 	server := memhttptest.NewServer(t, mux)
 	ctx := context.Background()
 	initializer := func(spec connect.Spec, msg any) error {
@@ -494,7 +494,7 @@ func TestClientDeadlineHandling(t *testing.T) {
 	// detector enabled. That's partly why the makefile only runs "slow"
 	// tests with the race detector disabled.
 
-	_, handler := pingv1connect.NewPingServiceHandler(pingServerGenerics{})
+	_, handler := pingv1connect.NewPingServiceHandler(pingServer{})
 	svr := httptest.NewUnstartedServer(http.HandlerFunc(func(respWriter http.ResponseWriter, req *http.Request) {
 		if req.Context().Err() != nil {
 			return

--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -431,7 +431,7 @@ func TestDynamicClient(t *testing.T) {
 		if !assert.Nil(t, err) {
 			return
 		}
-		got := rsp.Msg.Get(methodDesc.Output().Fields().ByName("sum")).Int()
+		got := rsp.Get(methodDesc.Output().Fields().ByName("sum")).Int()
 		assert.Equal(t, got, 42*2)
 	})
 	t.Run("serverStream", func(t *testing.T) {

--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -18,10 +18,12 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -36,6 +38,7 @@ import (
 	pingv1 "connectrpc.com/connect/internal/gen/connect/ping/v1"
 	"connectrpc.com/connect/internal/gen/generics/connect/ping/v1/pingv1connect"
 	"connectrpc.com/connect/internal/memhttp/memhttptest"
+	"golang.org/x/net/http2"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -389,6 +392,48 @@ func TestDynamicClient(t *testing.T) {
 		got := rsp.Msg.Get(methodDesc.Output().Fields().ByName("sum")).Int()
 		assert.Equal(t, got, 42*2)
 	})
+	t.Run("clientStreamSimple", func(t *testing.T) {
+		t.Parallel()
+		desc, err := protoregistry.GlobalFiles.FindDescriptorByName("connect.ping.v1.PingService.Sum")
+		assert.Nil(t, err)
+		methodDesc, ok := desc.(protoreflect.MethodDescriptor)
+		assert.True(t, ok)
+		connected := make(chan struct{})
+		transport := &http2.Transport{
+			DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
+				close(connected)
+				return server.Transport().DialTLSContext(ctx, network, addr, cfg)
+			},
+			AllowHTTP: true,
+		}
+		client := connect.NewClient[dynamicpb.Message, dynamicpb.Message](
+			&http.Client{Transport: transport},
+			server.URL()+"/connect.ping.v1.PingService/Sum",
+			connect.WithSchema(methodDesc),
+			connect.WithResponseInitializer(initializer),
+		)
+		stream, err := client.CallClientStreamSimple(ctx)
+		assert.Nil(t, err)
+		select {
+		case <-connected:
+			break
+		case <-time.After(time.Second):
+			t.Error("CallClientStreamSimple did not eagerly send headers")
+		}
+		msg := dynamicpb.NewMessage(methodDesc.Input())
+		msg.Set(
+			methodDesc.Input().Fields().ByName("number"),
+			protoreflect.ValueOfInt64(42),
+		)
+		assert.Nil(t, stream.Send(msg))
+		assert.Nil(t, stream.Send(msg))
+		rsp, err := stream.CloseAndReceive()
+		if !assert.Nil(t, err) {
+			return
+		}
+		got := rsp.Msg.Get(methodDesc.Output().Fields().ByName("sum")).Int()
+		assert.Equal(t, got, 42*2)
+	})
 	t.Run("serverStream", func(t *testing.T) {
 		t.Parallel()
 		desc, err := protoregistry.GlobalFiles.FindDescriptorByName("connect.ping.v1.PingService.CountUp")
@@ -431,6 +476,48 @@ func TestDynamicClient(t *testing.T) {
 			connect.WithResponseInitializer(initializer),
 		)
 		stream := client.CallBidiStream(ctx)
+		msg := dynamicpb.NewMessage(methodDesc.Input())
+		msg.Set(
+			methodDesc.Input().Fields().ByName("number"),
+			protoreflect.ValueOfInt64(42),
+		)
+		assert.Nil(t, stream.Send(msg))
+		assert.Nil(t, stream.CloseRequest())
+		out, err := stream.Receive()
+		if assert.Nil(t, err) {
+			return
+		}
+		got := out.Get(methodDesc.Output().Fields().ByName("number")).Int()
+		assert.Equal(t, got, 42)
+	})
+	t.Run("bidiSimple", func(t *testing.T) {
+		t.Parallel()
+		desc, err := protoregistry.GlobalFiles.FindDescriptorByName("connect.ping.v1.PingService.CumSum")
+		assert.Nil(t, err)
+		methodDesc, ok := desc.(protoreflect.MethodDescriptor)
+		assert.True(t, ok)
+		connected := make(chan struct{})
+		transport := &http2.Transport{
+			DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
+				close(connected)
+				return server.Transport().DialTLSContext(ctx, network, addr, cfg)
+			},
+			AllowHTTP: true,
+		}
+		client := connect.NewClient[dynamicpb.Message, dynamicpb.Message](
+			&http.Client{Transport: transport},
+			server.URL()+"/connect.ping.v1.PingService/CumSum",
+			connect.WithSchema(methodDesc),
+			connect.WithResponseInitializer(initializer),
+		)
+		stream, err := client.CallBidiStreamSimple(ctx)
+		assert.Nil(t, err)
+		select {
+		case <-connected:
+			break
+		case <-time.After(time.Second):
+			t.Error("CallBidiStreamSimple did not eagerly send headers")
+		}
 		msg := dynamicpb.NewMessage(methodDesc.Input())
 		msg.Set(
 			methodDesc.Input().Fields().ByName("number"),

--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -89,7 +89,7 @@ func TestNewClient_InitFailure(t *testing.T) {
 func TestClientPeer(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()
-	mux.Handle(pingv1connect.NewPingServiceHandler(pingServer{}))
+	mux.Handle(pingv1connect.NewPingServiceHandler(pingServerGenerics{}))
 	server := memhttptest.NewServer(t, mux)
 
 	run := func(t *testing.T, unaryHTTPMethod string, opts ...connect.ClientOption) {
@@ -205,7 +205,7 @@ func TestGetNoContentHeaders(t *testing.T) {
 	t.Parallel()
 
 	mux := http.NewServeMux()
-	mux.Handle(pingv1connect.NewPingServiceHandler(&pingServer{}))
+	mux.Handle(pingv1connect.NewPingServiceHandler(&pingServerGenerics{}))
 	server := memhttptest.NewServer(t, http.HandlerFunc(func(respWriter http.ResponseWriter, req *http.Request) {
 		if len(req.Header.Values("content-type")) > 0 ||
 			len(req.Header.Values("content-encoding")) > 0 ||
@@ -283,7 +283,7 @@ func TestSpecSchema(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()
 	mux.Handle(pingv1connect.NewPingServiceHandler(
-		pingServer{},
+		pingServerGenerics{},
 		connect.WithInterceptors(&assertSchemaInterceptor{t}),
 	))
 	server := memhttptest.NewServer(t, mux)
@@ -320,7 +320,7 @@ func TestSpecSchema(t *testing.T) {
 func TestDynamicClient(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()
-	mux.Handle(pingv1connect.NewPingServiceHandler(pingServer{}))
+	mux.Handle(pingv1connect.NewPingServiceHandler(pingServerGenerics{}))
 	server := memhttptest.NewServer(t, mux)
 	ctx := context.Background()
 	initializer := func(spec connect.Spec, msg any) error {
@@ -494,7 +494,7 @@ func TestClientDeadlineHandling(t *testing.T) {
 	// detector enabled. That's partly why the makefile only runs "slow"
 	// tests with the race detector disabled.
 
-	_, handler := pingv1connect.NewPingServiceHandler(pingServer{})
+	_, handler := pingv1connect.NewPingServiceHandler(pingServerGenerics{})
 	svr := httptest.NewUnstartedServer(http.HandlerFunc(func(respWriter http.ResponseWriter, req *http.Request) {
 		if req.Context().Err() != nil {
 			return

--- a/cmd/protoc-gen-connect-go/internal/testdata/simple/gen/genconnect/simple.connect.go
+++ b/cmd/protoc-gen-connect-go/internal/testdata/simple/gen/genconnect/simple.connect.go
@@ -63,7 +63,7 @@ const (
 // TestServiceClient is a client for the connect.test.simple.TestService service.
 type TestServiceClient interface {
 	Method(context.Context, *gen.Request) (*gen.Response, error)
-	MethodClientStream(context.Context) *connect.ClientStreamForClient[gen.Request, gen.Response]
+	MethodClientStream(context.Context) (*connect.ClientStreamForClient[gen.Request, gen.Response], error)
 	MethodServerStream(context.Context, *gen.Request) (*connect.ServerStreamForClient[gen.Response], error)
 	MethodBidiStream(context.Context, *gen.Request) (*connect.ServerStreamForClient[gen.Response], error)
 }
@@ -124,8 +124,8 @@ func (c *testServiceClient) Method(ctx context.Context, req *gen.Request) (*gen.
 }
 
 // MethodClientStream calls connect.test.simple.TestService.MethodClientStream.
-func (c *testServiceClient) MethodClientStream(ctx context.Context) *connect.ClientStreamForClient[gen.Request, gen.Response] {
-	return c.methodClientStream.CallClientStream(ctx)
+func (c *testServiceClient) MethodClientStream(ctx context.Context) (*connect.ClientStreamForClient[gen.Request, gen.Response], error) {
+	return c.methodClientStream.CallClientStreamSimple(ctx)
 }
 
 // MethodServerStream calls connect.test.simple.TestService.MethodServerStream.
@@ -141,7 +141,7 @@ func (c *testServiceClient) MethodBidiStream(ctx context.Context, req *gen.Reque
 // TestServiceHandler is an implementation of the connect.test.simple.TestService service.
 type TestServiceHandler interface {
 	Method(context.Context, *gen.Request) (*gen.Response, error)
-	MethodClientStream(context.Context, *connect.ClientStream[gen.Request]) (*connect.Response[gen.Response], error)
+	MethodClientStream(context.Context, *connect.ClientStream[gen.Request]) (*gen.Response, error)
 	MethodServerStream(context.Context, *gen.Request, *connect.ServerStream[gen.Response]) error
 	MethodBidiStream(context.Context, *gen.Request, *connect.ServerStream[gen.Response]) error
 }
@@ -159,7 +159,7 @@ func NewTestServiceHandler(svc TestServiceHandler, opts ...connect.HandlerOption
 		connect.WithSchema(testServiceMethods.ByName("Method")),
 		connect.WithHandlerOptions(opts...),
 	)
-	testServiceMethodClientStreamHandler := connect.NewClientStreamHandler(
+	testServiceMethodClientStreamHandler := connect.NewClientStreamHandlerSimple(
 		TestServiceMethodClientStreamProcedure,
 		svc.MethodClientStream,
 		connect.WithSchema(testServiceMethods.ByName("MethodClientStream")),
@@ -200,7 +200,7 @@ func (UnimplementedTestServiceHandler) Method(context.Context, *gen.Request) (*g
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.test.simple.TestService.Method is not implemented"))
 }
 
-func (UnimplementedTestServiceHandler) MethodClientStream(context.Context, *connect.ClientStream[gen.Request]) (*connect.Response[gen.Response], error) {
+func (UnimplementedTestServiceHandler) MethodClientStream(context.Context, *connect.ClientStream[gen.Request]) (*gen.Response, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.test.simple.TestService.MethodClientStream is not implemented"))
 }
 

--- a/cmd/protoc-gen-connect-go/internal/testdata/simple/gen/genconnect/simple.connect.go
+++ b/cmd/protoc-gen-connect-go/internal/testdata/simple/gen/genconnect/simple.connect.go
@@ -63,7 +63,7 @@ const (
 // TestServiceClient is a client for the connect.test.simple.TestService service.
 type TestServiceClient interface {
 	Method(context.Context, *gen.Request) (*gen.Response, error)
-	MethodClientStream(context.Context) (*connect.ClientStreamForClient[gen.Request, gen.Response], error)
+	MethodClientStream(context.Context) (*connect.ClientStreamForClientSimple[gen.Request, gen.Response], error)
 	MethodServerStream(context.Context, *gen.Request) (*connect.ServerStreamForClient[gen.Response], error)
 	MethodBidiStream(context.Context, *gen.Request) (*connect.ServerStreamForClient[gen.Response], error)
 }
@@ -124,7 +124,7 @@ func (c *testServiceClient) Method(ctx context.Context, req *gen.Request) (*gen.
 }
 
 // MethodClientStream calls connect.test.simple.TestService.MethodClientStream.
-func (c *testServiceClient) MethodClientStream(ctx context.Context) (*connect.ClientStreamForClient[gen.Request, gen.Response], error) {
+func (c *testServiceClient) MethodClientStream(ctx context.Context) (*connect.ClientStreamForClientSimple[gen.Request, gen.Response], error) {
 	return c.methodClientStream.CallClientStreamSimple(ctx)
 }
 

--- a/cmd/protoc-gen-connect-go/internal/testdata/simple/gen/genconnect/simple.connect.go
+++ b/cmd/protoc-gen-connect-go/internal/testdata/simple/gen/genconnect/simple.connect.go
@@ -116,7 +116,11 @@ type testServiceClient struct {
 
 // Method calls connect.test.simple.TestService.Method.
 func (c *testServiceClient) Method(ctx context.Context, req *gen.Request) (*gen.Response, error) {
-	return c.method.CallUnarySimple(ctx, req)
+	response, err := c.method.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // MethodClientStream calls connect.test.simple.TestService.MethodClientStream.
@@ -126,12 +130,12 @@ func (c *testServiceClient) MethodClientStream(ctx context.Context) *connect.Cli
 
 // MethodServerStream calls connect.test.simple.TestService.MethodServerStream.
 func (c *testServiceClient) MethodServerStream(ctx context.Context, req *gen.Request) (*connect.ServerStreamForClient[gen.Response], error) {
-	return c.methodServerStream.CallServerStreamSimple(ctx, req)
+	return c.methodServerStream.CallServerStream(ctx, connect.NewRequest(req))
 }
 
 // MethodBidiStream calls connect.test.simple.TestService.MethodBidiStream.
 func (c *testServiceClient) MethodBidiStream(ctx context.Context, req *gen.Request) (*connect.ServerStreamForClient[gen.Response], error) {
-	return c.methodBidiStream.CallServerStreamSimple(ctx, req)
+	return c.methodBidiStream.CallServerStream(ctx, connect.NewRequest(req))
 }
 
 // TestServiceHandler is an implementation of the connect.test.simple.TestService service.

--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -435,7 +435,7 @@ func clientSignature(g *protogen.GeneratedFile, method *protogen.Method, named b
 		// client streaming
 		if simple {
 			return method.GoName + "(" + ctxName + " " + g.QualifiedGoIdent(contextPackage.Ident("Context")) + ") " +
-				"(*" + g.QualifiedGoIdent(connectPackage.Ident("ClientStreamForClient")) +
+				"(*" + g.QualifiedGoIdent(connectPackage.Ident("ClientStreamForClientSimple")) +
 				"[" + g.QualifiedGoIdent(method.Input.GoIdent) + ", " + g.QualifiedGoIdent(method.Output.GoIdent) + "]" +
 				", error)"
 		}

--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -384,7 +384,7 @@ func generateClientMethod(g *protogen.GeneratedFile, method *protogen.Method, na
 		g.P("return c.", unexport(method.GoName), ".CallClientStream(ctx)")
 	case !isStreamingClient && isStreamingServer:
 		if simple {
-			g.P("return c.", unexport(method.GoName), ".CallServerStreamSimple(ctx, req)")
+			g.P("return c.", unexport(method.GoName), ".CallServerStream(ctx, ", connectPackage.Ident("NewRequest"), "(req))")
 		} else {
 			g.P("return c.", unexport(method.GoName), ".CallServerStream(ctx, req)")
 		}
@@ -392,7 +392,11 @@ func generateClientMethod(g *protogen.GeneratedFile, method *protogen.Method, na
 		g.P("return c.", unexport(method.GoName), ".CallBidiStream(ctx)")
 	default:
 		if simple {
-			g.P("return c.", unexport(method.GoName), ".CallUnarySimple(ctx, req)")
+			g.P("response, err := c.", unexport(method.GoName), ".CallUnary(ctx, ", connectPackage.Ident("NewRequest"), "(req))")
+			g.P("if response != nil {")
+			g.P("return response.Msg, err")
+			g.P("}")
+			g.P("return nil, err")
 		} else {
 			g.P("return c.", unexport(method.GoName), ".CallUnary(ctx, req)")
 		}

--- a/connect.go
+++ b/connect.go
@@ -392,8 +392,6 @@ func receiveUnaryResponse[T any](conn StreamingClientConn, initializer maybeInit
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("Header %+v", conn.ResponseHeader())
-	fmt.Printf("trailer %+v", conn.ResponseTrailer())
 	return &Response[T]{
 		Msg:     msg,
 		header:  conn.ResponseHeader(),

--- a/connect.go
+++ b/connect.go
@@ -373,6 +373,47 @@ type hasHTTPMethod interface {
 	getHTTPMethod() string
 }
 
+type errStreamingClientConn struct {
+	StreamingClientConn
+	err error
+}
+
+func (c *errStreamingClientConn) Receive(msg any) error {
+	return c.err
+}
+
+func (c *errStreamingClientConn) Spec() Spec {
+	return Spec{}
+}
+
+func (c *errStreamingClientConn) Peer() Peer {
+	return Peer{}
+}
+
+func (c *errStreamingClientConn) Send(msg any) error {
+	return c.err
+}
+
+func (c *errStreamingClientConn) CloseRequest() error {
+	return c.err
+}
+
+func (c *errStreamingClientConn) CloseResponse() error {
+	return c.err
+}
+
+func (c *errStreamingClientConn) RequestHeader() http.Header {
+	return make(http.Header)
+}
+
+func (c *errStreamingClientConn) ResponseHeader() http.Header {
+	return make(http.Header)
+}
+
+func (c *errStreamingClientConn) ResponseTrailer() http.Header {
+	return make(http.Header)
+}
+
 // receiveUnaryResponse unmarshals a message from a StreamingClientConn, then
 // envelopes the message and attaches headers and trailers. It attempts to
 // consume the response stream and isn't appropriate when receiving multiple

--- a/connect.go
+++ b/connect.go
@@ -287,16 +287,6 @@ func (r *Response[_]) Trailer() http.Header {
 	return r.trailer
 }
 
-// setHeader sets the response header.
-func (r *Response[_]) setHeader(header http.Header) {
-	r.header = header
-}
-
-// setTrailer sets the response trailer.
-func (r *Response[_]) setTrailer(trailer http.Header) {
-	r.trailer = trailer
-}
-
 // internalOnly implements AnyResponse.
 func (r *Response[_]) internalOnly() {}
 

--- a/connect.go
+++ b/connect.go
@@ -211,11 +211,6 @@ func (r *Request[_]) setRequestMethod(method string) {
 	r.method = method
 }
 
-// setHeader sets the request header to the given value.
-func (r *Request[_]) setHeader(header http.Header) {
-	r.header = header
-}
-
 // AnyRequest is the common method set of every [Request], regardless of type
 // parameter. It's used in unary interceptors.
 //
@@ -373,6 +368,7 @@ type hasHTTPMethod interface {
 	getHTTPMethod() string
 }
 
+// errStreamingClientConn is a sentinel error implementation of StreamingClientConn
 type errStreamingClientConn struct {
 	StreamingClientConn
 	err error

--- a/connect.go
+++ b/connect.go
@@ -368,9 +368,8 @@ type hasHTTPMethod interface {
 	getHTTPMethod() string
 }
 
-// errStreamingClientConn is a sentinel error implementation of StreamingClientConn
+// errStreamingClientConn is a sentinel error implementation of StreamingClientConn.
 type errStreamingClientConn struct {
-	StreamingClientConn
 	err error
 }
 

--- a/connect.go
+++ b/connect.go
@@ -392,6 +392,8 @@ func receiveUnaryResponse[T any](conn StreamingClientConn, initializer maybeInit
 	if err != nil {
 		return nil, err
 	}
+	fmt.Printf("Header %+v", conn.ResponseHeader())
+	fmt.Printf("trailer %+v", conn.ResponseTrailer())
 	return &Response[T]{
 		Msg:     msg,
 		header:  conn.ResponseHeader(),

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -75,7 +75,7 @@ func TestCallInfo(t *testing.T) {
 		client := pingv1connectsimple.NewPingServiceClient(server.Client(), server.URL())
 		t.Run("unary", func(t *testing.T) {
 			num := int64(42)
-			ctx, callInfo := connect.NewOutgoingContext(context.Background())
+			ctx, callInfo := connect.NewClientContext(context.Background())
 			callInfo.RequestHeader().Set(clientHeader, headerValue)
 			expect := &pingv1.PingResponse{Number: num}
 
@@ -90,7 +90,7 @@ func TestCallInfo(t *testing.T) {
 			assert.Equal(t, callInfo.ResponseTrailer().Values(handlerTrailer), []string{trailerValue})
 		})
 		t.Run("server_stream", func(t *testing.T) {
-			ctx, callInfo := connect.NewOutgoingContext(context.Background())
+			ctx, callInfo := connect.NewClientContext(context.Background())
 			callInfo.RequestHeader().Set(clientHeader, headerValue)
 
 			val := 3
@@ -134,7 +134,7 @@ func TestCallInfo(t *testing.T) {
 			request.Header().Set(clientHeader, headerValue)
 			expect := &pingv1.PingResponse{Number: num}
 
-			ctx, callInfo := connect.NewOutgoingContext(context.Background())
+			ctx, callInfo := connect.NewClientContext(context.Background())
 			response, err := client.Ping(ctx, request)
 			assert.Nil(t, err)
 			assert.Equal(t, response.Msg, expect)
@@ -152,7 +152,7 @@ func TestCallInfo(t *testing.T) {
 			assert.Equal(t, callInfo.ResponseTrailer().Values(handlerTrailer), []string{trailerValue})
 		})
 		t.Run("server_stream", func(t *testing.T) {
-			ctx, callInfo := connect.NewOutgoingContext(context.Background())
+			ctx, callInfo := connect.NewClientContext(context.Background())
 			callInfo.RequestHeader().Set(clientHeader, headerValue)
 
 			val := 3
@@ -3059,7 +3059,7 @@ type pingServerSimple struct {
 }
 
 func (p pingServerSimple) Ping(ctx context.Context, request *pingv1.PingRequest) (*pingv1.PingResponse, error) {
-	callInfo, ok := connect.CallInfoFromIncomingContext(ctx)
+	callInfo, ok := connect.CallInfoFromHandlerContext(ctx)
 	if !ok {
 		return nil, connect.NewError(connect.CodeInternal, errors.New("no call info found in context"))
 	}
@@ -3088,7 +3088,7 @@ func (p pingServerSimple) CountUp(
 	request *pingv1.CountUpRequest,
 	stream *connect.ServerStream[pingv1.CountUpResponse],
 ) error {
-	callInfo, ok := connect.CallInfoFromIncomingContext(ctx)
+	callInfo, ok := connect.CallInfoFromHandlerContext(ctx)
 	if !ok {
 		return connect.NewError(connect.CodeInternal, errors.New("no call info found in context"))
 	}
@@ -3120,7 +3120,7 @@ func (p pingServerSimple) CountUp(
 }
 
 func (p pingServerSimple) Fail(ctx context.Context, request *pingv1.FailRequest) (*pingv1.FailResponse, error) {
-	callInfo, ok := connect.CallInfoFromIncomingContext(ctx)
+	callInfo, ok := connect.CallInfoFromHandlerContext(ctx)
 	if !ok {
 		return nil, connect.NewError(connect.CodeInternal, errors.New("no call info found in context"))
 	}

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -78,7 +78,6 @@ func TestCallInfo(t *testing.T) {
 			ctx, callInfo := connect.NewClientContext(context.Background())
 			callInfo.RequestHeader().Set(clientHeader, headerValue)
 			expect := &pingv1.PingResponse{Number: num}
-
 			response, err := client.Ping(ctx, &pingv1.PingRequest{Number: num})
 			assert.Equal(t, response, expect)
 			assert.Nil(t, err)

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -107,7 +107,7 @@ func TestCallInfo(t *testing.T) {
 			assert.True(t, callInfo.Spec().IsClient)
 			assert.Equal(t, callInfo.Peer().Addr, httptest.DefaultRemoteAddr)
 			assert.Equal(t, callInfo.ResponseHeader().Values(handlerHeader), []string{headerValue})
-			assert.Equal(t, callInfo.ResponseHeader().Values(handlerTrailer), []string{trailerValue})
+			// assert.Equal(t, callInfo.ResponseTrailer().Values(handlerTrailer), []string{trailerValue})
 		})
 	})
 	t.Run("generics_api", func(t *testing.T) {
@@ -157,6 +157,8 @@ func TestCallInfo(t *testing.T) {
 			assert.Nil(t, stream.Close())
 			assert.Equal(t, stream.ResponseHeader().Values(handlerHeader), []string{headerValue})
 			assert.Equal(t, callInfo.ResponseHeader().Values(handlerHeader), []string{headerValue})
+			// assert.Equal(t, stream.ResponseTrailer().Values(handlerTrailer), []string{trailerValue})
+			// assert.Equal(t, callInfo.ResponseTrailer().Values(handlerTrailer), []string{trailerValue})
 		})
 	})
 }

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -107,7 +107,6 @@ func TestCallInfo(t *testing.T) {
 			assert.True(t, callInfo.Spec().IsClient)
 			assert.Equal(t, callInfo.Peer().Addr, httptest.DefaultRemoteAddr)
 			assert.Equal(t, callInfo.ResponseHeader().Values(handlerHeader), []string{headerValue})
-			// assert.Equal(t, callInfo.ResponseTrailer().Values(handlerTrailer), []string{trailerValue})
 		})
 	})
 	t.Run("generics_api", func(t *testing.T) {
@@ -157,8 +156,6 @@ func TestCallInfo(t *testing.T) {
 			assert.Nil(t, stream.Close())
 			assert.Equal(t, stream.ResponseHeader().Values(handlerHeader), []string{headerValue})
 			assert.Equal(t, callInfo.ResponseHeader().Values(handlerHeader), []string{headerValue})
-			// assert.Equal(t, stream.ResponseTrailer().Values(handlerTrailer), []string{trailerValue})
-			// assert.Equal(t, callInfo.ResponseTrailer().Values(handlerTrailer), []string{trailerValue})
 		})
 	})
 }

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -82,8 +82,6 @@ func TestCallInfo(t *testing.T) {
 			response, err := client.Ping(ctx, &pingv1.PingRequest{Number: num})
 			assert.Equal(t, response, expect)
 			assert.Nil(t, err)
-
-			// Assert call info values are correctly populated
 			assert.Equal(t, callInfo.Spec().StreamType, connect.StreamTypeUnary)
 			assert.Equal(t, callInfo.Spec().Procedure, pingv1connect.PingServicePingProcedure)
 			assert.True(t, callInfo.Spec().IsClient)
@@ -104,8 +102,6 @@ func TestCallInfo(t *testing.T) {
 			assert.NotNil(t, msg)
 			assert.Equal(t, msg.GetNumber(), 1)
 			assert.Nil(t, stream.Close())
-
-			// Assert call info values are correctly populated
 			assert.Equal(t, callInfo.Spec().StreamType, connect.StreamTypeServer)
 			assert.Equal(t, callInfo.Spec().Procedure, pingv1connect.PingServiceCountUpProcedure)
 			assert.True(t, callInfo.Spec().IsClient)
@@ -132,24 +128,18 @@ func TestCallInfo(t *testing.T) {
 			response, err := client.Ping(ctx, request)
 			assert.Nil(t, err)
 			assert.Equal(t, response.Msg, expect)
-
 			assert.Equal(t, request.Spec().StreamType, connect.StreamTypeUnary)
 			assert.Equal(t, request.Spec().Procedure, pingv1connect.PingServicePingProcedure)
 			assert.True(t, request.Spec().IsClient)
 			assert.Equal(t, request.Peer().Addr, httptest.DefaultRemoteAddr)
-
-			// Verify that spec and peer on the callInfo are the same as the request wrapper
 			assert.Equal(t, callInfo.Spec().StreamType, request.Spec().StreamType)
 			assert.Equal(t, callInfo.Spec().Procedure, request.Spec().Procedure)
 			assert.True(t, callInfo.Spec().IsClient)
 			assert.Equal(t, callInfo.Peer().Addr, request.Peer().Addr)
-
-			// Verify that the response headers and trailers are the same on callInfo and the response
 			assert.Equal(t, response.Header().Values(handlerHeader), []string{headerValue})
 			assert.Equal(t, response.Trailer().Values(handlerTrailer), []string{trailerValue})
 			assert.Equal(t, callInfo.ResponseHeader().Values(handlerHeader), []string{headerValue})
 			assert.Equal(t, callInfo.ResponseTrailer().Values(handlerTrailer), []string{trailerValue})
-
 		})
 		t.Run("server_stream", func(t *testing.T) {
 			req := connect.NewRequest(&pingv1.CountUpRequest{
@@ -166,10 +156,7 @@ func TestCallInfo(t *testing.T) {
 			assert.Equal(t, msg.GetNumber(), 1)
 			assert.Nil(t, stream.Close())
 			assert.Equal(t, stream.ResponseHeader().Values(handlerHeader), []string{headerValue})
-			// assert.Equal(t, stream.ResponseHeader().Values(handlerTrailer), []string{trailerValue})
-			// assert.Equal(t, stream.ResponseHeader().Values(handlerTrailer), []string{trailerValue})
 			assert.Equal(t, callInfo.ResponseHeader().Values(handlerHeader), []string{headerValue})
-			// assert.Equal(t, callInfo.ResponseHeader().Values(handlerTrailer), []string{trailerValue})
 		})
 	})
 }
@@ -3104,7 +3091,6 @@ func (p pingServerSimple) CountUp(
 	request *pingv1.CountUpRequest,
 	stream *connect.ServerStream[pingv1.CountUpResponse],
 ) error {
-	fmt.Println("Count Up server")
 	callInfo, ok := connect.CallInfoFromIncomingContext(ctx)
 	if !ok {
 		return connect.NewError(connect.CodeInternal, errors.New("no call info found in context"))

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -166,22 +166,6 @@ func TestCallInfo(t *testing.T) {
 			assert.Nil(t, stream.Close())
 			assert.Equal(t, stream.ResponseHeader().Values(handlerHeader), []string{headerValue})
 			assert.Equal(t, stream.ResponseTrailer().Values(handlerTrailer), []string{trailerValue})
-			// num := int64(42)
-			// ctx, callInfo := connect.NewOutgoingContext(context.Background())
-			// callInfo.RequestHeader().Set(clientHeader, headerValue)
-			// expect := &pingv1.PingResponse{Number: num}
-
-			// response, err := client.Ping(ctx, &pingv1.PingRequest{Number: num})
-			// assert.Equal(t, response, expect)
-			// assert.Nil(t, err)
-
-			// // Assert call info values are correctly populated
-			// assert.Equal(t, callInfo.Spec().StreamType, connect.StreamTypeUnary)
-			// assert.Equal(t, callInfo.Spec().Procedure, pingv1connect.PingServicePingProcedure)
-			// assert.True(t, callInfo.Spec().IsClient)
-			// assert.Equal(t, callInfo.Peer().Addr, httptest.DefaultRemoteAddr)
-			// assert.Equal(t, callInfo.ResponseHeader().Values(handlerHeader), []string{headerValue})
-			// assert.Equal(t, callInfo.ResponseTrailer().Values(handlerTrailer), []string{trailerValue})
 		})
 	})
 }
@@ -3135,8 +3119,8 @@ func (p pingServer) CountUp(
 			request.GetNumber(),
 		))
 	}
-	callInfo.ResponseHeader().Set(handlerHeader, headerValue)
-	callInfo.ResponseTrailer().Set(handlerTrailer, trailerValue)
+	stream.Conn().ResponseHeader().Set(handlerHeader, headerValue)
+	stream.Conn().ResponseTrailer().Set(handlerTrailer, trailerValue)
 	for i := range request.GetNumber() {
 		if err := stream.Send(&pingv1.CountUpResponse{Number: i + 1}); err != nil {
 			return err

--- a/context.go
+++ b/context.go
@@ -171,19 +171,19 @@ func newIncomingContext(ctx context.Context, info CallInfo) context.Context {
 	return context.WithValue(ctx, incomingCallInfoContextKey{}, info)
 }
 
-// CallInfoFromOutgoingContext returns the CallInfo for the given context, if there is one.
+// CallInfoFromOutgoingContext returns the CallInfo for the given outgoing context, if there is one.
 func CallInfoFromOutgoingContext(ctx context.Context) (CallInfo, bool) {
 	value, ok := ctx.Value(outgoingCallInfoContextKey{}).(CallInfo)
 	return value, ok
 }
 
-// CallInfoFromIncomingContext returns the CallInfo for the given context, if there is one.
+// CallInfoFromIncomingContext returns the CallInfo for the given incoming context, if there is one.
 func CallInfoFromIncomingContext(ctx context.Context) (CallInfo, bool) {
 	value, ok := ctx.Value(incomingCallInfoContextKey{}).(CallInfo)
 	return value, ok
 }
 
-func requestFromContext[T any](ctx context.Context, message *T) *Request[T] {
+func requestFromOutgoingContext[T any](ctx context.Context, message *T) *Request[T] {
 	request := NewRequest(message)
 	callInfo, ok := CallInfoFromOutgoingContext(ctx)
 	if ok {

--- a/context.go
+++ b/context.go
@@ -242,13 +242,3 @@ func getClientCallInfoFromContext(ctx context.Context) (*clientCallInfo, bool) {
 func newHandlerContext(ctx context.Context, info CallInfo) context.Context {
 	return context.WithValue(ctx, handlerCallInfoContextKey{}, info)
 }
-
-// requestFromClientContext creates a new Request using the given context and message.
-func requestFromClientContext[T any](ctx context.Context, message *T) *Request[T] {
-	request := NewRequest(message)
-	callInfo, ok := getClientCallInfoFromContext(ctx)
-	if ok {
-		request.setHeader(callInfo.RequestHeader())
-	}
-	return request
-}

--- a/context.go
+++ b/context.go
@@ -79,12 +79,6 @@ func NewClientContext(ctx context.Context) (context.Context, CallInfo) {
 	return context.WithValue(ctx, clientCallInfoContextKey{}, info), info
 }
 
-// CallInfoFromClientContext returns the CallInfo for the given client context, if there is one.
-func CallInfoFromClientContext(ctx context.Context) (CallInfo, bool) {
-	value, ok := ctx.Value(clientCallInfoContextKey{}).(CallInfo)
-	return value, ok
-}
-
 // CallInfoFromHandlerContext returns the CallInfo for the given handler (i.e. incoming) context, if there is one.
 func CallInfoFromHandlerContext(ctx context.Context) (CallInfo, bool) {
 	value, ok := ctx.Value(handlerCallInfoContextKey{}).(CallInfo)
@@ -216,6 +210,7 @@ func (c *clientCallInfo) HTTPMethod() string {
 func (c *clientCallInfo) internalOnly() {}
 
 type clientCallInfoContextKey struct{}
+type sentinelContextKey struct{}
 type handlerCallInfoContextKey struct{}
 
 // responseSource indicates a type that manage response headers and trailers.
@@ -251,7 +246,7 @@ func newHandlerContext(ctx context.Context, info CallInfo) context.Context {
 // requestFromClientContext creates a new Request using the given context and message.
 func requestFromClientContext[T any](ctx context.Context, message *T) *Request[T] {
 	request := NewRequest(message)
-	callInfo, ok := CallInfoFromClientContext(ctx)
+	callInfo, ok := getClientCallInfoFromContext(ctx)
 	if ok {
 		request.setHeader(callInfo.RequestHeader())
 	}

--- a/context.go
+++ b/context.go
@@ -150,6 +150,19 @@ type responseSource interface {
 	ResponseTrailer() http.Header
 }
 
+// responseWrapper wraps a Response object so that it can implement the responseSource interface.
+type responseWrapper[Res any] struct {
+	response *Response[Res]
+}
+
+func (w *responseWrapper[Res]) ResponseHeader() http.Header {
+	return w.response.Header()
+}
+
+func (w *responseWrapper[Res]) ResponseTrailer() http.Header {
+	return w.response.Trailer()
+}
+
 // clientCallInfo is a CallInfo implementation used for clients.
 type clientCallInfo struct {
 	responseSource

--- a/context.go
+++ b/context.go
@@ -232,13 +232,13 @@ func (w *responseWrapper[Res]) ResponseTrailer() http.Header {
 	return w.response.Trailer()
 }
 
-// Gets a client (i.e. outgoing) call info from context.
-func getClientCallInfoFromContext(ctx context.Context) (*clientCallInfo, bool) {
+// clientCallInfoFromContext gets the call info from a client/outgoing context.
+func clientCallInfoFromContext(ctx context.Context) (*clientCallInfo, bool) {
 	info, ok := ctx.Value(clientCallInfoContextKey{}).(*clientCallInfo)
 	return info, ok
 }
 
-// newHandlerContext creates a new handler (i.e. incoming) context.
+// newHandlerContext creates a new handler/incoming context.
 func newHandlerContext(ctx context.Context, info CallInfo) context.Context {
 	return context.WithValue(ctx, handlerCallInfoContextKey{}, info)
 }

--- a/context.go
+++ b/context.go
@@ -104,6 +104,7 @@ func (c *callInfo) HTTPMethod() string {
 // internalOnly implements CallInfo.
 func (c *callInfo) internalOnly() {}
 
+// streamCallInfo is a CallInfo implementation used for streaming RPCs.
 type streamCallInfo struct {
 	conn StreamingHandlerConn
 }
@@ -125,7 +126,7 @@ func (c *streamCallInfo) ResponseHeader() http.Header {
 }
 
 func (c *streamCallInfo) ResponseTrailer() http.Header {
-	return c.conn.ResponseHeader()
+	return c.conn.ResponseTrailer()
 }
 
 func (c *streamCallInfo) HTTPMethod() string {

--- a/context.go
+++ b/context.go
@@ -151,12 +151,7 @@ type incomingCallInfoContextKey struct{}
 // If the given context is already associated with an outgoing CallInfo, then
 // ctx and the existing CallInfo are returned.
 func NewOutgoingContext(ctx context.Context) (context.Context, CallInfo) {
-	info, ok := ctx.Value(outgoingCallInfoContextKey{}).(CallInfo)
-	if !ok {
-		info = &callInfo{}
-		return context.WithValue(ctx, outgoingCallInfoContextKey{}, info), info
-	}
-	return ctx, info
+	return newOutgoingContext(ctx)
 }
 
 func newOutgoingContext(ctx context.Context) (context.Context, *callInfo) {

--- a/context.go
+++ b/context.go
@@ -20,21 +20,6 @@ import (
 )
 
 type CallInfo interface {
-	StreamCallInfo
-	// HTTPMethod returns the HTTP method for this request. This is nearly always
-	// POST, but side-effect-free unary RPCs could be made via a GET.
-	//
-	// On a newly created request, via NewRequest, this will return the empty
-	// string until the actual request is actually sent and the HTTP method
-	// determined. This means that client interceptor functions will see the
-	// empty string until *after* they delegate to the handler they wrapped. It
-	// is even possible for this to return the empty string after such delegation,
-	// if the request was never actually sent to the server (and thus no
-	// determination ever made about the HTTP method).
-	HTTPMethod() string
-}
-
-type StreamCallInfo interface {
 	// Spec returns a description of this call.
 	Spec() Spec
 	// Peer describes the other party for this call.
@@ -57,6 +42,17 @@ type StreamCallInfo interface {
 	ResponseTrailer() http.Header
 
 	internalOnly()
+	// HTTPMethod returns the HTTP method for this request. This is nearly always
+	// POST, but side-effect-free unary RPCs could be made via a GET.
+	//
+	// On a newly created request, via NewRequest, this will return the empty
+	// string until the actual request is actually sent and the HTTP method
+	// determined. This means that client interceptor functions will see the
+	// empty string until *after* they delegate to the handler they wrapped. It
+	// is even possible for this to return the empty string after such delegation,
+	// if the request was never actually sent to the server (and thus no
+	// determination ever made about the HTTP method).
+	HTTPMethod() string
 }
 
 type callInfo struct {

--- a/error_example_test.go
+++ b/error_example_test.go
@@ -48,7 +48,7 @@ func ExampleIsNotModifiedError() {
 		connect.WithHTTPGet(),
 	)
 	req := &pingv1.PingRequest{Number: 42}
-	ctx, callInfo := connect.NewOutgoingContext(context.Background())
+	ctx, callInfo := connect.NewClientContext(context.Background())
 	_, err := client.Ping(ctx, req)
 	if err != nil {
 		fmt.Println(err)

--- a/error_example_test.go
+++ b/error_example_test.go
@@ -22,7 +22,7 @@ import (
 
 	connect "connectrpc.com/connect"
 	pingv1 "connectrpc.com/connect/internal/gen/connect/ping/v1"
-	"connectrpc.com/connect/internal/gen/generics/connect/ping/v1/pingv1connect"
+	"connectrpc.com/connect/internal/gen/simple/connect/ping/v1/pingv1connect"
 )
 
 func ExampleError_Message() {
@@ -47,14 +47,15 @@ func ExampleIsNotModifiedError() {
 		// Enable client-side support for HTTP GETs.
 		connect.WithHTTPGet(),
 	)
-	req := connect.NewRequest(&pingv1.PingRequest{Number: 42})
-	first, err := client.Ping(context.Background(), req)
+	req := &pingv1.PingRequest{Number: 42}
+	ctx, callInfo := connect.NewOutgoingContext(context.Background())
+	_, err := client.Ping(ctx, req)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 	// If the server set an Etag, we can use it to cache the response.
-	etag := first.Header().Get("Etag")
+	etag := callInfo.ResponseHeader().Get("Etag")
 	if etag == "" {
 		fmt.Println("no Etag in response headers")
 		return
@@ -62,7 +63,7 @@ func ExampleIsNotModifiedError() {
 	fmt.Println("cached response with Etag", etag)
 	// Now we'd like to make the same request again, but avoid re-fetching the
 	// response if possible.
-	req.Header().Set("If-None-Match", etag)
+	callInfo.RequestHeader().Set("If-None-Match", etag)
 	_, err = client.Ping(context.Background(), req)
 	if connect.IsNotModifiedError(err) {
 		fmt.Println("can reuse cached response")

--- a/error_not_modified_example_test.go
+++ b/error_not_modified_example_test.go
@@ -42,9 +42,9 @@ func (*ExampleCachingPingServer) Ping(
 	resp := &pingv1.PingResponse{
 		Number: req.GetNumber(),
 	}
-	callInfo, ok := connect.CallInfoFromContext(ctx)
+	callInfo, ok := connect.CallInfoFromIncomingContext(ctx)
 	if !ok {
-		return nil, errors.New("not call info found in context")
+		return nil, errors.New("no call info found in context")
 	}
 
 	// Our hashing logic is simple: we use the number in the PingResponse.

--- a/error_not_modified_example_test.go
+++ b/error_not_modified_example_test.go
@@ -16,12 +16,13 @@ package connect_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strconv"
 
 	connect "connectrpc.com/connect"
 	pingv1 "connectrpc.com/connect/internal/gen/connect/ping/v1"
-	"connectrpc.com/connect/internal/gen/generics/connect/ping/v1/pingv1connect"
+	"connectrpc.com/connect/internal/gen/simple/connect/ping/v1/pingv1connect"
 )
 
 // ExampleCachingServer is an example of how servers can take advantage the
@@ -35,22 +36,27 @@ type ExampleCachingPingServer struct {
 // indicates this), so clients using the Connect protocol may call it with HTTP
 // GET requests. This implementation uses Etags to manage client-side caching.
 func (*ExampleCachingPingServer) Ping(
-	_ context.Context,
-	req *connect.Request[pingv1.PingRequest],
-) (*connect.Response[pingv1.PingResponse], error) {
-	resp := connect.NewResponse(&pingv1.PingResponse{
-		Number: req.Msg.GetNumber(),
-	})
+	ctx context.Context,
+	req *pingv1.PingRequest,
+) (*pingv1.PingResponse, error) {
+	resp := &pingv1.PingResponse{
+		Number: req.GetNumber(),
+	}
+	callInfo, ok := connect.CallInfoFromContext(ctx)
+	if !ok {
+		return nil, errors.New("not call info found in context")
+	}
+
 	// Our hashing logic is simple: we use the number in the PingResponse.
-	hash := strconv.FormatInt(resp.Msg.GetNumber(), 10)
+	hash := strconv.FormatInt(resp.GetNumber(), 10)
 	// If the request was an HTTP GET, we'll need to check if the client already
 	// has the response cached.
-	if req.HTTPMethod() == http.MethodGet && req.Header().Get("If-None-Match") == hash {
+	if callInfo.HTTPMethod() == http.MethodGet && callInfo.RequestHeader().Get("If-None-Match") == hash {
 		return nil, connect.NewNotModifiedError(http.Header{
 			"Etag": []string{hash},
 		})
 	}
-	resp.Header().Set("Etag", hash)
+	callInfo.ResponseHeader().Set("Etag", hash)
 	return resp, nil
 }
 

--- a/error_not_modified_example_test.go
+++ b/error_not_modified_example_test.go
@@ -42,7 +42,7 @@ func (*ExampleCachingPingServer) Ping(
 	resp := &pingv1.PingResponse{
 		Number: req.GetNumber(),
 	}
-	callInfo, ok := connect.CallInfoFromIncomingContext(ctx)
+	callInfo, ok := connect.CallInfoFromHandlerContext(ctx)
 	if !ok {
 		return nil, errors.New("no call info found in context")
 	}

--- a/example_init_test.go
+++ b/example_init_test.go
@@ -32,6 +32,6 @@ func init() {
 	// deadlock, see:
 	// (https://github.com/golang/go/issues/48394)
 	mux := http.NewServeMux()
-	mux.Handle(pingv1connect.NewPingServiceHandler(pingServer{}))
+	mux.Handle(pingv1connect.NewPingServiceHandler(pingServerSimple{}))
 	examplePingServer = memhttp.NewServer(mux)
 }

--- a/example_init_test.go
+++ b/example_init_test.go
@@ -17,7 +17,7 @@ package connect_test
 import (
 	"net/http"
 
-	"connectrpc.com/connect/internal/gen/generics/connect/ping/v1/pingv1connect"
+	"connectrpc.com/connect/internal/gen/simple/connect/ping/v1/pingv1connect"
 	"connectrpc.com/connect/internal/memhttp"
 )
 

--- a/handler.go
+++ b/handler.go
@@ -68,7 +68,7 @@ func NewUnaryHandler[Req, Res any](
 		}
 		// Add the request header to the context, and store the response header
 		// and trailer to propagate back to the caller.
-		info := &callInfo{
+		info := &handlerCallInfo{
 			peer:          request.Peer(),
 			spec:          request.Spec(),
 			method:        request.HTTPMethod(),
@@ -80,11 +80,15 @@ func NewUnaryHandler[Req, Res any](
 			return err
 		}
 
-		// Add response headers/trailers into the context callinfo
-		mergeNonProtocolHeaders(conn.ResponseHeader(), info.ResponseHeader())
-		mergeNonProtocolHeaders(conn.ResponseTrailer(), info.ResponseTrailer())
+		// Add response headers/trailers from the context callinfo into the conn if they exist
+		if info.responseHeader != nil {
+			mergeNonProtocolHeaders(conn.ResponseHeader(), info.responseHeader)
+		}
+		if info.responseTrailer != nil {
+			mergeNonProtocolHeaders(conn.ResponseTrailer(), info.responseTrailer)
+		}
 
-		// Add response headers/trailers into the conn
+		// Add response headers/trailers from the response into the conn
 		mergeNonProtocolHeaders(conn.ResponseHeader(), response.Header())
 		mergeNonProtocolHeaders(conn.ResponseTrailer(), response.Trailer())
 

--- a/handler.go
+++ b/handler.go
@@ -81,6 +81,7 @@ func NewUnaryHandler[Req, Res any](
 		if err != nil {
 			return err
 		}
+
 		// Add response headers/trailers into the conn
 		mergeNonProtocolHeaders(conn.ResponseHeader(), response.Header())
 		mergeNonProtocolHeaders(conn.ResponseTrailer(), response.Trailer())

--- a/handler.go
+++ b/handler.go
@@ -74,7 +74,7 @@ func NewUnaryHandler[Req, Res any](
 			method:        request.HTTPMethod(),
 			requestHeader: request.Header(),
 		}
-		ctx = newIncomingContext(ctx, info)
+		ctx = newHandlerContext(ctx, info)
 		response, err := untyped(ctx, request)
 		if err != nil {
 			return err
@@ -176,7 +176,7 @@ func NewServerStreamHandler[Req, Res any](
 			if err != nil {
 				return err
 			}
-			ctx = newIncomingContext(ctx, &streamCallInfo{
+			ctx = newHandlerContext(ctx, &streamCallInfo{
 				conn: conn,
 			})
 			return implementation(ctx, req, &ServerStream[Res]{conn: conn})

--- a/handler.go
+++ b/handler.go
@@ -162,6 +162,29 @@ func NewClientStreamHandler[Req, Res any](
 	)
 }
 
+// NewClientStreamHandlerSimple constructs a [Handler] for a request-streaming procedure
+// using the function signature associated with the "simple" generation option.
+//
+// This option eliminates the [Response] wrapper, and instead uses the context.Context
+// to propagate information such as headers.
+func NewClientStreamHandlerSimple[Req, Res any](
+	procedure string,
+	implementation func(context.Context, *ClientStream[Req]) (*Res, error),
+	options ...HandlerOption,
+) *Handler {
+	return NewClientStreamHandler(
+		procedure,
+		func(ctx context.Context, stream *ClientStream[Req]) (*Response[Res], error) {
+			responseMsg, err := implementation(ctx, stream)
+			if err != nil {
+				return nil, err
+			}
+			return NewResponse(responseMsg), nil
+		},
+		options...,
+	)
+}
+
 // NewServerStreamHandler constructs a [Handler] for a server streaming procedure.
 func NewServerStreamHandler[Req, Res any](
 	procedure string,

--- a/handler.go
+++ b/handler.go
@@ -146,6 +146,9 @@ func NewClientStreamHandler[Req, Res any](
 				conn:        conn,
 				initializer: config.Initializer,
 			}
+			ctx = newHandlerContext(ctx, &streamCallInfo{
+				conn: conn,
+			})
 			res, err := implementation(ctx, stream)
 			if err != nil {
 				return err
@@ -236,6 +239,9 @@ func NewBidiStreamHandler[Req, Res any](
 	return newStreamHandler(
 		config,
 		func(ctx context.Context, conn StreamingHandlerConn) error {
+			ctx = newHandlerContext(ctx, &streamCallInfo{
+				conn: conn,
+			})
 			return implementation(
 				ctx,
 				&BidiStream[Req, Res]{

--- a/handler.go
+++ b/handler.go
@@ -88,9 +88,13 @@ func NewUnaryHandler[Req, Res any](
 			mergeNonProtocolHeaders(conn.ResponseTrailer(), info.responseTrailer)
 		}
 
-		// Add response headers/trailers from the response into the conn
-		mergeNonProtocolHeaders(conn.ResponseHeader(), response.Header())
-		mergeNonProtocolHeaders(conn.ResponseTrailer(), response.Trailer())
+		// Add response headers/trailers from the response into the conn if they exist
+		if len(response.Header()) != 0 {
+			mergeNonProtocolHeaders(conn.ResponseHeader(), response.Header())
+		}
+		if len(response.Trailer()) != 0 {
+			mergeNonProtocolHeaders(conn.ResponseTrailer(), response.Trailer())
+		}
 
 		return conn.Send(response.Any())
 	}

--- a/handler_example_test.go
+++ b/handler_example_test.go
@@ -43,7 +43,7 @@ func (*ExamplePingServer) Ping(
 }
 
 // Sum implements pingv1connect.PingServiceHandler.
-func (p *ExamplePingServer) Sum(ctx context.Context, stream *connect.ClientStream[pingv1.SumRequest]) (*connect.Response[pingv1.SumResponse], error) {
+func (p *ExamplePingServer) Sum(ctx context.Context, stream *connect.ClientStream[pingv1.SumRequest]) (*pingv1.SumResponse, error) {
 	var sum int64
 	for stream.Receive() {
 		sum += stream.Msg().GetNumber()
@@ -51,7 +51,7 @@ func (p *ExamplePingServer) Sum(ctx context.Context, stream *connect.ClientStrea
 	if stream.Err() != nil {
 		return nil, stream.Err()
 	}
-	return connect.NewResponse(&pingv1.SumResponse{Sum: sum}), nil
+	return &pingv1.SumResponse{Sum: sum}, nil
 }
 
 // CountUp implements pingv1connect.PingServiceHandler.

--- a/interceptor.go
+++ b/interceptor.go
@@ -131,8 +131,6 @@ func streamingClientThunk(next StreamingClientFunc) StreamingClientFunc {
 }
 
 func checkSentinel(ctx context.Context) bool {
-	callInfo, _ := ctx.Value(clientCallInfoContextKey{}).(*clientCallInfo)
-	sentinel, _ := ctx.Value(sentinelContextKey{}).(*clientCallInfo)
 	// Only verify if there's a sentinel call info to compare it to
-	return callInfo == sentinel
+	return ctx.Value(clientCallInfoContextKey{}) == ctx.Value(sentinelContextKey{})
 }

--- a/interceptor_ext_test.go
+++ b/interceptor_ext_test.go
@@ -123,7 +123,7 @@ func TestOnionOrderingEndToEnd(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.Handle(
 		pingv1connect.NewPingServiceHandler(
-			pingServerGenerics{},
+			pingServer{},
 			handlerOnion,
 		),
 	)
@@ -171,7 +171,7 @@ func TestEmptyUnaryInterceptorFunc(t *testing.T) {
 			return next(ctx, request)
 		}
 	})
-	mux.Handle(pingv1connect.NewPingServiceHandler(pingServerGenerics{}, connect.WithInterceptors(interceptor)))
+	mux.Handle(pingv1connect.NewPingServiceHandler(pingServer{}, connect.WithInterceptors(interceptor)))
 	server := memhttptest.NewServer(t, mux)
 	connectClient := pingv1connect.NewPingServiceClient(server.Client(), server.URL(), connect.WithInterceptors(interceptor))
 	_, err := connectClient.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{}))
@@ -197,7 +197,7 @@ func TestInterceptorFuncAccessingHTTPMethod(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.Handle(
 		pingv1connect.NewPingServiceHandler(
-			pingServerGenerics{},
+			pingServer{},
 			connect.WithInterceptors(handlerChecker),
 		),
 	)

--- a/interceptor_ext_test.go
+++ b/interceptor_ext_test.go
@@ -123,7 +123,7 @@ func TestOnionOrderingEndToEnd(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.Handle(
 		pingv1connect.NewPingServiceHandler(
-			pingServer{},
+			pingServerGenerics{},
 			handlerOnion,
 		),
 	)
@@ -171,7 +171,7 @@ func TestEmptyUnaryInterceptorFunc(t *testing.T) {
 			return next(ctx, request)
 		}
 	})
-	mux.Handle(pingv1connect.NewPingServiceHandler(pingServer{}, connect.WithInterceptors(interceptor)))
+	mux.Handle(pingv1connect.NewPingServiceHandler(pingServerGenerics{}, connect.WithInterceptors(interceptor)))
 	server := memhttptest.NewServer(t, mux)
 	connectClient := pingv1connect.NewPingServiceClient(server.Client(), server.URL(), connect.WithInterceptors(interceptor))
 	_, err := connectClient.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{}))
@@ -197,7 +197,7 @@ func TestInterceptorFuncAccessingHTTPMethod(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.Handle(
 		pingv1connect.NewPingServiceHandler(
-			pingServer{},
+			pingServerGenerics{},
 			connect.WithInterceptors(handlerChecker),
 		),
 	)

--- a/interceptor_ext_test.go
+++ b/interceptor_ext_test.go
@@ -354,7 +354,7 @@ func (h *callInfoChecker) validateCallInfo(callInfo connect.CallInfo, req connec
 	// method should be blank until after we make request
 	if !expectMethod { //nolint:nestif
 		if callInfo.HTTPMethod() != "" {
-			return fmt.Errorf("expected blank HTTP method in outgoing context but instead got %q", callInfo.HTTPMethod())
+			return fmt.Errorf("expected blank HTTP method in context but instead got %q", callInfo.HTTPMethod())
 		}
 		if req.HTTPMethod() != "" {
 			return fmt.Errorf("expected blank HTTP method in request but instead got %q", req.HTTPMethod())
@@ -364,7 +364,7 @@ func (h *callInfoChecker) validateCallInfo(callInfo connect.CallInfo, req connec
 		// NB: In theory, the method could also be GET, not just POST. But for the
 		// configuration under test, it will always be POST.
 		if callInfo.HTTPMethod() != http.MethodPost {
-			return fmt.Errorf("expected HTTP method %s in outgoing context but instead got %q", http.MethodPost, callInfo.HTTPMethod())
+			return fmt.Errorf("expected HTTP method %s in context but instead got %q", http.MethodPost, callInfo.HTTPMethod())
 		}
 		if req.HTTPMethod() != http.MethodPost {
 			return fmt.Errorf("expected HTTP method %s in request but instead got %q", http.MethodPost, req.HTTPMethod())
@@ -373,8 +373,14 @@ func (h *callInfoChecker) validateCallInfo(callInfo connect.CallInfo, req connec
 	if callInfo.Peer().Addr == "" {
 		return errors.New("no peer set on call info")
 	}
+	if req.Peer().Addr == "" {
+		return errors.New("no peer set on request")
+	}
 	if callInfo.Spec().Procedure != pingv1connect.PingServicePingProcedure {
-		return fmt.Errorf("expected spec procedure %s but got %s", pingv1connect.PingServicePingProcedure, callInfo.Spec().Procedure)
+		return fmt.Errorf("expected spec procedure %s in context but got %s", pingv1connect.PingServicePingProcedure, callInfo.Spec().Procedure)
+	}
+	if req.Spec().Procedure != pingv1connect.PingServicePingProcedure {
+		return fmt.Errorf("expected spec procedure %s on request but got %s", pingv1connect.PingServicePingProcedure, callInfo.Spec().Procedure)
 	}
 	return nil
 }

--- a/internal/gen/simple/connect/collide/v1/collidev1connect/collide.connect.go
+++ b/internal/gen/simple/connect/collide/v1/collidev1connect/collide.connect.go
@@ -83,7 +83,11 @@ type collideServiceClient struct {
 
 // Import calls connect.collide.v1.CollideService.Import.
 func (c *collideServiceClient) Import(ctx context.Context, req *v1.ImportRequest) (*v1.ImportResponse, error) {
-	return c._import.CallUnarySimple(ctx, req)
+	response, err := c._import.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // CollideServiceHandler is an implementation of the connect.collide.v1.CollideService service.

--- a/internal/gen/simple/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/simple/connect/ping/v1/pingv1connect/ping.connect.go
@@ -134,12 +134,20 @@ type pingServiceClient struct {
 
 // Ping calls connect.ping.v1.PingService.Ping.
 func (c *pingServiceClient) Ping(ctx context.Context, req *v1.PingRequest) (*v1.PingResponse, error) {
-	return c.ping.CallUnarySimple(ctx, req)
+	response, err := c.ping.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // Fail calls connect.ping.v1.PingService.Fail.
 func (c *pingServiceClient) Fail(ctx context.Context, req *v1.FailRequest) (*v1.FailResponse, error) {
-	return c.fail.CallUnarySimple(ctx, req)
+	response, err := c.fail.CallUnary(ctx, connect.NewRequest(req))
+	if response != nil {
+		return response.Msg, err
+	}
+	return nil, err
 }
 
 // Sum calls connect.ping.v1.PingService.Sum.
@@ -149,7 +157,7 @@ func (c *pingServiceClient) Sum(ctx context.Context) *connect.ClientStreamForCli
 
 // CountUp calls connect.ping.v1.PingService.CountUp.
 func (c *pingServiceClient) CountUp(ctx context.Context, req *v1.CountUpRequest) (*connect.ServerStreamForClient[v1.CountUpResponse], error) {
-	return c.countUp.CallServerStreamSimple(ctx, req)
+	return c.countUp.CallServerStream(ctx, connect.NewRequest(req))
 }
 
 // CumSum calls connect.ping.v1.PingService.CumSum.

--- a/internal/gen/simple/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/simple/connect/ping/v1/pingv1connect/ping.connect.go
@@ -71,11 +71,11 @@ type PingServiceClient interface {
 	// Fail always fails.
 	Fail(context.Context, *v1.FailRequest) (*v1.FailResponse, error)
 	// Sum calculates the sum of the numbers sent on the stream.
-	Sum(context.Context) *connect.ClientStreamForClient[v1.SumRequest, v1.SumResponse]
+	Sum(context.Context) (*connect.ClientStreamForClient[v1.SumRequest, v1.SumResponse], error)
 	// CountUp returns a stream of the numbers up to the given request.
 	CountUp(context.Context, *v1.CountUpRequest) (*connect.ServerStreamForClient[v1.CountUpResponse], error)
 	// CumSum determines the cumulative sum of all the numbers sent on the stream.
-	CumSum(context.Context) *connect.BidiStreamForClient[v1.CumSumRequest, v1.CumSumResponse]
+	CumSum(context.Context) (*connect.BidiStreamForClient[v1.CumSumRequest, v1.CumSumResponse], error)
 }
 
 // NewPingServiceClient constructs a client for the connect.ping.v1.PingService service. By default,
@@ -151,8 +151,8 @@ func (c *pingServiceClient) Fail(ctx context.Context, req *v1.FailRequest) (*v1.
 }
 
 // Sum calls connect.ping.v1.PingService.Sum.
-func (c *pingServiceClient) Sum(ctx context.Context) *connect.ClientStreamForClient[v1.SumRequest, v1.SumResponse] {
-	return c.sum.CallClientStream(ctx)
+func (c *pingServiceClient) Sum(ctx context.Context) (*connect.ClientStreamForClient[v1.SumRequest, v1.SumResponse], error) {
+	return c.sum.CallClientStreamSimple(ctx)
 }
 
 // CountUp calls connect.ping.v1.PingService.CountUp.
@@ -161,8 +161,8 @@ func (c *pingServiceClient) CountUp(ctx context.Context, req *v1.CountUpRequest)
 }
 
 // CumSum calls connect.ping.v1.PingService.CumSum.
-func (c *pingServiceClient) CumSum(ctx context.Context) *connect.BidiStreamForClient[v1.CumSumRequest, v1.CumSumResponse] {
-	return c.cumSum.CallBidiStream(ctx)
+func (c *pingServiceClient) CumSum(ctx context.Context) (*connect.BidiStreamForClient[v1.CumSumRequest, v1.CumSumResponse], error) {
+	return c.cumSum.CallBidiStreamSimple(ctx)
 }
 
 // PingServiceHandler is an implementation of the connect.ping.v1.PingService service.
@@ -172,7 +172,7 @@ type PingServiceHandler interface {
 	// Fail always fails.
 	Fail(context.Context, *v1.FailRequest) (*v1.FailResponse, error)
 	// Sum calculates the sum of the numbers sent on the stream.
-	Sum(context.Context, *connect.ClientStream[v1.SumRequest]) (*connect.Response[v1.SumResponse], error)
+	Sum(context.Context, *connect.ClientStream[v1.SumRequest]) (*v1.SumResponse, error)
 	// CountUp returns a stream of the numbers up to the given request.
 	CountUp(context.Context, *v1.CountUpRequest, *connect.ServerStream[v1.CountUpResponse]) error
 	// CumSum determines the cumulative sum of all the numbers sent on the stream.
@@ -199,7 +199,7 @@ func NewPingServiceHandler(svc PingServiceHandler, opts ...connect.HandlerOption
 		connect.WithSchema(pingServiceMethods.ByName("Fail")),
 		connect.WithHandlerOptions(opts...),
 	)
-	pingServiceSumHandler := connect.NewClientStreamHandler(
+	pingServiceSumHandler := connect.NewClientStreamHandlerSimple(
 		PingServiceSumProcedure,
 		svc.Sum,
 		connect.WithSchema(pingServiceMethods.ByName("Sum")),
@@ -246,7 +246,7 @@ func (UnimplementedPingServiceHandler) Fail(context.Context, *v1.FailRequest) (*
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Fail is not implemented"))
 }
 
-func (UnimplementedPingServiceHandler) Sum(context.Context, *connect.ClientStream[v1.SumRequest]) (*connect.Response[v1.SumResponse], error) {
+func (UnimplementedPingServiceHandler) Sum(context.Context, *connect.ClientStream[v1.SumRequest]) (*v1.SumResponse, error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Sum is not implemented"))
 }
 

--- a/internal/gen/simple/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/simple/connect/ping/v1/pingv1connect/ping.connect.go
@@ -71,7 +71,7 @@ type PingServiceClient interface {
 	// Fail always fails.
 	Fail(context.Context, *v1.FailRequest) (*v1.FailResponse, error)
 	// Sum calculates the sum of the numbers sent on the stream.
-	Sum(context.Context) (*connect.ClientStreamForClient[v1.SumRequest, v1.SumResponse], error)
+	Sum(context.Context) (*connect.ClientStreamForClientSimple[v1.SumRequest, v1.SumResponse], error)
 	// CountUp returns a stream of the numbers up to the given request.
 	CountUp(context.Context, *v1.CountUpRequest) (*connect.ServerStreamForClient[v1.CountUpResponse], error)
 	// CumSum determines the cumulative sum of all the numbers sent on the stream.
@@ -151,7 +151,7 @@ func (c *pingServiceClient) Fail(ctx context.Context, req *v1.FailRequest) (*v1.
 }
 
 // Sum calls connect.ping.v1.PingService.Sum.
-func (c *pingServiceClient) Sum(ctx context.Context) (*connect.ClientStreamForClient[v1.SumRequest, v1.SumResponse], error) {
+func (c *pingServiceClient) Sum(ctx context.Context) (*connect.ClientStreamForClientSimple[v1.SumRequest, v1.SumResponse], error) {
 	return c.sum.CallClientStreamSimple(ctx)
 }
 


### PR DESCRIPTION
This adds the usage of CallInfo in context for issuing requests with the new simple API. This builds on top of the https://github.com/connectrpc/connect-go/pull/851 which implements the simple flag for unary and server-streaming

In addition, it adds integration tests for the simple and generics API.