### PR TITLE
Add better comments

### DIFF
--- a/client.go
+++ b/client.go
@@ -159,6 +159,10 @@ func (c *Client[Req, Res]) CallUnary(ctx context.Context, request *Request[Req])
 }
 
 // CallClientStream calls a client streaming procedure.
+//
+// Request headers can be sent via the [ClientStreamForClient.RequestHeader] method on the stream. Note that the
+// request headers are not sent automatically when this method is invoked and instead require an explicit call to
+// [ClientStreamForClient.Send].
 func (c *Client[Req, Res]) CallClientStream(ctx context.Context) *ClientStreamForClient[Req, Res] {
 	if c.err != nil {
 		return &ClientStreamForClient[Req, Res]{err: c.err}
@@ -169,7 +173,14 @@ func (c *Client[Req, Res]) CallClientStream(ctx context.Context) *ClientStreamFo
 	}
 }
 
-// CallClientStream calls a client streaming procedure in simple mode.
+// CallClientStreamSimple calls a client streaming procedure.
+//
+// Request headers should be set in a [CallInfo] object inside the context using [NewClientContext]. These headers are
+// transmitted when this method is called and do not require an explicit call to [ClientStreamForClientSimple.Send].
+//
+// In addition, when calling [ClientStreamForClientSimple.CloseAndReceive] on the returned stream, the returned response
+// is the response type defined for the stream and _not_ a Connect [Response] wrapper type. As a result, any response
+// headers and trailers should be read from the [CallInfo] object in context.
 func (c *Client[Req, Res]) CallClientStreamSimple(ctx context.Context) (*ClientStreamForClientSimple[Req, Res], error) {
 	if c.err != nil {
 		return &ClientStreamForClientSimple[Req, Res]{err: c.err}, c.err
@@ -216,6 +227,10 @@ func (c *Client[Req, Res]) CallServerStream(ctx context.Context, request *Reques
 }
 
 // CallBidiStream calls a bidirectional streaming procedure.
+//
+// Request headers can be sent via the [BidiStreamForClient.RequestHeader] method. Note that the
+// request headers are not sent automatically when this method is invoked and instead require an explicit call to
+// [BidiStreamForClient.Send].
 func (c *Client[Req, Res]) CallBidiStream(ctx context.Context) *BidiStreamForClient[Req, Res] {
 	if c.err != nil {
 		return &BidiStreamForClient[Req, Res]{err: c.err}
@@ -226,7 +241,12 @@ func (c *Client[Req, Res]) CallBidiStream(ctx context.Context) *BidiStreamForCli
 	}
 }
 
-// CallBidiStreamSimple calls a bidirectional streaming procedure in simple mode.
+// CallBidiStreamSimple calls a bidirectional streaming procedure.
+//
+// Request headers should be set in a [CallInfo] object inside the context using [NewClientContext]. These headers
+// are transmitted when this method is called and do not require an explicit call to [BidiStreamForClient.Send].
+//
+// Likewise, response headers and trailers should be read from the [CallInfo] object in context.
 func (c *Client[Req, Res]) CallBidiStreamSimple(ctx context.Context) (*BidiStreamForClient[Req, Res], error) {
 	stream := c.CallBidiStream(ctx)
 	if stream.err != nil {

--- a/client_stream.go
+++ b/client_stream.go
@@ -20,11 +20,15 @@ import (
 	"net/http"
 )
 
-// ClientStreamForClientsimple is the client's view of a client streaming RPC.
-// for the simple API.
+// ClientStreamForClientSimple is the client's view of a client streaming RPC.
 //
-// It's returned from [Client].CallClientStreamSimple, but doesn't currently have an
+// It's returned from [Client.CallClientStreamSimple], but doesn't currently have an
 // exported constructor function.
+//
+// Usage of this stream requires that request headers be set in a [CallInfo] object in context via [NewClientContext].
+// In addition, the response returned by [ClientStreamForClientSimple.CloseAndReceive] is the response type defined for
+// the stream and _not_ a Connect [Response] wrapper type. As a result, response headers/trailers should be read from
+// the [CallInfo] object in context.
 type ClientStreamForClientSimple[Req, Res any] struct {
 	conn        StreamingClientConn
 	initializer maybeInitializer
@@ -86,6 +90,8 @@ func (c *ClientStreamForClientSimple[Req, Res]) Conn() (StreamingClientConn, err
 //
 // It's returned from [Client].CallClientStream, but doesn't currently have an
 // exported constructor function.
+//
+// When using this stream, request headers should be set via the [ClientStreamForClient.RequestHeader] method.
 type ClientStreamForClient[Req, Res any] struct {
 	conn        StreamingClientConn
 	initializer maybeInitializer

--- a/handler.go
+++ b/handler.go
@@ -146,7 +146,7 @@ func NewClientStreamHandler[Req, Res any](
 				conn:        conn,
 				initializer: config.Initializer,
 			}
-			ctx = newHandlerContext(ctx, &streamCallInfo{
+			ctx = newHandlerContext(ctx, &streamingHandlerCallInfo{
 				conn: conn,
 			})
 			res, err := implementation(ctx, stream)
@@ -202,7 +202,7 @@ func NewServerStreamHandler[Req, Res any](
 			if err != nil {
 				return err
 			}
-			ctx = newHandlerContext(ctx, &streamCallInfo{
+			ctx = newHandlerContext(ctx, &streamingHandlerCallInfo{
 				conn: conn,
 			})
 			return implementation(ctx, req, &ServerStream[Res]{conn: conn})
@@ -239,7 +239,7 @@ func NewBidiStreamHandler[Req, Res any](
 	return newStreamHandler(
 		config,
 		func(ctx context.Context, conn StreamingHandlerConn) error {
-			ctx = newHandlerContext(ctx, &streamCallInfo{
+			ctx = newHandlerContext(ctx, &streamingHandlerCallInfo{
 				conn: conn,
 			})
 			return implementation(


### PR DESCRIPTION
This adds better comments to some of the new types by expanding on what is meant by each `Simple` type instead of using a generic description of 'simple mode'.

This also renames `streamCallInfo` to `streamingHandlerCallInfo` to better reflect its usage.