### PR TITLE
Bump Go version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         go-version:
         - name: latest
-          version: 1.25.x
+          version: 1.26.x
         - name: previous
-          version: 1.24.x
+          version: 1.25.x
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -46,9 +46,9 @@ jobs:
       matrix:
         go-version:
         - name: latest
-          version: 1.25.x
+          version: 1.26.x
         - name: previous
-          version: 1.24.x
+          version: 1.25.x
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -71,6 +71,6 @@ jobs:
         uses: actions/setup-go@v6
         with:
           # only the latest
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: Run Slow Tests
         run: make slowtest

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         go-version:
           - name: latest
-            version: 1.25.x
+            version: 1.26.x
           - name: previous
-            version: 1.24.x
+            version: 1.25.x
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6

--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -721,9 +721,7 @@ func testClientDeadlineBruteForceLoop(
 
 	var wg sync.WaitGroup
 	for goroutine := range parallelism {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			// We try a range of timeouts since the timing issue is sensitive
 			// to execution environment (e.g. CPU, memory, and network speeds).
 			// So the lower timeout values may be more likely to trigger an issue
@@ -794,7 +792,7 @@ func testClientDeadlineBruteForceLoop(
 				}
 				t.Logf("goroutine %d: repeating duration loop", goroutine)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	t.Logf("Issued %d RPCs.", rpcCount.Load())

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -837,9 +837,7 @@ func TestConcurrentStreams(t *testing.T) {
 	var done, start sync.WaitGroup
 	start.Add(1)
 	for range runtime.GOMAXPROCS(0) * 8 {
-		done.Add(1)
-		go func() {
-			defer done.Done()
+		done.Go(func() {
 			client := pingv1connect.NewPingServiceClient(server.Client(), server.URL())
 			var total int64
 			sum := client.CumSum(t.Context())
@@ -867,7 +865,7 @@ func TestConcurrentStreams(t *testing.T) {
 			if err := sum.CloseResponse(); err != nil {
 				t.Errorf("failed to close response: %v", err)
 			}
-		}()
+		})
 	}
 	start.Done()
 	done.Wait()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module connectrpc.com/connect
 
-go 1.24.0
+go 1.25.0
 
 retract (
 	v1.10.0 // module cache poisoned, use v1.10.1
@@ -8,6 +8,6 @@ retract (
 )
 
 require (
-	github.com/google/go-cmp v0.5.9
+	github.com/google/go-cmp v0.7.0
 	google.golang.org/protobuf v1.36.9
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
 google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=

--- a/internal/conformance/go.mod
+++ b/internal/conformance/go.mod
@@ -1,6 +1,6 @@
 module connectrpc.com/connect/internal/conformance
 
-go 1.24.0
+go 1.25.0
 
 require connectrpc.com/conformance v1.0.5
 
@@ -35,7 +35,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/grpc v1.79.3 // indirect
-	google.golang.org/protobuf v1.36.10 // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	nhooyr.io/websocket v1.8.6 // indirect
 )

--- a/internal/conformance/go.sum
+++ b/internal/conformance/go.sum
@@ -553,8 +553,8 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
-google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
-google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
+google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/example/go.mod
+++ b/internal/example/go.mod
@@ -1,6 +1,6 @@
 module connectrpc.com/connect/internal/example
 
-go 1.24.0
+go 1.25.0
 
 require (
 	connectrpc.com/connect v1.19.0

--- a/internal/memhttp/memhttp.go
+++ b/internal/memhttp/memhttp.go
@@ -63,11 +63,9 @@ func NewServer(handler http.Handler, opts ...Option) *Server {
 		url:            "http://" + listener.Addr().String(),
 		cleanupTimeout: cfg.CleanupTimeout,
 	}
-	server.serverWG.Add(1)
-	go func() {
-		defer server.serverWG.Done()
+	server.serverWG.Go(func() {
 		server.serverErr = server.server.Serve(server.listener)
-	}()
+	})
 	return server
 }
 

--- a/internal/memhttp/memhttp_test.go
+++ b/internal/memhttp/memhttp_test.go
@@ -49,9 +49,7 @@ func TestServerTransport(t *testing.T) {
 			t.Parallel()
 			var wg sync.WaitGroup
 			for range concurrency {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					req, err := http.NewRequestWithContext(
 						t.Context(),
 						http.MethodGet,
@@ -66,7 +64,7 @@ func TestServerTransport(t *testing.T) {
 					assert.Nil(t, err)
 					assert.Nil(t, res.Body.Close())
 					assert.Equal(t, string(body), greeting)
-				}()
+				})
 			}
 			wg.Wait()
 		})


### PR DESCRIPTION
- bump go CI versions tests to 1.25 and 1.26. 
- bump go.mod version to 1.25. 
- update code to use modern features.
