### PR TITLE
Standardize on For over From

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -339,7 +339,7 @@ type Peer struct {
 	Query    url.Values // server-only
 }
 
-func newPeerFromURL(url *url.URL, protocol string) Peer {
+func newPeerForURL(url *url.URL, protocol string) Peer {
 	return Peer{
 		Addr:     url.Host,
 		Protocol: protocol,

--- a/error.go
+++ b/error.go
@@ -80,7 +80,7 @@ func (d *ErrorDetail) Type() string {
 	//
 	// If we ever want to support remote registries, we can add an explicit
 	// `TypeURL` method.
-	return typeNameFromURL(d.pbAny.GetTypeUrl())
+	return typeNameForURL(d.pbAny.GetTypeUrl())
 }
 
 // Bytes returns a copy of the Protobuf-serialized detail.
@@ -459,6 +459,6 @@ func wrapIfMaxBytesError(err error, tmpl string, args ...any) error {
 	return errorf(CodeResourceExhausted, "%s: exceeded %d byte http.MaxBytesReader limit", prefix, maxBytesErr.Limit)
 }
 
-func typeNameFromURL(url string) string {
+func typeNameForURL(url string) string {
 	return url[strings.LastIndexByte(url, '/')+1:]
 }

--- a/error_test.go
+++ b/error_test.go
@@ -108,7 +108,7 @@ func TestErrorIs(t *testing.T) {
 	assert.True(t, errors.Is(connectErr, connectErr))
 }
 
-func TestTypeNameFromURL(t *testing.T) {
+func TestTypeNameForURL(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		name     string
@@ -144,7 +144,7 @@ func TestTypeNameFromURL(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, typeNameFromURL(testCase.url), testCase.typeName)
+			assert.Equal(t, typeNameForURL(testCase.url), testCase.typeName)
 		})
 	}
 }

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -98,9 +98,9 @@ func (g *protocolGRPC) NewHandler(params *protocolHandlerParams) protocolHandler
 
 // NewClient implements protocol, so it must return an interface.
 func (g *protocolGRPC) NewClient(params *protocolClientParams) (protocolClient, error) {
-	peer := newPeerFromURL(params.URL, ProtocolGRPC)
+	peer := newPeerForURL(params.URL, ProtocolGRPC)
 	if g.web {
-		peer = newPeerFromURL(params.URL, ProtocolGRPCWeb)
+		peer = newPeerForURL(params.URL, ProtocolGRPCWeb)
 	}
 	return &grpcClient{
 		protocolClientParams: *params,
@@ -173,7 +173,7 @@ func (g *grpcHandler) NewConn(
 		header[grpcHeaderCompression] = []string{responseCompression}
 	}
 
-	codecName := grpcCodecFromContentType(g.web, getHeaderCanonical(request.Header, headerContentType))
+	codecName := grpcCodecForContentType(g.web, getHeaderCanonical(request.Header, headerContentType))
 	codec := g.Codecs.Get(codecName) // handler.go guarantees this is not nil
 	protocolName := ProtocolGRPC
 	if g.web {
@@ -247,7 +247,7 @@ func (g *grpcClient) WriteRequestHeader(_ StreamType, header http.Header) {
 		// both.
 		header[headerXUserAgent] = []string{defaultGrpcUserAgent}
 	}
-	header[headerContentType] = []string{grpcContentTypeFromCodecName(g.web, g.Codec.Name())}
+	header[headerContentType] = []string{grpcContentTypeForCodecName(g.web, g.Codec.Name())}
 	// gRPC handles compression on a per-message basis, so we don't want to
 	// compress the whole stream. By default, http.Client will ask the server
 	// to gzip the stream if we don't set Accept-Encoding.
@@ -388,7 +388,7 @@ func (cc *grpcClientConn) Receive(msg any) error {
 		delHeaderCanonical(cc.responseTrailer, headerContentType)
 
 		// Try to read the status out of the headers.
-		serverErr := grpcErrorFromTrailer(cc.protobuf, cc.responseHeader)
+		serverErr := grpcErrorForTrailer(cc.protobuf, cc.responseHeader)
 		if serverErr == nil {
 			// Status says "OK". So return original error (io.EOF).
 			return err
@@ -398,7 +398,7 @@ func (cc *grpcClientConn) Receive(msg any) error {
 	}
 
 	// See if the server sent an explicit error in the HTTP or gRPC-Web trailers.
-	serverErr := grpcErrorFromTrailer(cc.protobuf, cc.responseTrailer)
+	serverErr := grpcErrorForTrailer(cc.protobuf, cc.responseTrailer)
 	if serverErr != nil && (errors.Is(err, io.EOF) || !errors.Is(serverErr, errTrailersWithoutGRPCStatus)) {
 		// We've either:
 		//   - Cleanly read until the end of the response body and *not* received
@@ -689,7 +689,7 @@ func grpcValidateResponse(
 // A nil error is only returned when a grpc-status key IS present, but it
 // indicates a code of zero (no error). If no grpc-status key is present, this
 // returns a non-nil *Error that wraps errTrailersWithoutGRPCStatus.
-func grpcErrorFromTrailer(protobuf Codec, trailer http.Header) *Error {
+func grpcErrorForTrailer(protobuf Codec, trailer http.Header) *Error {
 	codeHeader := getHeaderCanonical(trailer, grpcHeaderStatus)
 	if codeHeader == "" {
 		// If there are no trailers at all, that's an internal error.
@@ -812,7 +812,7 @@ func grpcTimeoutUnitLookup(unit byte) (time.Duration, error) {
 	}
 }
 
-func grpcCodecFromContentType(web bool, contentType string) string {
+func grpcCodecForContentType(web bool, contentType string) string {
 	if (!web && contentType == grpcContentTypeDefault) || (web && contentType == grpcWebContentTypeDefault) {
 		// implicitly protobuf
 		return codecNameProto
@@ -824,7 +824,7 @@ func grpcCodecFromContentType(web bool, contentType string) string {
 	return strings.TrimPrefix(contentType, prefix)
 }
 
-func grpcContentTypeFromCodecName(web bool, name string) string {
+func grpcContentTypeForCodecName(web bool, name string) string {
 	if web {
 		return grpcWebContentTypePrefix + name
 	}
@@ -847,7 +847,7 @@ func grpcErrorToTrailer(trailer http.Header, protobuf Codec, err error) {
 		mergeNonProtocolHeaders(trailer, connectErr.meta)
 	}
 	var (
-		status  = grpcStatusFromError(err)
+		status  = grpcStatusForError(err)
 		code    = status.GetCode()
 		message = status.GetMessage()
 		bin     []byte
@@ -867,7 +867,7 @@ func grpcErrorToTrailer(trailer http.Header, protobuf Codec, err error) {
 	}
 }
 
-func grpcStatusFromError(err error) *statusv1.Status {
+func grpcStatusForError(err error) *statusv1.Status {
 	status := &statusv1.Status{
 		Code:    int32(CodeUnknown),
 		Message: err.Error(),


### PR DESCRIPTION
This is in relation to https://github.com/connectrpc/connect-go/pull/851. This standardizes on using `For` instead of `From` for all of our functions. The two words are interchangeable, and all of our public methods use `For`, so this has all of our private methods do so as well. A new public method `CallInfoFromHandler` is/was being introduced in #851, and in relation to renaming it to `CallInfoForHandler`, this furthers the standardization.