### PR TITLE
Fix bounds check on envelope for 32-bit archs

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -375,6 +375,7 @@ func (r *envelopeReader) Read(env *envelope) *Error {
 }
 
 func makeEnvelopePrefix(flags uint8, size int) ([5]byte, error) {
+	// Cast as 64-bit to ensure comparison works on all architectures.
 	size64 := int64(size)
 	if size64 < 0 || size64 > math.MaxUint32 {
 		return [5]byte{}, fmt.Errorf("connect.makeEnvelopePrefix: size %d out of bounds", size)


### PR DESCRIPTION
<!--
Before submitting your PR, please read through the contribution guide!

https://github.com/connectrpc/connect-go/blob/main/.github/CONTRIBUTING.md
-->
Fix bounds check on construction of payload envelopes for 32-bit archs.

Fixes https://github.com/connectrpc/connect-go/issues/886