### PR TITLE
Clarify UnaryFunc response type

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -54,6 +54,10 @@ func NewUnaryHandler[Req, Res any](
 			// if we panic here instead, so we can include the procedure name.
 			panic(procedure + " returned nil *connect.Response and nil error") //nolint: forbidigo
 		}
+		if res == nil {
+			// Avoid returning a typed nil (*Response[Res]) as an AnyResponse interface value.
+			return nil, err
+		}
 		return res, err
 	})
 	config := newHandlerConfig(procedure, StreamTypeUnary, options)

--- a/interceptor.go
+++ b/interceptor.go
@@ -31,6 +31,8 @@ var (
 // The type of the request and response structs depend on the codec being used.
 // When using Protobuf, request.Any() and response.Any() will always be
 // [proto.Message] implementations.
+//
+// On return, response is non-nil if and only if err is nil.
 type UnaryFunc func(context.Context, AnyRequest) (AnyResponse, error)
 
 // StreamingClientFunc is the generic signature of a streaming RPC from the client's

--- a/interceptor_ext_test.go
+++ b/interceptor_ext_test.go
@@ -708,6 +708,37 @@ func TestInterceptorFuncAccessingHTTPMethod(t *testing.T) {
 	assert.Equal(t, int32(2), handlerChecker.count.Load())
 }
 
+func TestHandlerErrorResponseNilInInterceptor(t *testing.T) {
+	t.Parallel()
+	handlerErr := connect.NewError(connect.CodeInternal, errors.New("handler error"))
+	var interceptorSawNilResponse bool
+	checkNilInterceptor := connect.UnaryInterceptorFunc(
+		func(next connect.UnaryFunc) connect.UnaryFunc {
+			return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+				res, err := next(ctx, req)
+				// res must be nil when err is non-nil; a typed nil stored in an
+				// interface would make this check incorrectly report non-nil.
+				interceptorSawNilResponse = res == nil
+				return res, err
+			}
+		},
+	)
+	mux := http.NewServeMux()
+	mux.Handle(pingv1connect.NewPingServiceHandler(
+		&pluggablePingServer{
+			ping: func(_ context.Context, _ *connect.Request[pingv1.PingRequest]) (*connect.Response[pingv1.PingResponse], error) {
+				return nil, handlerErr
+			},
+		},
+		connect.WithInterceptors(checkNilInterceptor),
+	))
+	server := memhttptest.NewServer(t, mux)
+	client := pingv1connect.NewPingServiceClient(server.Client(), server.URL())
+	_, err := client.Ping(t.Context(), connect.NewRequest(&pingv1.PingRequest{}))
+	assert.NotNil(t, err)
+	assert.True(t, interceptorSawNilResponse)
+}
+
 // headerInterceptor makes it easier to write interceptors that inspect or
 // mutate HTTP headers. It applies the same logic to unary and streaming
 // procedures, wrapping the send or receive side of the stream as appropriate.


### PR DESCRIPTION
Currently we return a typed nil (`*Response[Res]`) for the `AnyResponse` interface on unary handlers. This is only an issue if interceptors ignore the `err` and only check the `response` type. To simplify, we now guarantee a nil `AnyResponse` when `err` is not nil.

The doc comment on UnaryFunc is updated to state the contract: on return, response is non-nil if and only if err is nil.

Fixes https://github.com/connectrpc/connect-go/issues/827