### PR TITLE
Fix size check for envelope prefix (32bit build)

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -375,7 +375,7 @@ func (r *envelopeReader) Read(env *envelope) *Error {
 }
 
 func makeEnvelopePrefix(flags uint8, size int) ([5]byte, error) {
-	if size < 0 || size > math.MaxUint32 {
+	if size < 0 || size > min(math.MaxInt, math.MaxUint32) {
 		return [5]byte{}, fmt.Errorf("connect.makeEnvelopePrefix: size %d out of bounds", size)
 	}
 	prefix := [5]byte{}


### PR DESCRIPTION
This PR updates the size check in `makeEnvelopePrefix` to fix compilation error `connect@v1.19.0/envelope.go:378:24: math.MaxUint32 (untyped int constant 4294967295) overflows int` for 32-bit build.

Related issue: https://github.com/connectrpc/connect-go/issues/886