### PR TITLE
Add pkwarren as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,6 +7,7 @@ Maintainers
 * [Matt Robenolt](https://github.com/mattrobenolt), [PlanetScale](https://planetscale.com)
 * [Edward McFarlane](https://github.com/emcfarlane), [Buf](https://buf.build)
 * [Timo Stamm](https://github.com/timostamm), [Buf](https://buf.build)
+* [Philip Warren](https://github.com/pkwarren), [Buf](https://buf.build)
 
 ## Former
 * [Akshay Shah](https://github.com/akshayjshah)


### PR DESCRIPTION
@pkwarren has been working on connect-go for years; he triages and fixes issues, and is a core collaborator. I'm proposing he is made a maintainer.

Signed-off-by: bufdev <bufdev-github@buf.build>
