### PR TITLE
Skip sendMaxBytes check for EndStream control frames (#907)

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -28,11 +28,17 @@ import (
 // same meaning in the gRPC-Web, gRPC-HTTP2, and Connect protocols.
 const flagEnvelopeCompressed = 0b00000001
 
-var errSpecialEnvelope = errorf(
-	CodeUnknown,
-	"final message has protocol-specific flags: %w",
-	// User code checks for end of stream with errors.Is(err, io.EOF).
-	io.EOF,
+var (
+	errSpecialEnvelope = errorf(
+		CodeUnknown,
+		"final message has protocol-specific flags: %w",
+		// User code checks for end of stream with errors.Is(err, io.EOF).
+		io.EOF,
+	)
+	// errExceedsSendMax is a sentinel wrapped by sendMaxBytes errors so
+	// that callers (e.g. MarshalEndStream) can detect the violation and
+	// fall back to a smaller frame.
+	errExceedsSendMax = errors.New("")
 )
 
 // envelope is a block of arbitrary bytes wrapped in gRPC and Connect's framing
@@ -160,7 +166,7 @@ func (w *envelopeWriter) Write(env *envelope) *Error {
 		w.compressionPool == nil ||
 		env.Data.Len() < w.compressMinBytes {
 		if w.sendMaxBytes > 0 && env.Data.Len() > w.sendMaxBytes {
-			return errorf(CodeResourceExhausted, "message size %d exceeds sendMaxBytes %d", env.Data.Len(), w.sendMaxBytes)
+			return errorf(CodeResourceExhausted, "message size %d exceeds sendMaxBytes %d%w", env.Data.Len(), w.sendMaxBytes, errExceedsSendMax)
 		}
 		return w.write(env)
 	}
@@ -170,12 +176,50 @@ func (w *envelopeWriter) Write(env *envelope) *Error {
 		return err
 	}
 	if w.sendMaxBytes > 0 && data.Len() > w.sendMaxBytes {
-		return errorf(CodeResourceExhausted, "compressed message size %d exceeds sendMaxBytes %d", data.Len(), w.sendMaxBytes)
+		return errorf(CodeResourceExhausted, "compressed message size %d exceeds sendMaxBytes %d%w", data.Len(), w.sendMaxBytes, errExceedsSendMax)
 	}
 	return w.write(&envelope{
 		Data:  data,
 		Flags: env.Flags | flagEnvelopeCompressed,
 	})
+}
+
+// writeControlFrame implements a fallback strategy for writing protocol
+// control frames (Connect EndStream, gRPC-Web trailers) that may exceed
+// sendMaxBytes. It calls marshal to produce the frame bytes and attempts to
+// write the frame. If the frame exceeds sendMaxBytes:
+//  1. Calls reduce (if non-nil) to strip non-essential data (e.g. error
+//     details), re-marshals, and retries.
+//  2. If still too large, sends the frame anyway — the limit is unreasonably
+//     low and delivering the error is more important.
+func (w *envelopeWriter) writeControlFrame(flags uint8, marshal func() ([]byte, *Error), reduce func()) *Error {
+	write := func() *Error {
+		data, err := marshal()
+		if err != nil {
+			return err
+		}
+		raw := bytes.NewBuffer(data)
+		defer w.bufferPool.Put(raw)
+		return w.Write(&envelope{Data: raw, Flags: flags})
+	}
+	if writeErr := write(); writeErr == nil || !errors.Is(writeErr, errExceedsSendMax) {
+		return writeErr
+	}
+	if reduce != nil {
+		reduce()
+		if writeErr := write(); writeErr == nil || !errors.Is(writeErr, errExceedsSendMax) {
+			return writeErr
+		}
+	}
+	// Even the (possibly reduced) frame exceeds sendMaxBytes. The limit is
+	// unreasonably low, so send it anyway.
+	data, err := marshal()
+	if err != nil {
+		return err
+	}
+	raw := bytes.NewBuffer(data)
+	defer w.bufferPool.Put(raw)
+	return w.write(&envelope{Data: raw, Flags: flags})
 }
 
 func (w *envelopeWriter) marshalAppend(message any, codec marshalAppender) *Error {

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -16,6 +16,7 @@ package connect
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"testing"
 
@@ -100,6 +101,67 @@ func TestEnvelope(t *testing.T) {
 			assert.Equal(t, env.Len(), 0)
 		})
 	})
+}
+
+func TestEnvelopeWriteSendMaxBytes(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name       string
+		flags      uint8
+		compressed bool
+	}{
+		{
+			name: "rejects_oversized_message_uncompressed",
+		},
+		{
+			name:       "rejects_oversized_message_compressed",
+			compressed: true,
+		},
+		{
+			name:  "rejects_oversized_end_stream_uncompressed",
+			flags: connectFlagEnvelopeEndStream,
+		},
+		{
+			name:       "rejects_oversized_end_stream_compressed",
+			flags:      connectFlagEnvelopeEndStream,
+			compressed: true,
+		},
+		{
+			name:  "rejects_oversized_grpc_web_trailer_uncompressed",
+			flags: grpcFlagEnvelopeTrailer,
+		},
+		{
+			name:       "rejects_oversized_grpc_web_trailer_compressed",
+			flags:      grpcFlagEnvelopeTrailer,
+			compressed: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			out := &bytes.Buffer{}
+			writer := envelopeWriter{
+				sender:       writeSender{writer: out},
+				bufferPool:   newBufferPool(),
+				sendMaxBytes: 1,
+			}
+			if testCase.compressed {
+				gzipOption, ok := withGzip().(*compressionOption)
+				assert.True(t, ok)
+				writer.compressMinBytes = 1
+				writer.compressionPool = gzipOption.CompressionPool
+				writer.bufferPool = newBufferPool()
+			}
+			env := &envelope{
+				Data:  bytes.NewBuffer(make([]byte, 64)),
+				Flags: testCase.flags,
+			}
+			err := writer.Write(env)
+			assert.NotNil(t, err)
+			assert.Equal(t, CodeOf(err), CodeResourceExhausted)
+			assert.True(t, errors.Is(err, errExceedsSendMax))
+		})
+	}
 }
 
 // byteByByteReader is test reader that reads a single byte at a time.

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -855,16 +855,18 @@ func (m *connectStreamingMarshaler) MarshalEndStream(err error, trailer http.Hea
 			mergeNonProtocolHeaders(end.Trailer, connectErr.meta)
 		}
 	}
