### PR TITLE
Bump minimum Go version to v1.24 and document H2C with stdlib

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         go-version:
         - name: latest
-          version: 1.24.x
+          version: 1.25.x
         - name: previous
-          version: 1.23.x
+          version: 1.24.x
     steps:
       - name: Checkout Code
         uses: actions/checkout@v5
@@ -46,9 +46,9 @@ jobs:
       matrix:
         go-version:
         - name: latest
-          version: 1.24.x
+          version: 1.25.x
         - name: previous
-          version: 1.23.x
+          version: 1.24.x
     steps:
       - name: Checkout Code
         uses: actions/checkout@v5
@@ -71,6 +71,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           # only the latest
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: Run Slow Tests
         run: make slowtest

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         go-version:
           - name: latest
-            version: 1.24.x
+            version: 1.25.x
           - name: previous
-            version: 1.23.x
+            version: 1.24.x
     steps:
       - name: Checkout Code
         uses: actions/checkout@v5

--- a/bench_test.go
+++ b/bench_test.go
@@ -17,7 +17,6 @@ package connect_test
 import (
 	"bytes"
 	"compress/gzip"
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -76,7 +75,7 @@ func BenchmarkConnect(b *testing.B) {
 				connect.WithClientOptions(client.opts...),
 			)
 
-			ctx := context.Background()
+			ctx := b.Context()
 			b.Run("unary_big", func(b *testing.B) {
 				b.ReportAllocs()
 				b.RunParallel(func(pb *testing.PB) {
@@ -263,7 +262,7 @@ func unaryRESTIteration(b *testing.B, client *http.Client, url string, text stri
 	}
 	compressedRequestBody.Close()
 	request, err := http.NewRequestWithContext(
-		context.Background(),
+		b.Context(),
 		http.MethodPost,
 		url,
 		rawRequestBody,

--- a/client_get_fallback_test.go
+++ b/client_get_fallback_test.go
@@ -47,7 +47,7 @@ func TestClientUnaryGetFallback(t *testing.T) {
 		WithHTTPGetMaxURLSize(1, true),
 		WithSendGzip(),
 	)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, err := client.CallUnary(ctx, NewRequest[pingv1.PingRequest](nil))
 	assert.Nil(t, err)

--- a/cmd/protoc-gen-connect-go/main_test.go
+++ b/cmd/protoc-gen-connect-go/main_test.go
@@ -203,7 +203,7 @@ func TestGenerate(t *testing.T) {
 
 func TestClientHandler(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 	t.Run("defaultpackage.proto", func(t *testing.T) {
 		t.Parallel()
 		svc := testDefaultPackageService{}

--- a/code.go
+++ b/code.go
@@ -205,8 +205,8 @@ func (c *Code) UnmarshalText(data []byte) error {
 	}
 	// Ensure that non-canonical codes round-trip through MarshalText and
 	// UnmarshalText.
-	if strings.HasPrefix(dataStr, "code_") {
-		dataStr = strings.TrimPrefix(dataStr, "code_")
+	if after, ok := strings.CutPrefix(dataStr, "code_"); ok {
+		dataStr = after
 		code, err := strconv.ParseUint(dataStr, 10 /* base */, 32 /* bitsize */)
 		if err == nil && (code < uint64(minCode) || code > uint64(maxCode)) {
 			*c = Code(code)

--- a/compression_test.go
+++ b/compression_test.go
@@ -15,7 +15,6 @@
 package connect
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -49,7 +48,7 @@ func TestAcceptEncodingOrdering(t *testing.T) {
 		withFakeBrotli,
 		withGzip(),
 	)
-	_, _ = client.CallUnary(context.Background(), NewRequest(&emptypb.Empty{}))
+	_, _ = client.CallUnary(t.Context(), NewRequest(&emptypb.Empty{}))
 	assert.True(t, called)
 }
 

--- a/duplex_http_call_test.go
+++ b/duplex_http_call_test.go
@@ -16,7 +16,6 @@ package connect
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -49,7 +48,7 @@ func TestHTTPCallGetBody(t *testing.T) {
 	errGetBodyCalled := errors.New("getBodyCalled") // sentinel error
 	caller := func(size int) error {
 		call := newDuplexHTTPCall(
-			context.Background(),
+			t.Context(),
 			server.Client(),
 			serverURL,
 			Spec{StreamType: StreamTypeUnary},

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -16,7 +16,6 @@ package connect
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"testing"
 
@@ -46,7 +45,7 @@ func TestEnvelope(t *testing.T) {
 			t.Parallel()
 			env := &envelope{Data: &bytes.Buffer{}}
 			rdr := envelopeReader{
-				ctx: context.Background(),
+				ctx: t.Context(),
 				reader: byteByByteReader{
 					reader: bytes.NewReader(buf.Bytes()),
 				},

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module connectrpc.com/connect
 
-go 1.23.0
+go 1.24.0
 
 retract (
 	v1.10.0 // module cache poisoned, use v1.10.1

--- a/handler_example_test.go
+++ b/handler_example_test.go
@@ -100,10 +100,14 @@ func Example_handler() {
 		"internal/testdata/server.key",
 		mux,
 	)
-	// To serve HTTP/2 requests without TLS (as many gRPC clients expect), import
-	// golang.org/x/net/http2/h2c and golang.org/x/net/http2 and change to:
-	// _ = http.ListenAndServe(
-	// 	"localhost:8080",
-	// 	h2c.NewHandler(mux, &http2.Server{}),
-	// )
+	// To serve HTTP/2 requests without TLS (as many gRPC clients expect), use
+	// Protocols.SetUnencryptedHTTP2 and change to:
+	// p := new(http.Protocols)
+	// p.SetHTTP1(true)
+	// p.SetUnencryptedHTTP2(true)
+	// s := &http.Server{
+	// 	Addr:    "localhost:8080",
+	// 	Handler: mux,
+	// }
+	// _ = s.ListenAndServe()
 }

--- a/handler_example_test.go
+++ b/handler_example_test.go
@@ -106,8 +106,9 @@ func Example_handler() {
 	// p.SetHTTP1(true)
 	// p.SetUnencryptedHTTP2(true)
 	// s := &http.Server{
-	// 	Addr:    "localhost:8080",
-	// 	Handler: mux,
+	// 	Addr:      "localhost:8080",
+	// 	Handler:   mux,
+	// 	Protocols: p,
 	// }
 	// _ = s.ListenAndServe()
 }

--- a/handler_ext_test.go
+++ b/handler_ext_test.go
@@ -53,7 +53,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 	t.Run("get_method_no_encoding", func(t *testing.T) {
 		t.Parallel()
 		request, err := http.NewRequestWithContext(
-			context.Background(),
+			t.Context(),
 			http.MethodGet,
 			server.URL()+pingProcedure,
 			strings.NewReader(""),
@@ -68,7 +68,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 	t.Run("get_method_bad_encoding", func(t *testing.T) {
 		t.Parallel()
 		request, err := http.NewRequestWithContext(
-			context.Background(),
+			t.Context(),
 			http.MethodGet,
 			server.URL()+pingProcedure+`?encoding=unk&message={}`,
 			strings.NewReader(""),
@@ -84,7 +84,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		t.Parallel()
 		const queryStringSuffix = `?encoding=json&message={}`
 		request, err := http.NewRequestWithContext(
-			context.Background(),
+			t.Context(),
 			http.MethodGet,
 			server.URL()+pingProcedure+queryStringSuffix,
 			strings.NewReader("!"), // non-empty body
@@ -97,7 +97,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 
 		// Same thing, but this time w/ a content-length header
 		request, err = http.NewRequestWithContext(
-			context.Background(),
+			t.Context(),
 			http.MethodGet,
 			server.URL()+pingProcedure+queryStringSuffix,
 			strings.NewReader("!"), // non-empty body
@@ -113,7 +113,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 	t.Run("idempotent_get_method", func(t *testing.T) {
 		t.Parallel()
 		request, err := http.NewRequestWithContext(
-			context.Background(),
+			t.Context(),
 			http.MethodGet,
 			server.URL()+pingProcedure+`?encoding=json&message={}`,
 			strings.NewReader(""),
@@ -128,7 +128,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 	t.Run("prefixed_get_method", func(t *testing.T) {
 		t.Parallel()
 		request, err := http.NewRequestWithContext(
-			context.Background(),
+			t.Context(),
 			http.MethodGet,
 			server.URL()+"/prefixed"+pingProcedure+`?encoding=json&message={}`,
 			strings.NewReader(""),
@@ -143,7 +143,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 	t.Run("method_not_allowed", func(t *testing.T) {
 		t.Parallel()
 		request, err := http.NewRequestWithContext(
-			context.Background(),
+			t.Context(),
 			http.MethodGet,
 			server.URL()+sumProcedure,
 			strings.NewReader(""),
@@ -159,7 +159,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 	t.Run("unsupported_content_type", func(t *testing.T) {
 		t.Parallel()
 		request, err := http.NewRequestWithContext(
-			context.Background(),
+			t.Context(),
 			http.MethodPost,
 			server.URL()+pingProcedure,
 			strings.NewReader("{}"),
@@ -188,7 +188,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 	t.Run("charset_in_content_type_header", func(t *testing.T) {
 		t.Parallel()
 		req, err := http.NewRequestWithContext(
-			context.Background(),
+			t.Context(),
 			http.MethodPost,
 			server.URL()+pingProcedure,
 			strings.NewReader("{}"),
@@ -204,7 +204,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 	t.Run("unsupported_charset", func(t *testing.T) {
 		t.Parallel()
 		req, err := http.NewRequestWithContext(
-			context.Background(),
+			t.Context(),
 			http.MethodPost,
 			server.URL()+pingProcedure,
 			strings.NewReader("{}"),
@@ -220,7 +220,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 	t.Run("unsupported_content_encoding", func(t *testing.T) {
 		t.Parallel()
 		req, err := http.NewRequestWithContext(
-			context.Background(),
+			t.Context(),
 			http.MethodPost,
 			server.URL()+pingProcedure,
 			strings.NewReader("{}"),
@@ -263,7 +263,7 @@ func TestHandlerMaliciousPrefix(t *testing.T) {
 		// sending.
 		binary.BigEndian.PutUint32(body[1:5], spuriousSize)
 		req, err := http.NewRequestWithContext(
-			context.Background(),
+			t.Context(),
 			http.MethodPost,
 			server.URL()+pingv1connect.PingServicePingProcedure,
 			bytes.NewReader(body),
@@ -330,7 +330,7 @@ func TestDynamicHandler(t *testing.T) {
 		)
 		server := memhttptest.NewServer(t, mux)
 		client := pingv1connect.NewPingServiceClient(server.Client(), server.URL())
-		rsp, err := client.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{
+		rsp, err := client.Ping(t.Context(), connect.NewRequest(&pingv1.PingRequest{
 			Number: 42,
 		}))
 		if !assert.Nil(t, err) {
@@ -371,7 +371,7 @@ func TestDynamicHandler(t *testing.T) {
 		)
 		server := memhttptest.NewServer(t, mux)
 		client := pingv1connect.NewPingServiceClient(server.Client(), server.URL())
-		stream := client.Sum(context.Background())
+		stream := client.Sum(t.Context())
 		assert.Nil(t, stream.Send(&pingv1.SumRequest{Number: 42}))
 		assert.Nil(t, stream.Send(&pingv1.SumRequest{Number: 42}))
 		rsp, err := stream.CloseAndReceive()
@@ -412,7 +412,7 @@ func TestDynamicHandler(t *testing.T) {
 		)
 		server := memhttptest.NewServer(t, mux)
 		client := pingv1connect.NewPingServiceClient(server.Client(), server.URL())
-		stream := client.Sum(context.Background())
+		stream := client.Sum(t.Context())
 		assert.Nil(t, stream.Send(&pingv1.SumRequest{Number: 42}))
 		assert.Nil(t, stream.Send(&pingv1.SumRequest{Number: 42}))
 		rsp, err := stream.CloseAndReceive()
@@ -452,7 +452,7 @@ func TestDynamicHandler(t *testing.T) {
 		)
 		server := memhttptest.NewServer(t, mux)
 		client := pingv1connect.NewPingServiceClient(server.Client(), server.URL())
-		stream, err := client.CountUp(context.Background(), connect.NewRequest(&pingv1.CountUpRequest{
+		stream, err := client.CountUp(t.Context(), connect.NewRequest(&pingv1.CountUpRequest{
 			Number: 2,
 		}))
 		if !assert.Nil(t, err) {
@@ -506,7 +506,7 @@ func TestDynamicHandler(t *testing.T) {
 		)
 		server := memhttptest.NewServer(t, mux)
 		client := pingv1connect.NewPingServiceClient(server.Client(), server.URL())
-		stream := client.CumSum(context.Background())
+		stream := client.CumSum(t.Context())
 		assert.Nil(t, stream.Send(&pingv1.CumSumRequest{Number: 1}))
 		msg, err := stream.Receive()
 		if !assert.Nil(t, err) {
@@ -556,7 +556,7 @@ func TestDynamicHandler(t *testing.T) {
 		)
 		server := memhttptest.NewServer(t, mux)
 		client := pingv1connect.NewPingServiceClient(server.Client(), server.URL())
-		rsp, err := client.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{
+		rsp, err := client.Ping(t.Context(), connect.NewRequest(&pingv1.PingRequest{
 			Number: 42,
 		}))
 		if !assert.Nil(t, err) {

--- a/interceptor_ext_test.go
+++ b/interceptor_ext_test.go
@@ -61,7 +61,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 			t.Run("unary", func(t *testing.T) {
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
-				resp, err := client.Ping(context.Background(), &pingv1.PingRequest{Number: 10})
+				resp, err := client.Ping(t.Context(), &pingv1.PingRequest{Number: 10})
 
 				assert.Nil(t, resp)
 				assert.NotNil(t, err)
@@ -74,7 +74,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				t.Parallel()
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
-				stream, err := client.CountUp(context.Background(), &pingv1.CountUpRequest{Number: 10})
+				stream, err := client.CountUp(t.Context(), &pingv1.CountUpRequest{Number: 10})
 
 				assert.Nil(t, stream)
 				assert.NotNil(t, err)
@@ -90,7 +90,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 
 				// With client-streaming and the simple API, the initial call fails. This differs from
 				// the generics API which requires a call to stream.Send first to receive an error.
-				stream, err := client.Sum(context.Background())
+				stream, err := client.Sum(t.Context())
 				assert.NotNil(t, err)
 				assert.Nil(t, stream)
 				assert.Equal(t, int32(1), clientCounter1.Load())
@@ -103,7 +103,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 
 				// With bidi-streaming and the simple API, the initial call fails. This differs from
 				// the generics API which requires a call to stream.Send first to receive an error.
-				stream, err := client.CumSum(context.Background())
+				stream, err := client.CumSum(t.Context())
 				assert.NotNil(t, err)
 				assert.Nil(t, stream)
 				assert.Equal(t, int32(1), clientCounter1.Load())
@@ -127,7 +127,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
 
-				resp, err := client.Ping(context.Background(), &pingv1.PingRequest{Number: 10})
+				resp, err := client.Ping(t.Context(), &pingv1.PingRequest{Number: 10})
 				assert.Nil(t, resp)
 				assert.NotNil(t, err)
 				assert.Equal(t, err.Error(), expectedContextErrorMessage)
@@ -139,7 +139,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
 
-				stream, err := client.CountUp(context.Background(), &pingv1.CountUpRequest{Number: 10})
+				stream, err := client.CountUp(t.Context(), &pingv1.CountUpRequest{Number: 10})
 				assert.Nil(t, stream)
 				assert.NotNil(t, err)
 				assert.Equal(t, err.Error(), expectedContextErrorMessage)
@@ -153,7 +153,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 
 				// With client-streaming and the simple API, the initial call fails. This differs from
 				// the generics API which requires a call to stream.Send first to receive an error.
-				stream, err := client.Sum(context.Background())
+				stream, err := client.Sum(t.Context())
 				assert.NotNil(t, err)
 				assert.Nil(t, stream)
 				assert.Equal(t, int32(1), clientCounter1.Load())
@@ -166,7 +166,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 
 				// With bidi-streaming and the simple API, the initial call fails. This differs from
 				// the generics API which requires a call to stream.Send first to receive an error.
-				stream, err := client.CumSum(context.Background())
+				stream, err := client.CumSum(t.Context())
 				assert.NotNil(t, err)
 				assert.Nil(t, stream)
 				assert.Equal(t, int32(1), clientCounter1.Load())
@@ -193,7 +193,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
 
-				resp, err := client.Ping(context.Background(), &pingv1.PingRequest{Number: 10})
+				resp, err := client.Ping(t.Context(), &pingv1.PingRequest{Number: 10})
 				assert.NotNil(t, resp)
 				assert.Nil(t, err)
 				assert.Equal(t, int32(1), clientCounter1.Load())
@@ -204,7 +204,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
 
-				stream, err := client.CountUp(context.Background(), &pingv1.CountUpRequest{Number: 10})
+				stream, err := client.CountUp(t.Context(), &pingv1.CountUpRequest{Number: 10})
 				assert.NotNil(t, stream)
 				assert.Nil(t, err)
 				assert.Equal(t, int32(1), clientCounter1.Load())
@@ -215,7 +215,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
 
-				stream, err := client.Sum(context.Background())
+				stream, err := client.Sum(t.Context())
 				assert.NotNil(t, stream)
 				assert.Nil(t, err)
 				assert.Equal(t, int32(1), clientCounter1.Load())
@@ -226,7 +226,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
 
-				stream, err := client.CumSum(context.Background())
+				stream, err := client.CumSum(t.Context())
 				assert.Nil(t, err)
 				assert.NotNil(t, stream)
 
@@ -264,7 +264,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
 
-				resp, err := client.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{Number: 10}))
+				resp, err := client.Ping(t.Context(), connect.NewRequest(&pingv1.PingRequest{Number: 10}))
 				assert.Nil(t, resp)
 				assert.NotNil(t, err)
 				assert.Equal(t, err.Error(), expectedContextErrorMessage)
@@ -276,7 +276,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
 
-				stream, err := client.CountUp(context.Background(), connect.NewRequest(&pingv1.CountUpRequest{Number: 10}))
+				stream, err := client.CountUp(t.Context(), connect.NewRequest(&pingv1.CountUpRequest{Number: 10}))
 				assert.Nil(t, stream)
 				assert.NotNil(t, err)
 				assert.Equal(t, err.Error(), expectedContextErrorMessage)
@@ -287,7 +287,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				t.Parallel()
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
-				stream := client.Sum(context.Background())
+				stream := client.Sum(t.Context())
 				assert.NotNil(t, stream)
 
 				// With client-streaming and the generics API, a call to stream.Send is required to receive an error.
@@ -308,7 +308,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				t.Parallel()
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
-				stream := client.CumSum(context.Background())
+				stream := client.CumSum(t.Context())
 				assert.NotNil(t, stream)
 
 				// With bidi-streaming and the generics API, a call to stream.Send is required to receive an error.
@@ -348,7 +348,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
 
-				resp, err := client.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{Number: 10}))
+				resp, err := client.Ping(t.Context(), connect.NewRequest(&pingv1.PingRequest{Number: 10}))
 				assert.Nil(t, resp)
 				assert.NotNil(t, err)
 				assert.Equal(t, err.Error(), expectedContextErrorMessage)
@@ -360,7 +360,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
 
-				stream, err := client.CountUp(context.Background(), connect.NewRequest(&pingv1.CountUpRequest{Number: 10}))
+				stream, err := client.CountUp(t.Context(), connect.NewRequest(&pingv1.CountUpRequest{Number: 10}))
 				assert.Nil(t, stream)
 				assert.NotNil(t, err)
 				assert.Equal(t, err.Error(), expectedContextErrorMessage)
@@ -371,7 +371,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				t.Parallel()
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
-				stream := client.Sum(context.Background())
+				stream := client.Sum(t.Context())
 				assert.NotNil(t, stream)
 
 				// With client-streaming and the generics API, a call to stream.Send is required to receive an error.
@@ -392,7 +392,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				t.Parallel()
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
-				stream := client.CumSum(context.Background())
+				stream := client.CumSum(t.Context())
 				assert.NotNil(t, stream)
 
 				// With bidi-streaming and the generics API, a call to stream.Send is required to receive an error.
@@ -432,7 +432,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
 
-				resp, err := client.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{Number: 10}))
+				resp, err := client.Ping(t.Context(), connect.NewRequest(&pingv1.PingRequest{Number: 10}))
 				assert.NotNil(t, resp)
 				assert.Nil(t, err)
 				assert.Equal(t, int32(1), clientCounter1.Load())
@@ -443,7 +443,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
 
-				stream, err := client.CountUp(context.Background(), connect.NewRequest(&pingv1.CountUpRequest{Number: 10}))
+				stream, err := client.CountUp(t.Context(), connect.NewRequest(&pingv1.CountUpRequest{Number: 10}))
 				assert.NotNil(t, stream)
 				assert.Nil(t, err)
 				assert.Equal(t, int32(1), clientCounter1.Load())
@@ -453,7 +453,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				t.Parallel()
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
-				stream := client.Sum(context.Background())
+				stream := client.Sum(t.Context())
 				assert.NotNil(t, stream)
 
 				err := stream.Send(&pingv1.SumRequest{Number: int64(1)})
@@ -468,7 +468,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				t.Parallel()
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
-				stream := client.CumSum(context.Background())
+				stream := client.CumSum(t.Context())
 				assert.NotNil(t, stream)
 
 				// The initial send should succeed
@@ -602,7 +602,7 @@ func TestOnionOrderingEndToEnd(t *testing.T) {
 		clientOnion,
 	)
 
-	_, err := client.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{Number: 10}))
+	_, err := client.Ping(t.Context(), connect.NewRequest(&pingv1.PingRequest{Number: 10}))
 	assert.Nil(t, err)
 
 	// make sure the interceptors were actually invoked
@@ -613,7 +613,7 @@ func TestOnionOrderingEndToEnd(t *testing.T) {
 	assert.Equal(t, int32(1), handlerCounter2.Load())
 	assert.Equal(t, int32(1), handlerCounter3.Load())
 
-	responses, err := client.CountUp(context.Background(), connect.NewRequest(&pingv1.CountUpRequest{Number: 10}))
+	responses, err := client.CountUp(t.Context(), connect.NewRequest(&pingv1.CountUpRequest{Number: 10}))
 	assert.Nil(t, err)
 	var sum int64
 	for responses.Receive() {
@@ -642,14 +642,14 @@ func TestEmptyUnaryInterceptorFunc(t *testing.T) {
 	mux.Handle(pingv1connect.NewPingServiceHandler(pingServer{}, connect.WithInterceptors(interceptor)))
 	server := memhttptest.NewServer(t, mux)
 	connectClient := pingv1connect.NewPingServiceClient(server.Client(), server.URL(), connect.WithInterceptors(interceptor))
-	_, err := connectClient.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{}))
+	_, err := connectClient.Ping(t.Context(), connect.NewRequest(&pingv1.PingRequest{}))
 	assert.Nil(t, err)
-	sumStream := connectClient.Sum(context.Background())
+	sumStream := connectClient.Sum(t.Context())
 	assert.Nil(t, sumStream.Send(&pingv1.SumRequest{Number: 1}))
 	resp, err := sumStream.CloseAndReceive()
 	assert.Nil(t, err)
 	assert.NotNil(t, resp)
-	countUpStream, err := connectClient.CountUp(context.Background(), connect.NewRequest(&pingv1.CountUpRequest{}))
+	countUpStream, err := connectClient.CountUp(t.Context(), connect.NewRequest(&pingv1.CountUpRequest{}))
 	assert.Nil(t, err)
 	for countUpStream.Receive() {
 		assert.NotNil(t, countUpStream.Msg())
@@ -678,7 +678,7 @@ func TestInterceptorFuncAccessingHTTPMethod(t *testing.T) {
 
 	pingReq := connect.NewRequest(&pingv1.PingRequest{Number: 10})
 	assert.Equal(t, "", pingReq.HTTPMethod())
-	_, err := client.Ping(context.Background(), pingReq)
+	_, err := client.Ping(t.Context(), pingReq)
 	assert.Nil(t, err)
 	assert.Equal(t, http.MethodPost, pingReq.HTTPMethod())
 
@@ -688,7 +688,7 @@ func TestInterceptorFuncAccessingHTTPMethod(t *testing.T) {
 
 	countUpReq := connect.NewRequest(&pingv1.CountUpRequest{Number: 10})
 	assert.Equal(t, "", countUpReq.HTTPMethod())
-	responses, err := client.CountUp(context.Background(), countUpReq)
+	responses, err := client.CountUp(t.Context(), countUpReq)
 	assert.Nil(t, err)
 	var sum int64
 	for responses.Receive() {

--- a/internal/conformance/go.mod
+++ b/internal/conformance/go.mod
@@ -1,6 +1,6 @@
 module connectrpc.com/connect/internal/conformance
 
-go 1.23.0
+go 1.24.0
 
 require connectrpc.com/conformance v1.0.4
 

--- a/internal/memhttp/memhttp_test.go
+++ b/internal/memhttp/memhttp_test.go
@@ -53,7 +53,7 @@ func TestServerTransport(t *testing.T) {
 				go func() {
 					defer wg.Done()
 					req, err := http.NewRequestWithContext(
-						context.Background(),
+						t.Context(),
 						http.MethodGet,
 						server.URL(),
 						nil,
@@ -83,7 +83,7 @@ func TestRegisterOnShutdown(t *testing.T) {
 	server.RegisterOnShutdown(func() {
 		close(done)
 	})
-	assert.Nil(t, server.Shutdown(context.Background()))
+	assert.Nil(t, server.Shutdown(t.Context()))
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):

--- a/protocol_connect_test.go
+++ b/protocol_connect_test.go
@@ -16,7 +16,6 @@ package connect
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -121,7 +120,7 @@ func TestConnectEndOfResponseCanonicalTrailers(t *testing.T) {
 
 	unmarshaler := connectStreamingUnmarshaler{
 		envelopeReader: envelopeReader{
-			ctx:        context.Background(),
+			ctx:        t.Context(),
 			reader:     &buffer,
 			bufferPool: bufferPool,
 		},

--- a/protocol_grpc_test.go
+++ b/protocol_grpc_test.go
@@ -201,7 +201,7 @@ func BenchmarkGRPCPercentEncoding(b *testing.B) {
 	input := "Hello, 世界"
 	want := "Hello, %E4%B8%96%E7%95%8C"
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		got := grpcPercentEncode(input)
 		if got != want {
 			b.Fatalf("grpcPercentEncode(%q) = %s, want %s", input, got, want)
@@ -213,7 +213,7 @@ func BenchmarkGRPCPercentDecoding(b *testing.B) {
 	input := "Hello, %E4%B8%96%E7%95%8C"
 	want := "Hello, 世界"
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		got, _ := grpcPercentDecode(input)
 		if got != want {
 			b.Fatalf("grpcPercentDecode(%q) = %s, want %s", input, got, want)
@@ -225,7 +225,7 @@ func BenchmarkGRPCTimeoutEncoding(b *testing.B) {
 	input := time.Second * 45
 	want := "45000000u"
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		got := grpcEncodeTimeout(input)
 		if got != want {
 			b.Fatalf("grpcEncodeTimeout(%q) = %s, want %s", input, got, want)

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -42,21 +42,21 @@ func TestCanonicalizeContentType(t *testing.T) {
 
 func BenchmarkCanonicalizeContentType(b *testing.B) {
 	b.Run("simple", func(b *testing.B) {
-		for range b.N {
+		for b.Loop() {
 			_ = canonicalizeContentType("application/json")
 		}
 		b.ReportAllocs()
 	})
 
 	b.Run("with charset", func(b *testing.B) {
-		for range b.N {
+		for b.Loop() {
 			_ = canonicalizeContentType("application/json; charset=utf-8")
 		}
 		b.ReportAllocs()
 	})
 
 	b.Run("with other param", func(b *testing.B) {
-		for range b.N {
+		for b.Loop() {
 			_ = canonicalizeContentType("application/json; foo=utf-8")
 		}
 		b.ReportAllocs()

--- a/recover_ext_test.go
+++ b/recover_ext_test.go
@@ -86,20 +86,20 @@ func TestWithRecover(t *testing.T) {
 	for _, panicWith := range []any{42, nil} {
 		pinger.panicWith = panicWith
 
-		_, err := client.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{}))
+		_, err := client.Ping(t.Context(), connect.NewRequest(&pingv1.PingRequest{}))
 		assertHandled(err)
 
-		stream, err := client.CountUp(context.Background(), connect.NewRequest(&pingv1.CountUpRequest{}))
+		stream, err := client.CountUp(t.Context(), connect.NewRequest(&pingv1.CountUpRequest{}))
 		assert.Nil(t, err)
 		assertHandled(drainStream(stream))
 	}
 
 	pinger.panicWith = http.ErrAbortHandler
 
-	_, err := client.Ping(context.Background(), connect.NewRequest(&pingv1.PingRequest{}))
+	_, err := client.Ping(t.Context(), connect.NewRequest(&pingv1.PingRequest{}))
 	assertNotHandled(err)
 
-	stream, err := client.CountUp(context.Background(), connect.NewRequest(&pingv1.CountUpRequest{}))
+	stream, err := client.CountUp(t.Context(), connect.NewRequest(&pingv1.CountUpRequest{}))
 	assert.Nil(t, err)
 	assertNotHandled(drainStream(stream))
 }


### PR DESCRIPTION
<!--
Before submitting your PR, please read through the contribution guide!

https://github.com/connectrpc/connect-go/blob/main/.github/CONTRIBUTING.md
-->

Go v1.24 introduced H2C support in the standard library (fixing issues like graceful shutdown, [golang/go#26682](https://redirect.github.com/golang/go/issues/26682)), this documents its usage and bumps the minimum required Go version

> The server and client may be configured to support unencrypted HTTP/2 connections.

> Unencrypted HTTP/2 support uses “HTTP/2 with Prior Knowledge” (RFC 9113, section 3.3). The deprecated “Upgrade: h2c” header is not supported.

https://tip.golang.org/doc/go1.24#nethttppkgnethttp

I will do a separate PR to drop the experimental H2C module from the test suite, I have the changes ready.
