### PR TITLE
Prepare for v1.19.1

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Version is the semantic version of the connect module.
-const Version = "1.20.0-dev"
+const Version = "1.19.1"
 
 // These constants are used in compile-time handshakes with connect's generated
 // code.


### PR DESCRIPTION
Below are the draft release notes for v1.19.1.

## What's Changed
### Bugfixes
* Fix bounds check on envelope for 32-bit archs by @emcfarlane in #887
* Fix CallInfo header/trailer propagation on error responses by @emcfarlane in #892

**Full Changelog**: https://github.com/connectrpc/connect-go/compare/v1.19.0...v1.19.1