-	data, marshalErr := json.Marshal(end)
-	if marshalErr != nil {
-		return errorf(CodeInternal, "marshal end stream: %w", marshalErr)
+	marshal := func() ([]byte, *Error) {
+		data, marshalErr := json.Marshal(end)
+		if marshalErr != nil {
+			return nil, errorf(CodeInternal, "marshal end stream: %w", marshalErr)
+		}
+		return data, nil
 	}
-	raw := bytes.NewBuffer(data)
-	defer m.envelopeWriter.bufferPool.Put(raw)
-	return m.Write(&envelope{
-		Data:  raw,
-		Flags: connectFlagEnvelopeEndStream,
-	})
+	var reduce func()
+	if end.Error != nil && len(end.Error.Details) > 0 {
+		reduce = func() { end.Error.Details = nil }
+	}
+	return m.writeControlFrame(connectFlagEnvelopeEndStream, marshal, reduce)
 }
 
 type connectStreamingUnmarshaler struct {

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -16,6 +16,7 @@ package connect
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -577,8 +578,6 @@ type grpcMarshaler struct {
 }
 
 func (m *grpcMarshaler) MarshalWebTrailers(trailer http.Header) *Error {
-	raw := m.envelopeWriter.bufferPool.Get()
-	defer m.envelopeWriter.bufferPool.Put(raw)
 	for key, values := range trailer {
 		// Per the Go specification, keys inserted during iteration may be produced
 		// later in the iteration or may be skipped. For safety, avoid mutating the
@@ -590,13 +589,21 @@ func (m *grpcMarshaler) MarshalWebTrailers(trailer http.Header) *Error {
 		delete(trailer, key)
 		trailer[lower] = values
 	}
-	if err := trailer.Write(raw); err != nil {
-		return errorf(CodeInternal, "format trailers: %w", err)
+	marshal := func() ([]byte, *Error) {
+		var buf bytes.Buffer
+		if err := trailer.Write(&buf); err != nil {
+			return nil, errorf(CodeInternal, "format trailers: %w", err)
+		}
+		return buf.Bytes(), nil
 	}
-	return m.Write(&envelope{
-		Data:  raw,
-		Flags: grpcFlagEnvelopeTrailer,
-	})
+	// Use direct map access because the loop above lowercased all keys,
+	// so http.Header.Get/Del (which canonicalize) won't find them.
+	detailsKey := strings.ToLower(grpcHeaderDetails)
+	var reduce func()
+	if _, ok := trailer[detailsKey]; ok {
+		reduce = func() { delete(trailer, detailsKey) }
+	}
+	return m.writeControlFrame(grpcFlagEnvelopeTrailer, marshal, reduce)
 }
 
 type grpcUnmarshaler struct {


### PR DESCRIPTION
Use two-stage fallback for oversized EndStream control frames

Instead of unconditionally bypassing the sendMaxBytes check for control
frames, implement a graduated fallback strategy in envelopeWriter:

  1. Try to send the full EndStream frame (error code + message + details).
  2. If it exceeds sendMaxBytes, call a reduce closure to strip error
     details in-place, re-marshal via a marshal closure, and retry.
  3. If even the minimal frame is too large (unreasonably low limit),
     force-send it anyway.

The fallback logic lives entirely in envelope.go's writeControlFrame,
which takes two closures from the protocol layer:

  - marshal: serializes the current frame state into bytes. Because it
    closes over the frame struct, it automatically reflects any mutations
    made by reduce.
  - reduce: mutates the captured frame struct to strip non-essential data
    (error details for Connect, grpc-status-details-bin for gRPC-Web).

This keeps sendMaxBytes enforcement intact for control frames while
guaranteeing that the client always receives at least a minimal error.

Fixes #907