### PR TITLE
Use 'deadline_exceeded' instead of 'canceled' on HTTP/2 cancelation when appropriate

### DIFF
--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -229,7 +229,7 @@ func (d *duplexHTTPCall) Read(data []byte) (int, error) {
 	n, err := d.response.Body.Read(data)
 	if err != nil && !errors.Is(err, io.EOF) {
 		err = wrapIfContextDone(d.ctx, err)
-		err = wrapIfRSTError(err)
+		err = wrapIfRSTError(d.ctx, err)
 	}
 	return n, err
 }
@@ -241,7 +241,7 @@ func (d *duplexHTTPCall) CloseRead() error {
 	}
 	err := d.response.Body.Close()
 	err = wrapIfContextDone(d.ctx, err)
-	return wrapIfRSTError(err)
+	return wrapIfRSTError(d.ctx, err)
 }
 
 // ResponseStatusCode is the response's HTTP status code.
@@ -310,7 +310,7 @@ func (d *duplexHTTPCall) makeRequest() {
 		err = wrapIfContextError(err)
 		err = wrapIfLikelyH2CNotConfiguredError(d.request, err)
 		err = wrapIfLikelyWithGRPCNotUsedError(err)
-		err = wrapIfRSTError(err)
+		err = wrapIfRSTError(d.ctx, err)
 		if _, ok := asError(err); !ok {
 			err = NewError(CodeUnavailable, err)
 		}


### PR DESCRIPTION
This applies the same change as was done in an interceptor in the conformance client here: https://github.com/connectrpc/conformance/pull/1028.

Some server implementations can use an HTTP/2 RST_STREAM frame to cancel the operation after the client's deadline has been exceeded. Because of how the deadline is actually implemented in Go's `context` package (via a `time.Timer` function), it is possible that the deadline lapse and the server cancels the stream, all before that `time.Timer` function has actually executed and set `ctx.Err()`. Because of that, the connect-go client can sometimes misattribute the error as `CANCELED` instead of `DEADLINE_EXCEEDED`.

The above linked change in the conformance client was adequate to address flaky tests around this issue (where the conformance suite was asserting the error to be `DEADLINE_EXCEEDED` but it would sometimes be `CANCELED` instead). So this seems appropriate to promote into the runtime itself. 