### PR TITLE
Fix issue with user-agent getting inappropriately injected into request headers

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -2444,35 +2444,88 @@ func TestConnectProtocolHeaderRequired(t *testing.T) {
 	}
 }
 
-func TestAllowCustomUserAgent(t *testing.T) {
+func TestUserAgent(t *testing.T) {
 	t.Parallel()
 
 	const customAgent = "custom"
-	mux := http.NewServeMux()
-	mux.Handle(pingv1connect.NewPingServiceHandler(&pluggablePingServer{
-		ping: func(_ context.Context, req *connect.Request[pingv1.PingRequest]) (*connect.Response[pingv1.PingResponse], error) {
-			agent := req.Header().Get("User-Agent")
-			assert.Equal(t, agent, customAgent)
-			return connect.NewResponse(&pingv1.PingResponse{Number: req.Msg.GetNumber()}), nil
-		},
-	}))
-	server := memhttptest.NewServer(t, mux)
-
-	// If the user has set a User-Agent, we shouldn't clobber it.
-	tests := []struct {
-		protocol string
-		opts     []connect.ClientOption
+	protocols := []struct {
+		name string
+		opts []connect.ClientOption
 	}{
 		{"connect", nil},
 		{"grpc", []connect.ClientOption{connect.WithGRPC()}},
 		{"grpcweb", []connect.ClientOption{connect.WithGRPCWeb()}},
 	}
-	for _, testCase := range tests {
-		client := pingv1connect.NewPingServiceClient(server.Client(), server.URL(), testCase.opts...)
-		req := connect.NewRequest(&pingv1.PingRequest{Number: 42})
-		req.Header().Set("User-Agent", customAgent)
-		_, err := client.Ping(t.Context(), req)
-		assert.Nil(t, err)
+	headers := []struct {
+		name string
+		// set mutates the outgoing request header. A nil func leaves the
+		// User-Agent unset, so the framework should supply its own default.
+		set func(http.Header)
+		// check verifies what the server received for the User-Agent header.
+		check func(t *testing.T, values []string, ok bool)
+	}{
+		{
+			// With no User-Agent provided, the framework injects its default.
+			name: "unset",
+			set:  nil,
+			check: func(t *testing.T, values []string, ok bool) {
+				t.Helper()
+				assert.True(t, ok)
+				assert.Equal(t, len(values), 1)
+				assert.NotZero(t, values[0])
+			},
+		},
+		{
+			// A user-provided User-Agent must not be clobbered.
+			name: "custom",
+			set:  func(h http.Header) { h.Set("User-Agent", customAgent) },
+			check: func(t *testing.T, values []string, _ bool) {
+				t.Helper()
+				assert.Equal(t, values, []string{customAgent})
+			},
+		},
+		{
+			// An explicit empty value suppresses the default; the server
+			// should see no User-Agent header at all.
+			name: "empty-string",
+			set:  func(h http.Header) { h["User-Agent"] = []string{""} },
+			check: func(t *testing.T, _ []string, ok bool) {
+				t.Helper()
+				assert.False(t, ok)
+			},
+		},
+		{
+			// An explicit nil slice also suppresses the default.
+			name: "nil-slice",
+			set:  func(h http.Header) { h["User-Agent"] = nil },
+			check: func(t *testing.T, _ []string, ok bool) {
+				t.Helper()
+				assert.False(t, ok)
+			},
+		},
+	}
+	for _, protocol := range protocols {
+		for _, header := range headers {
+			t.Run(protocol.name+"/"+header.name, func(t *testing.T) {
+				t.Parallel()
+				mux := http.NewServeMux()
+				mux.Handle(pingv1connect.NewPingServiceHandler(&pluggablePingServer{
+					ping: func(_ context.Context, req *connect.Request[pingv1.PingRequest]) (*connect.Response[pingv1.PingResponse], error) {
+						values, ok := req.Header()["User-Agent"]
+						header.check(t, values, ok)
+						return connect.NewResponse(&pingv1.PingResponse{Number: req.Msg.GetNumber()}), nil
+					},
+				}))
+				server := memhttptest.NewServer(t, mux)
+				client := pingv1connect.NewPingServiceClient(server.Client(), server.URL(), protocol.opts...)
+				req := connect.NewRequest(&pingv1.PingRequest{Number: 42})
+				if header.set != nil {
+					header.set(req.Header())
+				}
+				_, err := client.Ping(t.Context(), req)
+				assert.Nil(t, err)
+			})
+		}
 	}
 }
 

--- a/header.go
+++ b/header.go
@@ -113,6 +113,17 @@ func getHeaderCanonical(h http.Header, key string) string {
 	return v[0]
 }
 
+func hasHeaderCanonical(hdr http.Header, key string) bool {
+	// Return true if the key exists at all. So if a user explicitly
+	// sets a nil/empty slice of values or an empty value, we still
+	// consider that to be present. This is more precise than
+	// getHeaderCanonical(...) == "" which indicates the value is
+	// not present, even when the key is present but explicitly
+	// unset/empty.
+	_, ok := hdr[key]
+	return ok
+}
+
 // setHeaderCanonical is a shortcut for Header.Set() which
 // bypasses the CanonicalMIMEHeaderKey operation when we
 // know the key is already in canonical form.

--- a/header.go
+++ b/header.go
@@ -113,15 +113,17 @@ func getHeaderCanonical(h http.Header, key string) string {
 	return v[0]
 }
 
-func hasHeaderCanonical(hdr http.Header, key string) bool {
-	// Return true if the key exists at all. So if a user explicitly
-	// sets a nil/empty slice of values or an empty value, we still
-	// consider that to be present. This is more precise than
-	// getHeaderCanonical(...) == "" which indicates the value is
-	// not present, even when the key is present but explicitly
-	// unset/empty.
-	_, ok := hdr[key]
-	return ok
+// setUserAgentIfAbsent sets the User-Agent header to the given value, but
+// only if the caller has not already provided one. We check for the key's
+// presence rather than comparing getHeaderCanonical(...) to "" so that a
+// caller can suppress the default entirely by explicitly setting a nil/empty
+// slice of values or an empty value.
+func setUserAgentIfAbsent(header http.Header, value string) {
+	// headerUserAgent is already in canonical form, so we can index the map
+	// directly and bypass the checks in Header.Get and Header.Set.
+	if _, ok := header[headerUserAgent]; !ok {
+		header[headerUserAgent] = []string{value}
+	}
 }
 
 // setHeaderCanonical is a shortcut for Header.Set() which

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -317,11 +317,9 @@ func (c *connectClient) Peer() Peer {
 }
 
 func (c *connectClient) WriteRequestHeader(streamType StreamType, header http.Header) {
+	setUserAgentIfAbsent(header, defaultConnectUserAgent)
 	// We know these header keys are in canonical form, so we can bypass all the
 	// checks in Header.Set.
-	if !hasHeaderCanonical(header, headerUserAgent) {
-		header[headerUserAgent] = []string{defaultConnectUserAgent}
-	}
 	header[connectHeaderProtocolVersion] = []string{connectProtocolVersion}
 	header[headerContentType] = []string{
 		connectContentTypeForCodecName(streamType, c.Codec.Name()),

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -319,7 +319,7 @@ func (c *connectClient) Peer() Peer {
 func (c *connectClient) WriteRequestHeader(streamType StreamType, header http.Header) {
 	// We know these header keys are in canonical form, so we can bypass all the
 	// checks in Header.Set.
-	if getHeaderCanonical(header, headerUserAgent) == "" {
+	if !hasHeaderCanonical(header, headerUserAgent) {
 		header[headerUserAgent] = []string{defaultConnectUserAgent}
 	}
 	header[connectHeaderProtocolVersion] = []string{connectProtocolVersion}

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -235,11 +235,9 @@ func (g *grpcClient) Peer() Peer {
 }
 
 func (g *grpcClient) WriteRequestHeader(_ StreamType, header http.Header) {
+	setUserAgentIfAbsent(header, defaultGrpcUserAgent)
 	// We know these header keys are in canonical form, so we can bypass all the
 	// checks in Header.Set.
-	if !hasHeaderCanonical(header, headerUserAgent) {
-		header[headerUserAgent] = []string{defaultGrpcUserAgent}
-	}
 	if g.web && getHeaderCanonical(header, headerXUserAgent) == "" {
 		// The gRPC-Web pseudo-specification seems to require X-User-Agent rather
 		// than User-Agent for all clients, even if they're not browser-based. This

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -237,7 +237,7 @@ func (g *grpcClient) Peer() Peer {
 func (g *grpcClient) WriteRequestHeader(_ StreamType, header http.Header) {
 	// We know these header keys are in canonical form, so we can bypass all the
 	// checks in Header.Set.
-	if getHeaderCanonical(header, headerUserAgent) == "" {
+	if !hasHeaderCanonical(header, headerUserAgent) {
 		header[headerUserAgent] = []string{defaultGrpcUserAgent}
 	}
 	if g.web && getHeaderCanonical(header, headerXUserAgent) == "" {


### PR DESCRIPTION
Resolves #933. If the user explicitly sets a "user-agent" header to a nil/empty value, don't inject the library's user-agent. This mirrors the handling of "user-agent" headers in the underlying net/http. So you can always opt-out of the library inserting its user-agent by setting a "user-agent" header. And if you don't want any value to be passed at all, simply insert the "user-agent" key with a nil slice or an empty value.

This augments the tests to cover new scenarios ("user-agent" value is a nil slice and "user-agent" value is a single empty-string) and also adds a case to make sure that when the incoming request has no "user-agent" header, the library does inject its own user-agent string.