### PR TITLE
Upgrade golangci-lint to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,130 +1,137 @@
-linters-settings:
-  errcheck:
-    check-type-assertions: true
-  exhaustruct:
-    include:
-      # No zero values for param structs.
-      - 'connectrpc\.com/connect\..*[pP]arams'
-  forbidigo:
-    forbid:
-      - '^fmt\.Print'
-      - '^log\.'
-      - '^print$'
-      - '^println$'
-      - '^panic$'
-  godox:
-    # TODO, OPT, etc. comments are fine to commit. Use FIXME comments for
-    # temporary hacks, and use godox to prevent committing them.
-    keywords: [FIXME]
-  importas:
-    no-unaliased: true
-    alias:
-      - pkg: connectrpc.com/connect/internal/gen/connect/ping/v1
-        alias: pingv1
-  varnamelen:
-    ignore-decls:
-      - T any
-      - i int
-      - wg sync.WaitGroup
+version: "2"
 linters:
-  enable-all: true
+  default: all
   disable:
-    - cyclop            # covered by gocyclo
-    - depguard          # unnecessary for small libraries
-    - funlen            # rely on code review to limit function length
-    - gocognit          # dubious "cognitive overhead" quantification
-    - gofumpt           # prefer standard gofmt
-    - goimports         # rely on gci instead
-    - inamedparam       # convention is not followed
-    - ireturn           # "accept interfaces, return structs" isn't ironclad
-    - lll               # don't want hard limits for line length
-    - maintidx          # covered by gocyclo
-    - mnd               # status codes are clearer than constants
-    - nlreturn          # generous whitespace violates house style
-    - nonamedreturns    # named returns are fine; it's *bare* returns that are bad
-    - protogetter       # too many false positives
-    - tenv              # replaced by usetesting
-    - testpackage       # internal tests are fine
-    - wrapcheck         # don't _always_ need to wrap errors
-    - wsl               # generous whitespace violates house style
-issues:
-  exclude-dirs-use-default: false
-
-  exclude:
-    # Don't ban use of fmt.Errorf to create new errors, but the remaining
-    # checks from err113 are useful.
-    - "do not define dynamic errors, use wrapped static errors instead: .*"
-
-  exclude-rules:
-    # If future reflect.Kinds are nil-able, we'll find out when a test fails.
-    - linters: [exhaustive]
-      path: internal/assert/assert.go
-    # We need our duplex HTTP call to have access to the context.
-    - linters: [containedctx]
-      path: duplex_http_call.go
-    # We need to init a global in-mem HTTP server for testable examples.
-    - linters: [gochecknoinits, gochecknoglobals]
-      path: example_init_test.go
-    # We purposefully do an ineffectual assignment for an example.
-    - linters: [ineffassign]
-      path: client_example_test.go
-    # The generated file is effectively a global receiver.
-    - linters: [varnamelen]
-      path: cmd/protoc-gen-connect-go
-      text: "parameter name 'g' is too short"
-    # Thorough error logging and timeout config make this example unreadably long.
-    - linters: [errcheck, gosec]
-      path: error_writer_example_test.go
-    # It should be crystal clear that Connect uses plain *http.Clients.
-    - linters: [revive, stylecheck]
-      path: client_example_test.go
-    # Don't complain about timeout management or lack of output assertions in examples.
-    - linters: [gosec, testableexamples]
-      path: handler_example_test.go
-    # No output assertions needed for these examples.
-    - linters: [testableexamples]
-      path: error_writer_example_test.go
-    - linters: [testableexamples]
-      path: error_not_modified_example_test.go
-    - linters: [testableexamples]
-      path: error_example_test.go
-    # In examples, it's okay to use http.ListenAndServe.
-    - linters: [gosec]
-      path: error_not_modified_example_test.go
-    # There are many instances where we want to keep unused parameters
-    # as a matter of style or convention, for example when a context.Context
-    # is the first parameter, we choose to just globally ignore this.
-    - linters: [revive]
-      text: "^unused-parameter: "
-    # We want to return explicit nils in protocol_grpc.go
-    - linters: [revive]
-      text: "^if-return: "
-      path: protocol_grpc.go
-    # We want to return explicit nils in protocol_connect.go
-    - linters: [revive]
-      text: "^if-return: "
-      path: protocol_connect.go
-    # We want to return explicit nils in error_writer.go
-    - linters: [revive]
-      text: "^if-return: "
-      path: error_writer.go
-    # We want to set http.Server's logger
-    - linters: [forbidigo]
-      path: internal/memhttp
-      text: "use of `log.(New|Logger|Lshortfile)` forbidden by pattern .*"
-    # We want to show examples with http.Get
-    - linters: [noctx]
-      path: internal/memhttp/memhttp_test.go
-    # Allow fmt.Sprintf for cmd/protoc-gen-connect-go for consistency
-    - linters: [perfsprint]
-      path: cmd/protoc-gen-connect-go/main.go
-    # Allow non-canonical headers in tests
-    - linters: [canonicalheader]
-      path: '.*_test.go'
-    # Allow Code pointer receiver for UnmarshalText method
-    - linters: [recvcheck]
-      path: code.go
-    # Avoid false positives for int overflow in tests
-    - linters: [gosec]
-      text: "^G115: integer overflow conversion"
-      path: ".*_test.go"
+    - cyclop
+    - depguard
+    - funlen
+    - gocognit
+    - inamedparam
+    - ireturn
+    - lll
+    - maintidx
+    - mnd
+    - nlreturn
+    - nonamedreturns
+    - protogetter
+    - testpackage
+    - wrapcheck
+    - wsl
+  settings:
+    errcheck:
+      check-type-assertions: true
+    exhaustruct:
+      include:
+        - connectrpc\.com/connect\..*[pP]arams
+    forbidigo:
+      forbid:
+        - pattern: ^fmt\.Print
+        - pattern: ^log\.
+        - pattern: ^print$
+        - pattern: ^println$
+        - pattern: ^panic$
+    godox:
+      keywords:
+        - FIXME
+    importas:
+      alias:
+        - pkg: connectrpc.com/connect/internal/gen/connect/ping/v1
+          alias: pingv1
+      no-unaliased: true
+    varnamelen:
+      ignore-decls:
+        - T any
+        - i int
+        - wg sync.WaitGroup
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - exhaustive
+        path: internal/assert/assert.go
+      - linters:
+          - containedctx
+        path: duplex_http_call.go
+      - linters:
+          - gochecknoglobals
+          - gochecknoinits
+        path: example_init_test.go
+      - linters:
+          - ineffassign
+        path: client_example_test.go
+      - linters:
+          - varnamelen
+        path: cmd/protoc-gen-connect-go
+        text: parameter name 'g' is too short
+      - linters:
+          - errcheck
+          - gosec
+        path: error_writer_example_test.go
+      - linters:
+          - revive
+          - staticcheck
+        path: client_example_test.go
+      - linters:
+          - gosec
+          - testableexamples
+        path: handler_example_test.go
+      - linters:
+          - testableexamples
+        path: error_writer_example_test.go
+      - linters:
+          - testableexamples
+        path: error_not_modified_example_test.go
+      - linters:
+          - testableexamples
+        path: error_example_test.go
+      - linters:
+          - gosec
+        path: error_not_modified_example_test.go
+      - linters:
+          - revive
+        text: '^unused-parameter: '
+      - linters:
+          - revive
+        path: protocol_grpc.go
+        text: '^if-return: '
+      - linters:
+          - revive
+        path: protocol_connect.go
+        text: '^if-return: '
+      - linters:
+          - revive
+        path: error_writer.go
+        text: '^if-return: '
+      - linters:
+          - forbidigo
+        path: internal/memhttp
+        text: use of `log.(New|Logger|Lshortfile)` forbidden by pattern .*
+      - linters:
+          - noctx
+        path: internal/memhttp/memhttp_test.go
+      - linters:
+          - perfsprint
+        path: cmd/protoc-gen-connect-go/main.go
+      - linters:
+          - canonicalheader
+        path: .*_test.go
+      - linters:
+          - recvcheck
+        path: code.go
+      - linters:
+          - gosec
+        path: .*_test.go
+        text: '^G115: integer overflow conversion'
+      - path: (.+)\.go$
+        text: 'do not define dynamic errors, use wrapped static errors instead: .*'
+formatters:
+  enable:
+    - gci
+    - gofmt
+  exclusions:
+    generated: lax

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters:
   disable:
     - cyclop           # covered by gocyclo
     - depguard         # unnecessary for small libraries
