### PR TITLE
Revert README temporarily

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ on [connectrpc.com][docs] (especially the [Getting Started] guide for Go), the
 
 Curious what all this looks like in practice? From a [Protobuf
 schema](internal/proto/connect/ping/v1/ping.proto), we generate [a small RPC
-package](internal/gen/simple/connect/ping/v1/pingv1connect/ping.connect.go). Using that
+package](internal/gen/connect/ping/v1/pingv1connect/ping.connect.go). Using that
 package, we can build a server:
 
 ```go
@@ -66,7 +66,7 @@ import (
 
   "connectrpc.com/connect"
   pingv1 "connectrpc.com/connect/internal/gen/connect/ping/v1"
-  "connectrpc.com/connect/internal/gen/simple/connect/ping/v1/pingv1connect"
+  "connectrpc.com/connect/internal/gen/connect/ping/v1/pingv1connect"
   "golang.org/x/net/http2"
   "golang.org/x/net/http2/h2c"
 )
@@ -75,10 +75,20 @@ type PingServer struct {
   pingv1connect.UnimplementedPingServiceHandler // returns errors from all methods
 }
 
-func (ps *PingServer) Ping(ctx context.Context, req *pingv1.PingRequest) (*pingv1.PingResponse, error) {
-  return &pingv1.PingResponse{
-    Number: req.Number,
-  }, nil
+func (ps *PingServer) Ping(
+  ctx context.Context,
+  req *connect.Request[pingv1.PingRequest],
+) (*connect.Response[pingv1.PingResponse], error) {
+  // connect.Request and connect.Response give you direct access to headers and
+  // trailers. No context-based nonsense!
+  log.Println(req.Header().Get("Some-Header"))
+  res := connect.NewResponse(&pingv1.PingResponse{
+    // req.Msg is a strongly-typed *pingv1.PingRequest, so we can access its
+    // fields without type assertions.
+    Number: req.Msg.Number,
+  })
+  res.Header().Set("Some-Other-Header", "hello!")
+  return res, nil
 }
 
 func main() {
@@ -109,7 +119,7 @@ import (
 
   "connectrpc.com/connect"
   pingv1 "connectrpc.com/connect/internal/gen/connect/ping/v1"
-  "connectrpc.com/connect/internal/gen/simple/connect/ping/v1/pingv1connect"
+  "connectrpc.com/connect/internal/gen/connect/ping/v1/pingv1connect"
 )
 
 func main() {
@@ -117,14 +127,16 @@ func main() {
     http.DefaultClient,
     "http://localhost:8080/",
   )
-  req := &pingv1.PingRequest{
+  req := connect.NewRequest(&pingv1.PingRequest{
     Number: 42,
-  }
+  })
+  req.Header().Set("Some-Header", "hello from connect")
   res, err := client.Ping(context.Background(), req)
   if err != nil {
     log.Fatalln(err)
   }
-  log.Println(res)
+  log.Println(res.Msg)
+  log.Println(res.Header().Get("Some-Other-Header"))
 }
 ```
 


### PR DESCRIPTION
Reverting to the current README so that we don't advertise the simple flag until the release is complete.