### PR TITLE
Update Unary-Get query parameter order to match spec recommendation

### DIFF
--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -1056,21 +1056,33 @@ func (m *connectUnaryRequestMarshaler) marshalWithGet(message any) *Error {
 }
 
 func (m *connectUnaryRequestMarshaler) buildGetURL(data []byte, compressed bool) *url.URL {
-	url := *m.duplexCall.URL()
-	query := url.Query()
-	query.Set(connectUnaryConnectQueryParameter, connectUnaryConnectQueryValue)
-	query.Set(connectUnaryEncodingQueryParameter, m.codec.Name())
-	if m.stableCodec.IsBinary() || compressed {
-		query.Set(connectUnaryMessageQueryParameter, encodeBinaryQueryValue(data))
-		query.Set(connectUnaryBase64QueryParameter, "1")
-	} else {
-		query.Set(connectUnaryMessageQueryParameter, string(data))
+	var query strings.Builder
+	appendQueryParam(&query, false, connectUnaryConnectQueryParameter, connectUnaryConnectQueryValue)
+	binary := m.stableCodec.IsBinary() || compressed
+	if binary {
+		appendQueryParam(&query, true, connectUnaryBase64QueryParameter, "1")
 	}
 	if compressed {
-		query.Set(connectUnaryCompressionQueryParameter, m.compressionName)
+		appendQueryParam(&query, true, connectUnaryCompressionQueryParameter, url.QueryEscape(m.compressionName))
 	}
-	url.RawQuery = query.Encode()
-	return &url
+	appendQueryParam(&query, true, connectUnaryEncodingQueryParameter, url.QueryEscape(m.codec.Name()))
+	if binary {
+		appendQueryParam(&query, true, connectUnaryMessageQueryParameter, encodeBinaryQueryValue(data))
+	} else {
+		appendQueryParam(&query, true, connectUnaryMessageQueryParameter, url.QueryEscape(string(data)))
+	}
+	target := *m.duplexCall.URL()
+	target.RawQuery = query.String()
+	return &target
+}
+
+func appendQueryParam(query *strings.Builder, withSeparator bool, key, escapedValue string) {
+	if withSeparator {
+		query.WriteByte('&')
+	}
+	query.WriteString(key)
+	query.WriteByte('=')
+	query.WriteString(escapedValue)
 }
 
 func (m *connectUnaryRequestMarshaler) writeWithGet(url *url.URL) {

--- a/protocol_connect_test.go
+++ b/protocol_connect_test.go
@@ -360,3 +360,68 @@ func TestConnectValidateStreamResponseContentType(t *testing.T) {
 		})
 	}
 }
+
+func TestConnectUnaryGetURLQueryOrder(t *testing.T) {
+	t.Parallel()
+	const baseURL = "http://example.com/connect.ping.v1.PingService/Ping"
+	newMarshaler := func(t *testing.T, codec stableCodec, compressionName string) *connectUnaryRequestMarshaler {
+		t.Helper()
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, baseURL, http.NoBody)
+		assert.Nil(t, err)
+		return &connectUnaryRequestMarshaler{
+			connectUnaryMarshaler: connectUnaryMarshaler{
+				codec:           codec,
+				compressionName: compressionName,
+			},
+			stableCodec: codec,
+			duplexCall:  &duplexHTTPCall{request: req},
+		}
+	}
+	jsonCodec := &protoJSONCodec{name: "json"}
+	protoCodec := &protoBinaryCodec{}
+	testCases := []struct {
+		name            string
+		codec           stableCodec
+		data            []byte
+		compressed      bool
+		compressionName string
+		expectRawQuery  string
+	}{
+		{
+			name:           "binary uncompressed",
+			codec:          protoCodec,
+			data:           []byte{0x01, 0x02, 0x03},
+			expectRawQuery: "connect=v1&base64=1&encoding=proto&message=AQID",
+		},
+		{
+			name:            "binary compressed",
+			codec:           protoCodec,
+			data:            []byte{0x04, 0x05, 0x06},
+			compressed:      true,
+			compressionName: "gzip",
+			expectRawQuery:  "connect=v1&base64=1&compression=gzip&encoding=proto&message=BAUG",
+		},
+		{
+			name:           "text uncompressed",
+			codec:          jsonCodec,
+			data:           []byte(`{"value":"hi"}`),
+			expectRawQuery: "connect=v1&encoding=json&message=%7B%22value%22%3A%22hi%22%7D",
+		},
+		{
+			name:            "text compressed forces base64",
+			codec:           jsonCodec,
+			data:            []byte{0x07, 0x08, 0x09},
+			compressed:      true,
+			compressionName: "gzip",
+			expectRawQuery:  "connect=v1&base64=1&compression=gzip&encoding=json&message=BwgJ",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			marshaler := newMarshaler(t, testCase.codec, testCase.compressionName)
+			got := marshaler.buildGetURL(testCase.data, testCase.compressed)
+			assert.Equal(t, got.RawQuery, testCase.expectRawQuery)
+		})
+	}
+}


### PR DESCRIPTION
Recommended by the spec in https://github.com/connectrpc/connectrpc.com/pull/357.