+    - funcorder        # consider enabling in the future
     - funlen           # rely on code review to limit function length
     - gocognit         # dubious "cognitive overhead" quantification
     - inamedparam      # convention is not followed
@@ -12,11 +13,13 @@ linters:
     - maintidx         # covered by gocyclo
     - mnd              # status codes are clearer than constants
     - nlreturn         # generous whitespace violates house style
+    - noinlineerr      # inline is fine
     - nonamedreturns   # named returns are fine; it's *bare* returns that are bad
     - protogetter      # too many false positives
     - testpackage      # internal tests are fine
     - wrapcheck        # don't _always_ need to wrap errors
     - wsl              # generous whitespace violates house style
+    - wsl_v5           # generous whitespace violates house style
   settings:
     errcheck:
       check-type-assertions: true
@@ -51,6 +54,15 @@ linters:
       - legacy
       - std-error-handling
     rules:
+      # Loosen requirements on tests
+      - linters:
+          - funlen
+          - gosec
+          - gosmopolitan
+          - unparam
+          - varnamelen
+          - prealloc
+        path: _test.go
       # If future reflect.Kinds are nil-able, we'll find out when a test fails.
       - linters:
           - exhaustive

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,21 +2,21 @@ version: "2"
 linters:
   default: all
   disable:
-    - cyclop
-    - depguard
-    - funlen
-    - gocognit
-    - inamedparam
-    - ireturn
-    - lll
-    - maintidx
-    - mnd
-    - nlreturn
-    - nonamedreturns
-    - protogetter
-    - testpackage
-    - wrapcheck
-    - wsl
+    - cyclop           # covered by gocyclo
+    - depguard         # unnecessary for small libraries
+    - funlen           # rely on code review to limit function length
+    - gocognit         # dubious "cognitive overhead" quantification
+    - inamedparam      # convention is not followed
+    - ireturn          # "accept interfaces, return structs" isn't ironclad
+    - lll              # don't want hard limits for line length
+    - maintidx         # covered by gocyclo
+    - mnd              # status codes are clearer than constants
+    - nlreturn         # generous whitespace violates house style
+    - nonamedreturns   # named returns are fine; it's *bare* returns that are bad
+    - protogetter      # too many false positives
+    - testpackage      # internal tests are fine
+    - wrapcheck        # don't _always_ need to wrap errors
+    - wsl              # generous whitespace violates house style
   settings:
     errcheck:
       check-type-assertions: true
@@ -51,35 +51,44 @@ linters:
       - legacy
       - std-error-handling
     rules:
+      # If future reflect.Kinds are nil-able, we'll find out when a test fails.
       - linters:
           - exhaustive
         path: internal/assert/assert.go
+      # We need our duplex HTTP call to have access to the context.
       - linters:
           - containedctx
         path: duplex_http_call.go
+      # We need to init a global in-mem HTTP server for testable examples.
       - linters:
           - gochecknoglobals
           - gochecknoinits
         path: example_init_test.go
+      # We purposefully do an ineffectual assignment for an example.
       - linters:
           - ineffassign
         path: client_example_test.go
+      # The generated file is effectively a global receiver.
       - linters:
           - varnamelen
         path: cmd/protoc-gen-connect-go
         text: parameter name 'g' is too short
+      # Thorough error logging and timeout config make this example unreadably long.
       - linters:
           - errcheck
           - gosec
         path: error_writer_example_test.go
