### PR TITLE
Prepare for v1.20.0

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Version is the semantic version of the connect module.
-const Version = "1.20.0-dev"
+const Version = "1.20.0"
 
 // These constants are used in compile-time handshakes with connect's generated
 // code.


### PR DESCRIPTION
## What's Changed
### Other changes
* Bump minimum supported Go version to 1.25 by @jonbodner-buf in #922
* Update Unary-Get query parameter order to match spec recommendation by @oliversun9 in #926

## New Contributors
* @jonbodner-buf made their first contribution in #922

**Full Changelog**: https://github.com/connectrpc/connect-go/compare/v1.19.2...v1.20.0
