### PR TITLE
Fix several GoDoc comments

### DIFF
--- a/error_writer.go
+++ b/error_writer.go
@@ -46,7 +46,7 @@ type ErrorWriter struct {
 
 // NewErrorWriter constructs an ErrorWriter. Handler options may be passed to
 // configure the error writer behaviour to match the handlers.
-// [WithRequiredConnectProtocolHeader] will assert that Connect protocol
+// [WithRequireConnectProtocolHeader] will assert that Connect protocol
 // requests include the version header allowing the error writer to correctly
 // classify the request.
 // Options supplied via [WithConditionalHandlerOptions] are ignored.

--- a/option.go
+++ b/option.go
@@ -185,11 +185,11 @@ type Option interface {
 }
 
 // WithSchema provides a parsed representation of the schema for an RPC to a
-// client or handler. The supplied schema is exposed as [Spec.Schema]. This
+// client or handler. The supplied schema is exposed as [Spec].Schema. This
 // option is typically added by generated code.
 //
 // For services using protobuf schemas, the supplied schema should be a
-// [protoreflect.MethodDescriptor].
+// [google.golang.org/protobuf/reflect/protoreflect.MethodDescriptor].
 func WithSchema(schema any) Option {
 	return &schemaOption{Schema: schema}
 }

--- a/protocol.go
+++ b/protocol.go
@@ -27,7 +27,7 @@ import (
 )
 
 // The names of the Connect, gRPC, and gRPC-Web protocols (as exposed by
-// [Peer.Protocol]). Additional protocols may be added in the future.
+// [Peer].Protocol). Additional protocols may be added in the future.
 const (
 	ProtocolConnect = "connect"
 	ProtocolGRPC    = "grpc"


### PR DESCRIPTION
Just noticed these going through the [pkg.go.dev docs][1].

* Fixed a typo in an option name
* Use [{type}].{ExportedField} instead of [{type}.{ExportedField}], which doesn't seem to work (and is what is done elsewhere)
* Use full protoreflect module name, since it is not imported in the package

Ref: https://go.dev/doc/comment#doclinks

[1]: https://pkg.go.dev/connectrpc.com/connect