+      # It should be crystal clear that Connect uses plain *http.Clients.
       - linters:
           - revive
           - staticcheck
         path: client_example_test.go
+      # Don't complain about timeout management or lack of output assertions in examples.
       - linters:
           - gosec
           - testableexamples
         path: handler_example_test.go
+      # No output assertions needed for these examples.
       - linters:
           - testableexamples
         path: error_writer_example_test.go
@@ -89,44 +98,59 @@ linters:
       - linters:
           - testableexamples
         path: error_example_test.go
+      # In examples, it's okay to use http.ListenAndServe.
       - linters:
           - gosec
         path: error_not_modified_example_test.go
+      # There are many instances where we want to keep unused parameters
+      # as a matter of style or convention, for example when a context.Context
+      # is the first parameter, we choose to just globally ignore this.
       - linters:
           - revive
         text: '^unused-parameter: '
+      # We want to return explicit nils in protocol_grpc.go
       - linters:
           - revive
         path: protocol_grpc.go
         text: '^if-return: '
+      # We want to return explicit nils in protocol_connect.go
       - linters:
           - revive
         path: protocol_connect.go
         text: '^if-return: '
+      # We want to return explicit nils in error_writer.go
       - linters:
           - revive
         path: error_writer.go
         text: '^if-return: '
+      # We want to set http.Server's logger
       - linters:
           - forbidigo
         path: internal/memhttp
         text: use of `log.(New|Logger|Lshortfile)` forbidden by pattern .*
+      # We want to show examples with http.Get
       - linters:
           - noctx
         path: internal/memhttp/memhttp_test.go
+      # Allow fmt.Sprintf for cmd/protoc-gen-connect-go for consistency
       - linters:
           - perfsprint
         path: cmd/protoc-gen-connect-go/main.go
+      # Allow non-canonical headers in tests
       - linters:
           - canonicalheader
         path: .*_test.go
+      # Allow Code pointer receiver for UnmarshalText method
       - linters:
           - recvcheck
         path: code.go
+      # Avoid false positives for int overflow in tests
       - linters:
           - gosec
         path: .*_test.go
         text: '^G115: integer overflow conversion'
+      # Don't ban use of fmt.Errorf to create new errors, but the remaining
+      # checks from err113 are useful.
       - path: (.+)\.go$
         text: 'do not define dynamic errors, use wrapped static errors instead: .*'
 formatters:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ export GOBIN := $(abspath $(BIN))
 COPYRIGHT_YEARS := 2021-2025
 LICENSE_IGNORE := --ignore /testdata/
 BUF_VERSION := 1.50.1
+GOLANGCI_LINT_VERSION ?= v2.11.4
 
 .PHONY: help
 help: ## Describe useful make targets
@@ -112,7 +113,7 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.7
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 $(BIN)/protoc-gen-go: Makefile go.mod
 	@mkdir -p $(@D)

--- a/cmd/protoc-gen-connect-go/main_test.go
+++ b/cmd/protoc-gen-connect-go/main_test.go
@@ -28,14 +28,6 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
-	"connectrpc.com/connect/internal/assert"
-	pingv1 "connectrpc.com/connect/internal/gen/connect/ping/v1"
-	"github.com/google/go-cmp/cmp"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protodesc"
-	"google.golang.org/protobuf/types/descriptorpb"
-	"google.golang.org/protobuf/types/pluginpb"
-
 	defaultpackage "connectrpc.com/connect/cmd/protoc-gen-connect-go/internal/testdata/defaultpackage/gen"
 	defaultpackageconnect "connectrpc.com/connect/cmd/protoc-gen-connect-go/internal/testdata/defaultpackage/gen/genconnect"
 	diffpackage "connectrpc.com/connect/cmd/protoc-gen-connect-go/internal/testdata/diffpackage/gen"
@@ -44,6 +36,13 @@ import (
 	samepackage "connectrpc.com/connect/cmd/protoc-gen-connect-go/internal/testdata/samepackage/gen"
 	simple "connectrpc.com/connect/cmd/protoc-gen-connect-go/internal/testdata/simple/gen"
 	_ "connectrpc.com/connect/cmd/protoc-gen-connect-go/internal/testdata/v1beta1service/gen"
+	"connectrpc.com/connect/internal/assert"
+	pingv1 "connectrpc.com/connect/internal/gen/connect/ping/v1"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/pluginpb"
 )
 
 //go:embed internal/testdata
@@ -278,7 +277,7 @@ func testRunProtocGenGo(t *testing.T, stdin io.Reader, args ...string) (stdout, 
 	stderr = &bytes.Buffer{}
 	args = append([]string{"run", "main.go"}, args...)
 
-	cmd := exec.Command("go", args...)
+	cmd := exec.CommandContext(t.Context(), "go", args...)
 	cmd.Env = os.Environ()
 	cmd.Stdin = stdin
 	cmd.Stdout = stdout

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -76,9 +76,11 @@ func TestCallInfo(t *testing.T) {
 		server := memhttptest.NewServer(t, mux)
 		client := pingv1connectsimple.NewPingServiceClient(server.Client(), server.URL())
 		t.Run("unary", func(t *testing.T) {
+			t.Parallel()
 			testUnarySimple(t, client)
 		})
 		t.Run("unary_no_callinfo", func(t *testing.T) {
+			t.Parallel()
 			num := int64(42)
 			expect := &pingv1.PingResponse{Number: num}
 			response, err := client.Ping(t.Context(), &pingv1.PingRequest{Number: num})
@@ -86,6 +88,7 @@ func TestCallInfo(t *testing.T) {
 			assert.Nil(t, err)
 		})
 		t.Run("unary_generics_server", func(t *testing.T) {
+			t.Parallel()
 			mux := http.NewServeMux()
 			mux.Handle(pingv1connect.NewPingServiceHandler(
 				pingServer{},
@@ -95,9 +98,11 @@ func TestCallInfo(t *testing.T) {
 			testUnarySimple(t, simpleClient)
 		})
 		t.Run("server_stream", func(t *testing.T) {
+			t.Parallel()
 			testServerStreamSimple(t, client)
 		})
 		t.Run("server_stream_no_callinfo", func(t *testing.T) {
+			t.Parallel()
 			val := 3
 			stream, err := client.CountUp(t.Context(), &pingv1.CountUpRequest{
 				Number: int64(val),
@@ -119,6 +124,7 @@ func TestCallInfo(t *testing.T) {
 			assert.Nil(t, stream.Close())
 		})
 		t.Run("server_stream_generics_server", func(t *testing.T) {
+			t.Parallel()
 			mux := http.NewServeMux()
 			mux.Handle(pingv1connect.NewPingServiceHandler(
 				pingServer{},
@@ -128,9 +134,11 @@ func TestCallInfo(t *testing.T) {
 			testServerStreamSimple(t, simpleClient)
 		})
 		t.Run("client_stream", func(t *testing.T) {
+			t.Parallel()
 			testClientStreamSimple(t, client)
 		})
 		t.Run("client_stream_generics_server", func(t *testing.T) {
+			t.Parallel()
 			mux := http.NewServeMux()
 			mux.Handle(pingv1connect.NewPingServiceHandler(
 				pingServer{},
@@ -140,6 +148,7 @@ func TestCallInfo(t *testing.T) {
 			testClientStreamSimple(t, simpleClient)
 		})
 		t.Run("client_stream_no_callinfo", func(t *testing.T) {
+			t.Parallel()
 			const (
 				upTo   = 10
 				expect = 55 // 1+10 + 2+9 + ... + 5+6 = 55
@@ -158,9 +167,11 @@ func TestCallInfo(t *testing.T) {
 			assert.Equal(t, response.GetSum(), expect)
 		})
 		t.Run("bidi_stream", func(t *testing.T) {
+			t.Parallel()
 			testBidiStreamSimple(t, client)
 		})
 		t.Run("bidi_stream_generics_server", func(t *testing.T) {
+			t.Parallel()
 			mux := http.NewServeMux()
 			mux.Handle(pingv1connect.NewPingServiceHandler(
 				pingServer{},
@@ -170,6 +181,7 @@ func TestCallInfo(t *testing.T) {
 			testBidiStreamSimple(t, simpleClient)
 		})
 		t.Run("bidi_stream_no_callinfo", func(t *testing.T) {
+			t.Parallel()
 			send := []int64{3, 5, 1}
 			expect := []int64{3, 8, 9}
 			var got []int64
@@ -217,9 +229,11 @@ func TestCallInfo(t *testing.T) {
 		server := memhttptest.NewServer(t, mux)
 		client := pingv1connect.NewPingServiceClient(server.Client(), server.URL())
 		t.Run("unary", func(t *testing.T) {
+			t.Parallel()
 			testUnaryGenerics(t, client)
 		})
 		t.Run("unary_simple_server", func(t *testing.T) {
+			t.Parallel()
 			mux := http.NewServeMux()
 			mux.Handle(pingv1connectsimple.NewPingServiceHandler(
 				pingServerSimple{},
@@ -229,6 +243,7 @@ func TestCallInfo(t *testing.T) {
 			testUnaryGenerics(t, genericsClient)
 		})
 		t.Run("unary_no_callinfo", func(t *testing.T) {
+			t.Parallel()
 			num := int64(42)
 			request := connect.NewRequest(&pingv1.PingRequest{Number: num})
 			request.Header().Add(clientHeader, "foo")
@@ -248,9 +263,11 @@ func TestCallInfo(t *testing.T) {
 			assertResponseHeadersAndTrailers(t, wrapper)
 		})
 		t.Run("server_stream", func(t *testing.T) {
+			t.Parallel()
 			testServerStreamGenerics(t, client)
 		})
 		t.Run("server_stream_simple_server", func(t *testing.T) {
+			t.Parallel()
 			mux := http.NewServeMux()
 			mux.Handle(pingv1connectsimple.NewPingServiceHandler(
 				pingServerSimple{},
@@ -260,6 +277,7 @@ func TestCallInfo(t *testing.T) {
 			testServerStreamGenerics(t, genericsClient)
 		})
 		t.Run("server_stream_no_callinfo", func(t *testing.T) {
+			t.Parallel()
 			val := 3
 			req := connect.NewRequest(&pingv1.CountUpRequest{
 				Number: int64(val),
@@ -291,9 +309,11 @@ func TestCallInfo(t *testing.T) {
 			assertResponseHeadersAndTrailers(t, stream)
 		})
 		t.Run("client_stream", func(t *testing.T) {
+			t.Parallel()
 			testClientStreamGenerics(t, client)
 		})
 		t.Run("client_stream_simple_server", func(t *testing.T) {
+			t.Parallel()
 			mux := http.NewServeMux()
 			mux.Handle(pingv1connectsimple.NewPingServiceHandler(
 				pingServerSimple{},
@@ -303,6 +323,7 @@ func TestCallInfo(t *testing.T) {
 			testClientStreamGenerics(t, genericsClient)
 		})
 		t.Run("client_stream_no_callinfo", func(t *testing.T) {
+			t.Parallel()
 			const (
 				upTo   = 10
 				expect = 55 // 1+10 + 2+9 + ... + 5+6 = 55
@@ -326,9 +347,11 @@ func TestCallInfo(t *testing.T) {
 			assertResponseHeadersAndTrailers(t, wrapper)
 		})
 		t.Run("bidi_stream", func(t *testing.T) {
+			t.Parallel()
 			testBidiStreamGenerics(t, client, true)
 		})
 		t.Run("bidi_stream_simple_server", func(t *testing.T) {
+			t.Parallel()
 			mux := http.NewServeMux()
 			mux.Handle(pingv1connectsimple.NewPingServiceHandler(
 				pingServerSimple{},
@@ -338,6 +361,7 @@ func TestCallInfo(t *testing.T) {
 			testBidiStreamGenerics(t, genericsClient, true)
 		})
 		t.Run("bidi_stream_no_callinfo", func(t *testing.T) {
+			t.Parallel()
 			send := []int64{3, 5, 1}
 			expect := []int64{3, 8, 9}
 			var got []int64
@@ -380,9 +404,11 @@ func TestServer(t *testing.T) {
 	t.Parallel()
 	testPing := func(t *testing.T, client pingv1connect.PingServiceClient) { //nolint:thelper
 		t.Run("ping", func(t *testing.T) {
+			t.Parallel()
 			testUnaryGenerics(t, client)
 		})
 		t.Run("zero_ping", func(t *testing.T) {
+			t.Parallel()
 			request := connect.NewRequest(&pingv1.PingRequest{})
 			for _, el := range expectedHeaderValues {
 				request.Header().Add(clientHeader, el)
@@ -397,6 +423,7 @@ func TestServer(t *testing.T) {
 			assertResponseHeadersAndTrailers(t, wrapper)
 		})
 		t.Run("large_ping", func(t *testing.T) {
+			t.Parallel()
 			// Using a large payload splits the request and response over multiple
 			// packets, ensuring that we're managing HTTP readers and writers
 			// correctly.
@@ -417,6 +444,7 @@ func TestServer(t *testing.T) {
 			assertResponseHeadersAndTrailers(t, wrapper)
 		})
 		t.Run("ping_error", func(t *testing.T) {
+			t.Parallel()
 			_, err := client.Ping(
 				t.Context(),
 				connect.NewRequest(&pingv1.PingRequest{}),
@@ -424,6 +452,7 @@ func TestServer(t *testing.T) {
 			assert.Equal(t, connect.CodeOf(err), connect.CodeInvalidArgument)
 		})
 		t.Run("ping_timeout", func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
 			defer cancel()
 			request := connect.NewRequest(&pingv1.PingRequest{})
@@ -434,9 +463,11 @@ func TestServer(t *testing.T) {
 	}
 	testSum := func(t *testing.T, client pingv1connect.PingServiceClient) { //nolint:thelper
 		t.Run("sum", func(t *testing.T) {
+			t.Parallel()
 			testClientStreamGenerics(t, client)
 		})
 		t.Run("sum_error", func(t *testing.T) {
+			t.Parallel()
 			stream := client.Sum(t.Context())
 			if err := stream.Send(&pingv1.SumRequest{Number: 1}); err != nil {
 				assert.ErrorIs(t, err, io.EOF)
@@ -446,6 +477,7 @@ func TestServer(t *testing.T) {
 			assert.Equal(t, connect.CodeOf(err), connect.CodeInvalidArgument)
 		})
 		t.Run("sum_close_and_receive_without_send", func(t *testing.T) {
+			t.Parallel()
 			stream := client.Sum(t.Context())
 			for _, el := range expectedHeaderValues {
 				stream.RequestHeader().Add(clientHeader, el)
@@ -461,9 +493,11 @@ func TestServer(t *testing.T) {
 	}
 	testCountUp := func(t *testing.T, client pingv1connect.PingServiceClient) { //nolint:thelper
 		t.Run("count_up", func(t *testing.T) {
+			t.Parallel()
 			testServerStreamGenerics(t, client)
 		})
 		t.Run("count_up_error", func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithCancel(t.Context())
 			t.Cleanup(cancel)
 			stream, err := client.CountUp(
@@ -482,6 +516,7 @@ func TestServer(t *testing.T) {
 			assert.Nil(t, stream.Close())
 		})
 		t.Run("count_up_timeout", func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
 			t.Cleanup(cancel)
 			_, err := client.CountUp(ctx, connect.NewRequest(&pingv1.CountUpRequest{Number: 1}))
@@ -489,6 +524,7 @@ func TestServer(t *testing.T) {
 			assert.Equal(t, connect.CodeOf(err), connect.CodeDeadlineExceeded)
 		})
 		t.Run("count_up_cancel_after_first_response", func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithCancel(t.Context())
 			request := connect.NewRequest(&pingv1.CountUpRequest{Number: 5})
 			request.Header().Add(clientHeader, "foo")
@@ -505,9 +541,11 @@ func TestServer(t *testing.T) {
 	}
 	testCumSum := func(t *testing.T, client pingv1connect.PingServiceClient, expectSuccess bool) { //nolint:thelper
 		t.Run("cumsum", func(t *testing.T) {
+			t.Parallel()
 			testBidiStreamGenerics(t, client, expectSuccess)
 		})
 		t.Run("cumsum_error", func(t *testing.T) {
+			t.Parallel()
 			stream := client.CumSum(t.Context())
 			if !expectSuccess { // server doesn't support HTTP/2
 				failNoHTTP2(t, stream)
@@ -524,6 +562,7 @@ func TestServer(t *testing.T) {
 			assert.True(t, connect.IsWireError(err))
 		})
 		t.Run("cumsum_empty_stream", func(t *testing.T) {
+			t.Parallel()
 			stream := client.CumSum(t.Context())
 			for _, el := range expectedHeaderValues {
 				stream.RequestHeader().Add(clientHeader, el)
@@ -542,6 +581,7 @@ func TestServer(t *testing.T) {
 			assert.Nil(t, stream.CloseResponse()) // clean-up the stream
 		})
 		t.Run("cumsum_cancel_after_first_response", func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithCancel(t.Context())
 			stream := client.CumSum(ctx)
 			for _, el := range expectedHeaderValues {
@@ -569,6 +609,7 @@ func TestServer(t *testing.T) {
 			assert.Nil(t, stream.CloseResponse())
 		})
 		t.Run("cumsum_cancel_before_send", func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithCancel(t.Context())
 			stream := client.CumSum(ctx)
 			if !expectSuccess { // server doesn't support HTTP/2
@@ -605,6 +646,7 @@ func TestServer(t *testing.T) {
 			assert.Equal(tb, len(connectErr.Details()), len(expect.Details()))
 		}
 		t.Run("errors", func(t *testing.T) {
+			t.Parallel()
 			request := connect.NewRequest(&pingv1.FailRequest{
 				Code: int32(connect.CodeResourceExhausted),
 			})
@@ -628,6 +670,7 @@ func TestServer(t *testing.T) {
 			assertResponseHeadersAndTrailers(t, wrapper)
 		})
 		t.Run("middleware_errors_unary", func(t *testing.T) {
+			t.Parallel()
 			request := connect.NewRequest(&pingv1.PingRequest{})
 			for _, el := range expectedHeaderValues {
 				request.Header().Set(clientMiddlewareErrorHeader, el)
@@ -636,6 +679,7 @@ func TestServer(t *testing.T) {
 			assertIsHTTPMiddlewareError(t, err)
 		})
 		t.Run("middleware_errors_streaming", func(t *testing.T) {
+			t.Parallel()
 			request := connect.NewRequest(&pingv1.CountUpRequest{Number: 10})
 			for _, el := range expectedHeaderValues {
 				request.Header().Set(clientMiddlewareErrorHeader, el)
@@ -657,13 +701,17 @@ func TestServer(t *testing.T) {
 			testErrors(t, client)
 		}
 		t.Run("connect", func(t *testing.T) {
+			t.Parallel()
 			t.Run("proto", func(t *testing.T) {
+				t.Parallel()
 				run(t)
 			})
 			t.Run("proto_gzip", func(t *testing.T) {
+				t.Parallel()
 				run(t, connect.WithSendGzip())
 			})
 			t.Run("json_gzip", func(t *testing.T) {
+				t.Parallel()
 				run(
 					t,
 					connect.WithProtoJSON(),
@@ -671,6 +719,7 @@ func TestServer(t *testing.T) {
 				)
 			})
 			t.Run("json_get", func(t *testing.T) {
+				t.Parallel()
 				run(
 					t,
 					connect.WithProtoJSON(),
@@ -680,13 +729,17 @@ func TestServer(t *testing.T) {
 			})
 		})
 		t.Run("grpc", func(t *testing.T) {
+			t.Parallel()
 			t.Run("proto", func(t *testing.T) {
+				t.Parallel()
 				run(t, connect.WithGRPC())
 			})
 			t.Run("proto_gzip", func(t *testing.T) {
+				t.Parallel()
 				run(t, connect.WithGRPC(), connect.WithSendGzip())
 			})
 			t.Run("json_gzip", func(t *testing.T) {
+				t.Parallel()
 				run(
 					t,
 					connect.WithGRPC(),
@@ -696,13 +749,17 @@ func TestServer(t *testing.T) {
 			})
 		})
 		t.Run("grpcweb", func(t *testing.T) {
+			t.Parallel()
 			t.Run("proto", func(t *testing.T) {
+				t.Parallel()
 				run(t, connect.WithGRPCWeb())
 			})
 			t.Run("proto_gzip", func(t *testing.T) {
+				t.Parallel()
 				run(t, connect.WithGRPCWeb(), connect.WithSendGzip())
 			})
 			t.Run("json_gzip", func(t *testing.T) {
+				t.Parallel()
 				run(
 					t,
 					connect.WithGRPCWeb(),
@@ -788,7 +845,7 @@ func TestConcurrentStreams(t *testing.T) {
 			sum := client.CumSum(t.Context())
 			start.Wait()
 			for range 100 {
-				num := rand.Int64N(1000) //nolint:gosec // No need for cryptographically secure random numbers.
+				num := rand.Int64N(1000)
 				total += num
 				if err := sum.Send(&pingv1.CumSumRequest{Number: num}); err != nil {
 					t.Errorf("failed to send request: %v", err)
@@ -887,6 +944,7 @@ func TestErrorHeaderPropagation(t *testing.T) {
 	testServices := func(t *testing.T, client pingv1connect.PingServiceClient) {
 		t.Helper()
 		t.Run("unary", func(t *testing.T) {
+			t.Parallel()
 			request := connect.NewRequest(&pingv1.PingRequest{})
 			request.Header().Set("X-Test", t.Name())
 			_, err := client.Ping(t.Context(), request)
@@ -895,6 +953,7 @@ func TestErrorHeaderPropagation(t *testing.T) {
 			}
 			assertError(t, err, true /* allowCustomHeaders */)
 			t.Run("wire", func(t *testing.T) {
+				t.Parallel()
 				request := connect.NewRequest(&pingv1.PingRequest{})
 				request.Header().Set("X-Test", t.Name())
 				request.Header().Set("X-Test-Is-Wire", "true")
@@ -906,6 +965,7 @@ func TestErrorHeaderPropagation(t *testing.T) {
 			})
 		})
 		t.Run("bidi", func(t *testing.T) {
+			t.Parallel()
 			stream := client.CumSum(t.Context())
 			stream.RequestHeader().Set("X-Test", t.Name())
 			if err := stream.Send(nil); err != nil {
@@ -917,6 +977,7 @@ func TestErrorHeaderPropagation(t *testing.T) {
 			}
 			assertError(t, err, true /* allowCustomHeaders */)
 			t.Run("wire", func(t *testing.T) {
+				t.Parallel()
 				stream := client.CumSum(t.Context())
 				stream.RequestHeader().Set("X-Test", t.Name())
 				stream.RequestHeader().Set("X-Test-Is-Wire", "true")
@@ -2796,6 +2857,7 @@ func TestClientDisconnect(t *testing.T) {
 	}
 	testTransportClosure := func(t *testing.T, captureTransport httpRoundTripFunc) { //nolint:thelper
 		t.Run("handler_reads", func(t *testing.T) {
+			t.Parallel()
 			var (
 				handlerReceiveErr error
 				handlerContextErr error
@@ -2838,6 +2900,7 @@ func TestClientDisconnect(t *testing.T) {
 			assert.ErrorIs(t, handlerContextErr, context.Canceled)
 		})
 		t.Run("handler_writes", func(t *testing.T) {
+			t.Parallel()
 			var (
 				handlerReceiveErr error
 				handlerContextErr error

--- a/context.go
+++ b/context.go
@@ -63,10 +63,10 @@ type CallInfo interface {
 	internalOnly()
 }
 
-// Create a new client (i.e. outgoing) context for use from a client. When the
-// returned context is passed to RPCs, the returned call info can be used to set
-// request metadata before the RPC is invoked and to inspect response
-// metadata after the RPC completes.
+// NewClientContext creates a new client (i.e. outgoing) context for use from a
+// client. When the returned context is passed to RPCs, the returned call info
+// can be used to set request metadata before the RPC is invoked and to inspect
+// response metadata after the RPC completes.
 //
 // The returned context may be re-used across RPCs as long as they are
 // not concurrent. Results of all CallInfo methods other than
@@ -164,6 +164,7 @@ func (c *streamingHandlerCallInfo) internalOnly() {}
 // clientCallInfo is a CallInfo implementation used for clients.
 type clientCallInfo struct {
 	responseSource
+
 	spec          Spec
 	peer          Peer
 	method        string

--- a/error_writer_test.go
+++ b/error_writer_test.go
@@ -28,14 +28,16 @@ func TestErrorWriter(t *testing.T) {
 		t.Parallel()
 		writer := NewErrorWriter(WithRequireConnectProtocolHeader())
 		t.Run("Unary", func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+			t.Parallel()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://localhost", nil)
 			req.Header.Set("Content-Type", connectUnaryContentTypePrefix+codecNameJSON)
 			assert.False(t, writer.IsSupported(req))
 			req.Header.Set(connectHeaderProtocolVersion, connectProtocolVersion)
 			assert.True(t, writer.IsSupported(req))
 		})
 		t.Run("UnaryGET", func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+			t.Parallel()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://localhost", nil)
 			assert.False(t, writer.IsSupported(req))
 			query := req.URL.Query()
 			query.Set(connectUnaryConnectQueryParameter, connectUnaryConnectQueryValue)
@@ -43,7 +45,8 @@ func TestErrorWriter(t *testing.T) {
 			assert.True(t, writer.IsSupported(req))
 		})
 		t.Run("Stream", func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+			t.Parallel()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://localhost", nil)
 			req.Header.Set("Content-Type", connectStreamingContentTypePrefix+codecNameJSON)
 			assert.True(t, writer.IsSupported(req)) // ignores WithRequireConnectProtocolHeader
 			req.Header.Set(connectHeaderProtocolVersion, connectProtocolVersion)
@@ -54,28 +57,33 @@ func TestErrorWriter(t *testing.T) {
 		t.Parallel()
 		writer := NewErrorWriter() // All supported by default
 		t.Run("ConnectUnary", func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+			t.Parallel()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://localhost", nil)
 			req.Header.Set("Content-Type", connectUnaryContentTypePrefix+codecNameJSON)
 			assert.True(t, writer.IsSupported(req))
 		})
 		t.Run("ConnectUnaryGET", func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+			t.Parallel()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://localhost", nil)
 			assert.True(t, writer.IsSupported(req))
 		})
 		t.Run("ConnectStream", func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+			t.Parallel()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://localhost", nil)
 			req.Header.Set("Content-Type", connectStreamingContentTypePrefix+codecNameJSON)
 			assert.True(t, writer.IsSupported(req))
 		})
 		t.Run("GRPC", func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+			t.Parallel()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://localhost", nil)
 			req.Header.Set("Content-Type", grpcContentTypeDefault)
 			assert.True(t, writer.IsSupported(req))
 			req.Header.Set("Content-Type", grpcContentTypePrefix+"json")
 			assert.True(t, writer.IsSupported(req))
 		})
 		t.Run("GRPCWeb", func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+			t.Parallel()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://localhost", nil)
 			req.Header.Set("Content-Type", grpcWebContentTypeDefault)
 			assert.True(t, writer.IsSupported(req))
 			req.Header.Set("Content-Type", grpcWebContentTypePrefix+"json")
@@ -83,29 +91,33 @@ func TestErrorWriter(t *testing.T) {
 		})
 	})
 	t.Run("UnknownCodec", func(t *testing.T) {
+		t.Parallel()
 		// An Unknown codec should return supported as the protocol is known and
 		// the error codec is agnostic to the codec used. The server can respond
 		// with a protocol error for the unknown codec.
-		t.Parallel()
 		writer := NewErrorWriter()
 		unknownCodec := "invalid"
 		t.Run("ConnectUnary", func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+			t.Parallel()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://localhost", nil)
 			req.Header.Set("Content-Type", connectUnaryContentTypePrefix+unknownCodec)
 			assert.True(t, writer.IsSupported(req))
 		})
 		t.Run("ConnectStream", func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+			t.Parallel()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://localhost", nil)
 			req.Header.Set("Content-Type", connectStreamingContentTypePrefix+unknownCodec)
 			assert.True(t, writer.IsSupported(req))
 		})
 		t.Run("GRPC", func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+			t.Parallel()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://localhost", nil)
 			req.Header.Set("Content-Type", grpcContentTypePrefix+unknownCodec)
 			assert.True(t, writer.IsSupported(req))
 		})
 		t.Run("GRPCWeb", func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+			t.Parallel()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://localhost", nil)
 			req.Header.Set("Content-Type", grpcWebContentTypePrefix+unknownCodec)
 			assert.True(t, writer.IsSupported(req))
 		})

--- a/interceptor_ext_test.go
+++ b/interceptor_ext_test.go
@@ -46,6 +46,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 		)
 		server := memhttptest.NewServer(t, mux)
 		t.Run("first_interceptor", func(t *testing.T) {
+			t.Parallel()
 			// Because we're creating a new context in the first interceptor, only the first interceptor should fire
 			createClient := func(counter1 *atomic.Int32, counter2 *atomic.Int32) pingv1connectsimple.PingServiceClient {
 				opts := connect.WithInterceptors(
@@ -59,6 +60,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				)
 			}
 			t.Run("unary", func(t *testing.T) {
+				t.Parallel()
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
 				resp, err := client.Ping(t.Context(), &pingv1.PingRequest{Number: 10})
@@ -111,6 +113,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 			})
 		})
 		t.Run("subsequent_interceptor", func(t *testing.T) {
+			t.Parallel()
 			// Because we're creating a new context in the last interceptor, all interceptors should fire
 			createClient := func(counter1 *atomic.Int32, counter2 *atomic.Int32) pingv1connectsimple.PingServiceClient {
 				opts := connect.WithInterceptors(
@@ -124,6 +127,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 				)
 			}
 			t.Run("unary", func(t *testing.T) {
+				t.Parallel()
 				var clientCounter1, clientCounter2 atomic.Int32
 				client := createClient(&clientCounter1, &clientCounter2)
 
@@ -174,9 +178,9 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 			})
 		})
 		t.Run("sidequest_succeeds", func(t *testing.T) {
+			t.Parallel()
 			// These tests create a new context but it is used to issue a separate/new request and not reused in the
 			// interceptor chain. So, all interceptors should fire and no errors should be returned.
-			t.Parallel()
 			createClient := func(counter1 *atomic.Int32, counter2 *atomic.Int32) pingv1connectsimple.PingServiceClient {
 				opts := connect.WithInterceptors(
 					newSideQuestInterceptor(t, counter1, server),
@@ -251,6 +255,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 		)
 		server := memhttptest.NewServer(t, mux)
 		t.Run("first_interceptor", func(t *testing.T) {
+			t.Parallel()
 			// Because we're creating a new context in the first interceptor, only the first interceptor should fire
 			createClient := func(counter1 *atomic.Int32, counter2 *atomic.Int32) pingv1connect.PingServiceClient {
 				opts := connect.WithInterceptors(
@@ -335,6 +340,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 		})
 
 		t.Run("subsequent_interceptor", func(t *testing.T) {
+			t.Parallel()
 			// Because we're creating a new context in the last interceptor, all interceptors should fire
 			createClient := func(counter1 *atomic.Int32, counter2 *atomic.Int32) pingv1connect.PingServiceClient {
 				opts := connect.WithInterceptors(
@@ -418,6 +424,7 @@ func TestNewClientContextInInterceptor(t *testing.T) {
 			})
 		})
 		t.Run("sidequest_succeeds", func(t *testing.T) {
+			t.Parallel()
 			// These tests create a new context but it is used to issue a separate/new request and not reused in the
 			// interceptor chain. So, all interceptors should fire and no errors should be returned.
 			createClient := func(counter1 *atomic.Int32, counter2 *atomic.Int32) pingv1connect.PingServiceClient {

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -860,7 +860,7 @@ func (m *connectStreamingMarshaler) MarshalEndStream(err error, trailer http.Hea
 		return errorf(CodeInternal, "marshal end stream: %w", marshalErr)
 	}
 	raw := bytes.NewBuffer(data)
-	defer m.envelopeWriter.bufferPool.Put(raw)
+	defer m.bufferPool.Put(raw)
 	return m.Write(&envelope{
 		Data:  raw,
 		Flags: connectFlagEnvelopeEndStream,

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -577,8 +577,8 @@ type grpcMarshaler struct {
 }
 
 func (m *grpcMarshaler) MarshalWebTrailers(trailer http.Header) *Error {
-	raw := m.envelopeWriter.bufferPool.Get()
-	defer m.envelopeWriter.bufferPool.Put(raw)
+	raw := m.bufferPool.Get()
+	defer m.bufferPool.Put(raw)
 	for key, values := range trailer {
 		// Per the Go specification, keys inserted during iteration may be produced
 		// later in the iteration or may be skipped. For safety, avoid mutating the

--- a/protocol_grpc_test.go
+++ b/protocol_grpc_test.go
@@ -36,12 +36,12 @@ func TestGRPCHandlerSender(t *testing.T) {
 		responseWriter := httptest.NewRecorder()
 		protobufCodec := &protoBinaryCodec{}
 		bufferPool := newBufferPool()
-		request, err := http.NewRequest(
+		request := httptest.NewRequestWithContext(
+			t.Context(),
 			http.MethodPost,
 			"https://demo.example.com",
 			strings.NewReader(""),
 		)
-		assert.Nil(t, err)
 		return &grpcHandlerConn{
 			spec:       Spec{},
 			web:        web,

--- a/recover.go
+++ b/recover.go
@@ -36,7 +36,7 @@ func (i *recoverHandlerInterceptor) WrapUnary(next UnaryFunc) UnaryFunc {
 		defer func() {
 			if r := recover(); r != nil {
 				// net/http checks for ErrAbortHandler with ==, so we should too.
-				if r == http.ErrAbortHandler { //nolint:errorlint,goerr113
+				if r == http.ErrAbortHandler { //nolint:errorlint,err113
 					panic(r) //nolint:forbidigo
 				}
 				retErr = i.handle(ctx, req.Spec(), req.Header(), r)
@@ -52,7 +52,7 @@ func (i *recoverHandlerInterceptor) WrapStreamingHandler(next StreamingHandlerFu
 		defer func() {
 			if r := recover(); r != nil {
 				// net/http checks for ErrAbortHandler with ==, so we should too.
-				if r == http.ErrAbortHandler { //nolint:errorlint,goerr113
+				if r == http.ErrAbortHandler { //nolint:errorlint,err113
 					panic(r) //nolint:forbidigo
 				}
 				retErr = i.handle(ctx, conn.Spec(), conn.RequestHeader(), r)


### PR DESCRIPTION
This updates the golangci-lint to the latest v2 version.
  - Add golangci-lint v2  and migrate`.golangci.yml` to new config format: 45ab2dfc804fb9834438003028e6056f66cb91f6
  - Correct mechanical migration and add back removed comments: 3bb6c71ca1209173eae4f7d16c1c5da93bb991ee
  - Fix lint issues surfaced by new and updated linters: `paralleltest`, `usetesting`, `recvcheck`, `noctx`:  3ff876d8896298d360e396feaf57a49905d06350