### PR TITLE
Fix data race and connection leak in duplexHTTPCall

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,11 +71,11 @@ linters:
       - linters:
           - containedctx
         path: duplex_http_call.go
-      # BlockUntilResponseReady returns the shared response, whose body is
+      # blockUntilResponseReady returns the shared response, whose body is
       # closed once by CloseRead rather than at each call site.
       - linters:
           - bodyclose
-        source: BlockUntilResponseReady
+        source: blockUntilResponseReady
       # We need to init a global in-mem HTTP server for testable examples.
       - linters:
           - gochecknoglobals

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,6 +71,11 @@ linters:
       - linters:
           - containedctx
         path: duplex_http_call.go
+      # BlockUntilResponseReady returns the shared response, whose body is
+      # closed once by CloseRead rather than at each call site.
+      - linters:
+          - bodyclose
+        source: BlockUntilResponseReady
       # We need to init a global in-mem HTTP server for testable examples.
       - linters:
           - gochecknoglobals

--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -264,7 +264,7 @@ func (d *duplexHTTPCall) ResponseStatusCode() (int, error) {
 
 // ResponseHeader returns the response HTTP headers.
 func (d *duplexHTTPCall) ResponseHeader() http.Header {
-	if response := d.responseAfterReady(); response != nil {
+	if response := d.responseAfterReady(); response != nil { //nolint:bodyclose // body is closed by CloseRead
 		return response.Header
 	}
 	return make(http.Header)
@@ -272,7 +272,7 @@ func (d *duplexHTTPCall) ResponseHeader() http.Header {
 
 // ResponseTrailer returns the response HTTP trailers.
 func (d *duplexHTTPCall) ResponseTrailer() http.Header {
-	if response := d.responseAfterReady(); response != nil {
+	if response := d.responseAfterReady(); response != nil { //nolint:bodyclose // body is closed by CloseRead
 		return response.Trailer
 	}
 	return make(http.Header)

--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -245,6 +245,7 @@ func (d *duplexHTTPCall) Read(data []byte) (int, error) {
 }
 
 func (d *duplexHTTPCall) CloseRead() error {
+	// Ignore the error: an error response still has a body that must be closed.
 	response, _ := d.BlockUntilResponseReady()
 	if response == nil {
 		return nil // No response, so nothing to close.
@@ -265,6 +266,7 @@ func (d *duplexHTTPCall) ResponseStatusCode() (int, error) {
 
 // ResponseHeader returns the response HTTP headers.
 func (d *duplexHTTPCall) ResponseHeader() http.Header {
+	// Ignore the error: an error response still carries headers to forward.
 	if response, _ := d.BlockUntilResponseReady(); response != nil {
 		return response.Header
 	}
@@ -273,6 +275,7 @@ func (d *duplexHTTPCall) ResponseHeader() http.Header {
 
 // ResponseTrailer returns the response HTTP trailers.
 func (d *duplexHTTPCall) ResponseTrailer() http.Header {
+	// Ignore the error: an error response still carries trailers to forward.
 	if response, _ := d.BlockUntilResponseReady(); response != nil {
 		return response.Trailer
 	}
@@ -286,22 +289,23 @@ func (d *duplexHTTPCall) SetValidateResponse(validate func(*http.Response) *Erro
 }
 
 // BlockUntilResponseReady blocks until the response is ready or the context is
-// cancelled. The response is nil only if the context was cancelled before it
-// arrived. Otherwise it is returned even alongside an error, so callers can
-// close its body and read its headers.
+// cancelled. It returns a nil response when none was received, either because
+// the request failed or the context was cancelled before the response arrived.
+//
+// The response and the error may both be non-nil. An error response (one with a
+// non-success status or that fails validation) still carries a body to close
+// and headers to forward, so it is returned alongside its error.
 func (d *duplexHTTPCall) BlockUntilResponseReady() (*http.Response, error) {
 	select {
 	case <-d.responseReady:
 		return d.response, d.responseErr
+	default:
+	}
+	select {
+	case <-d.responseReady:
+		return d.response, d.responseErr
 	case <-d.ctx.Done():
-		// The response may have arrived too, and the select above is random.
-		// Check again so we don't drop a ready response and leak its body.
-		select {
-		case <-d.responseReady:
-			return d.response, d.responseErr
-		default:
-			return nil, wrapIfContextError(d.ctx.Err())
-		}
+		return nil, wrapIfContextError(d.ctx.Err())
 	}
 }
 

--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -228,7 +228,7 @@ func (d *duplexHTTPCall) SetMethod(method string) {
 func (d *duplexHTTPCall) Read(data []byte) (int, error) {
 	// First, we wait until we've gotten the response headers and established the
 	// server-to-client side of the stream.
-	if _, err := d.BlockUntilResponseReady(); err != nil {
+	if _, err := d.blockUntilResponseReady(); err != nil {
 		// The stream is already closed or corrupted.
 		return 0, err
 	}
@@ -246,7 +246,7 @@ func (d *duplexHTTPCall) Read(data []byte) (int, error) {
 
 func (d *duplexHTTPCall) CloseRead() error {
 	// Ignore the error: an error response still has a body that must be closed.
-	response, _ := d.BlockUntilResponseReady()
+	response, _ := d.blockUntilResponseReady()
 	if response == nil {
 		return nil // No response, so nothing to close.
 	}
@@ -257,7 +257,7 @@ func (d *duplexHTTPCall) CloseRead() error {
 
 // ResponseStatusCode is the response's HTTP status code.
 func (d *duplexHTTPCall) ResponseStatusCode() (int, error) {
-	response, err := d.BlockUntilResponseReady()
+	response, err := d.blockUntilResponseReady()
 	if err != nil {
 		return 0, err
 	}
@@ -267,7 +267,7 @@ func (d *duplexHTTPCall) ResponseStatusCode() (int, error) {
 // ResponseHeader returns the response HTTP headers.
 func (d *duplexHTTPCall) ResponseHeader() http.Header {
 	// Ignore the error: an error response still carries headers to forward.
-	if response, _ := d.BlockUntilResponseReady(); response != nil {
+	if response, _ := d.blockUntilResponseReady(); response != nil {
 		return response.Header
 	}
 	return make(http.Header)
@@ -276,7 +276,7 @@ func (d *duplexHTTPCall) ResponseHeader() http.Header {
 // ResponseTrailer returns the response HTTP trailers.
 func (d *duplexHTTPCall) ResponseTrailer() http.Header {
 	// Ignore the error: an error response still carries trailers to forward.
-	if response, _ := d.BlockUntilResponseReady(); response != nil {
+	if response, _ := d.blockUntilResponseReady(); response != nil {
 		return response.Trailer
 	}
 	return make(http.Header)
@@ -288,14 +288,14 @@ func (d *duplexHTTPCall) SetValidateResponse(validate func(*http.Response) *Erro
 	d.validateResponse = validate
 }
 
-// BlockUntilResponseReady blocks until the response is ready or the context is
+// blockUntilResponseReady blocks until the response is ready or the context is
 // cancelled. It returns a nil response when none was received, either because
 // the request failed or the context was cancelled before the response arrived.
 //
 // The response and the error may both be non-nil. An error response (one with a
 // non-success status or that fails validation) still carries a body to close
 // and headers to forward, so it is returned alongside its error.
-func (d *duplexHTTPCall) BlockUntilResponseReady() (*http.Response, error) {
+func (d *duplexHTTPCall) blockUntilResponseReady() (*http.Response, error) {
 	select {
 	case <-d.responseReady:
 		return d.response, d.responseErr

--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -245,9 +245,8 @@ func (d *duplexHTTPCall) Read(data []byte) (int, error) {
 }
 
 func (d *duplexHTTPCall) CloseRead() error {
-	_ = d.BlockUntilResponseReady()
-	if d.response == nil {
-		return nil
+	if err := d.BlockUntilResponseReady(); err != nil {
+		return nil //nolint:nilerr // Response failed, close is successful.
 	}
 	err := d.response.Body.Close()
 	err = wrapIfContextDone(d.ctx, err)
@@ -264,20 +263,18 @@ func (d *duplexHTTPCall) ResponseStatusCode() (int, error) {
 
 // ResponseHeader returns the response HTTP headers.
 func (d *duplexHTTPCall) ResponseHeader() http.Header {
-	_ = d.BlockUntilResponseReady()
-	if d.response != nil {
-		return d.response.Header
+	if err := d.BlockUntilResponseReady(); err != nil {
+		return make(http.Header)
 	}
-	return make(http.Header)
+	return d.response.Header
 }
 
 // ResponseTrailer returns the response HTTP trailers.
 func (d *duplexHTTPCall) ResponseTrailer() http.Header {
-	_ = d.BlockUntilResponseReady()
-	if d.response != nil {
-		return d.response.Trailer
+	if err := d.BlockUntilResponseReady(); err != nil {
+		return make(http.Header)
 	}
-	return make(http.Header)
+	return d.response.Trailer
 }
 
 // SetValidateResponse sets the response validation function. The function runs
@@ -289,11 +286,18 @@ func (d *duplexHTTPCall) SetValidateResponse(validate func(*http.Response) *Erro
 // BlockUntilResponseReady returns when the response is ready or reports an
 // error from initializing the request or context cancellation.
 func (d *duplexHTTPCall) BlockUntilResponseReady() error {
+	// Prefer responseReady, then check together with context.
+	// Context is required to avoid hung clients (golang/go#48908, golang/go#43989).
 	select {
 	case <-d.responseReady:
 		return d.responseErr
-	case <-d.ctx.Done():
-		return wrapIfContextError(d.ctx.Err())
+	default:
+		select {
+		case <-d.responseReady:
+			return d.responseErr
+		case <-d.ctx.Done():
+			return wrapIfContextError(d.ctx.Err())
+		}
 	}
 }
 

--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -245,10 +245,11 @@ func (d *duplexHTTPCall) Read(data []byte) (int, error) {
 }
 
 func (d *duplexHTTPCall) CloseRead() error {
-	if err := d.BlockUntilResponseReady(); err != nil {
-		return nil //nolint:nilerr // Response failed, close is successful.
+	response := d.responseAfterReady()
+	if response == nil {
+		return nil // Response failed, close is successful.
 	}
-	err := d.response.Body.Close()
+	err := response.Body.Close()
 	err = wrapIfContextDone(d.ctx, err)
 	return wrapIfRSTError(d.ctx, err)
 }
@@ -263,18 +264,18 @@ func (d *duplexHTTPCall) ResponseStatusCode() (int, error) {
 
 // ResponseHeader returns the response HTTP headers.
 func (d *duplexHTTPCall) ResponseHeader() http.Header {
-	if err := d.BlockUntilResponseReady(); err != nil {
-		return make(http.Header)
+	if response := d.responseAfterReady(); response != nil {
+		return response.Header
 	}
-	return d.response.Header
+	return make(http.Header)
 }
 
 // ResponseTrailer returns the response HTTP trailers.
 func (d *duplexHTTPCall) ResponseTrailer() http.Header {
-	if err := d.BlockUntilResponseReady(); err != nil {
-		return make(http.Header)
+	if response := d.responseAfterReady(); response != nil {
+		return response.Trailer
 	}
-	return d.response.Trailer
+	return make(http.Header)
 }
 
 // SetValidateResponse sets the response validation function. The function runs
@@ -286,18 +287,26 @@ func (d *duplexHTTPCall) SetValidateResponse(validate func(*http.Response) *Erro
 // BlockUntilResponseReady returns when the response is ready or reports an
 // error from initializing the request or context cancellation.
 func (d *duplexHTTPCall) BlockUntilResponseReady() error {
-	// Prefer responseReady, then check together with context.
-	// Context is required to avoid hung clients (golang/go#48908, golang/go#43989).
 	select {
 	case <-d.responseReady:
 		return d.responseErr
+	case <-d.ctx.Done():
+		return wrapIfContextError(d.ctx.Err())
+	}
+}
+
+// responseAfterReady blocks until the response is ready, then returns it, or
+// nil if the context was cancelled before the response arrived. A nil result
+// means makeRequest may still be writing d.response, so it must not be read.
+// An error-status response is returned like any other, so callers can close
+// its body and read its headers.
+func (d *duplexHTTPCall) responseAfterReady() *http.Response {
+	_ = d.BlockUntilResponseReady()
+	select {
+	case <-d.responseReady:
+		return d.response
 	default:
-		select {
-		case <-d.responseReady:
-			return d.responseErr
-		case <-d.ctx.Done():
-			return wrapIfContextError(d.ctx.Err())
-		}
+		return nil
 	}
 }
 

--- a/duplex_http_call.go
+++ b/duplex_http_call.go
@@ -228,7 +228,7 @@ func (d *duplexHTTPCall) SetMethod(method string) {
 func (d *duplexHTTPCall) Read(data []byte) (int, error) {
 	// First, we wait until we've gotten the response headers and established the
 	// server-to-client side of the stream.
-	if err := d.BlockUntilResponseReady(); err != nil {
+	if _, err := d.BlockUntilResponseReady(); err != nil {
 		// The stream is already closed or corrupted.
 		return 0, err
 	}
@@ -245,9 +245,9 @@ func (d *duplexHTTPCall) Read(data []byte) (int, error) {
 }
 
 func (d *duplexHTTPCall) CloseRead() error {
-	response := d.responseAfterReady()
+	response, _ := d.BlockUntilResponseReady()
 	if response == nil {
-		return nil // Response failed, close is successful.
+		return nil // No response, so nothing to close.
 	}
 	err := response.Body.Close()
 	err = wrapIfContextDone(d.ctx, err)
@@ -256,15 +256,16 @@ func (d *duplexHTTPCall) CloseRead() error {
 
 // ResponseStatusCode is the response's HTTP status code.
 func (d *duplexHTTPCall) ResponseStatusCode() (int, error) {
-	if err := d.BlockUntilResponseReady(); err != nil {
+	response, err := d.BlockUntilResponseReady()
+	if err != nil {
 		return 0, err
 	}
-	return d.response.StatusCode, nil
+	return response.StatusCode, nil
 }
 
 // ResponseHeader returns the response HTTP headers.
 func (d *duplexHTTPCall) ResponseHeader() http.Header {
-	if response := d.responseAfterReady(); response != nil { //nolint:bodyclose // body is closed by CloseRead
+	if response, _ := d.BlockUntilResponseReady(); response != nil {
 		return response.Header
 	}
 	return make(http.Header)
@@ -272,7 +273,7 @@ func (d *duplexHTTPCall) ResponseHeader() http.Header {
 
 // ResponseTrailer returns the response HTTP trailers.
 func (d *duplexHTTPCall) ResponseTrailer() http.Header {
-	if response := d.responseAfterReady(); response != nil { //nolint:bodyclose // body is closed by CloseRead
+	if response, _ := d.BlockUntilResponseReady(); response != nil {
 		return response.Trailer
 	}
 	return make(http.Header)
@@ -284,29 +285,23 @@ func (d *duplexHTTPCall) SetValidateResponse(validate func(*http.Response) *Erro
 	d.validateResponse = validate
 }
 
-// BlockUntilResponseReady returns when the response is ready or reports an
-// error from initializing the request or context cancellation.
-func (d *duplexHTTPCall) BlockUntilResponseReady() error {
+// BlockUntilResponseReady blocks until the response is ready or the context is
+// cancelled. The response is nil only if the context was cancelled before it
+// arrived. Otherwise it is returned even alongside an error, so callers can
+// close its body and read its headers.
+func (d *duplexHTTPCall) BlockUntilResponseReady() (*http.Response, error) {
 	select {
 	case <-d.responseReady:
-		return d.responseErr
+		return d.response, d.responseErr
 	case <-d.ctx.Done():
-		return wrapIfContextError(d.ctx.Err())
-	}
-}
-
-// responseAfterReady blocks until the response is ready, then returns it, or
-// nil if the context was cancelled before the response arrived. A nil result
-// means makeRequest may still be writing d.response, so it must not be read.
-// An error-status response is returned like any other, so callers can close
-// its body and read its headers.
-func (d *duplexHTTPCall) responseAfterReady() *http.Response {
-	_ = d.BlockUntilResponseReady()
-	select {
-	case <-d.responseReady:
-		return d.response
-	default:
-		return nil
+		// The response may have arrived too, and the select above is random.
+		// Check again so we don't drop a ready response and leak its body.
+		select {
+		case <-d.responseReady:
+			return d.response, d.responseErr
+		default:
+			return nil, wrapIfContextError(d.ctx.Err())
+		}
 	}
 }
 

--- a/duplex_http_call_test.go
+++ b/duplex_http_call_test.go
@@ -232,7 +232,8 @@ func TestBlockUntilResponseReadyRespectsContext(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- call.BlockUntilResponseReady()
+		_, err := call.BlockUntilResponseReady()
+		done <- err
 	}()
 	select {
 	case err := <-done:

--- a/duplex_http_call_test.go
+++ b/duplex_http_call_test.go
@@ -232,7 +232,7 @@ func TestBlockUntilResponseReadyRespectsContext(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := call.BlockUntilResponseReady()
+		_, err := call.blockUntilResponseReady()
 		done <- err
 	}()
 	select {

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -474,7 +474,7 @@ func (cc *connectUnaryClientConn) CloseRequest() error {
 }
 
 func (cc *connectUnaryClientConn) Receive(msg any) error {
-	if _, err := cc.duplexCall.BlockUntilResponseReady(); err != nil {
+	if _, err := cc.duplexCall.blockUntilResponseReady(); err != nil {
 		return err
 	}
 	if err := cc.unmarshaler.Unmarshal(msg); err != nil {
@@ -484,12 +484,12 @@ func (cc *connectUnaryClientConn) Receive(msg any) error {
 }
 
 func (cc *connectUnaryClientConn) ResponseHeader() http.Header {
-	_, _ = cc.duplexCall.BlockUntilResponseReady()
+	_, _ = cc.duplexCall.blockUntilResponseReady()
 	return cc.responseHeader
 }
 
 func (cc *connectUnaryClientConn) ResponseTrailer() http.Header {
-	_, _ = cc.duplexCall.BlockUntilResponseReady()
+	_, _ = cc.duplexCall.blockUntilResponseReady()
 	return cc.responseTrailer
 }
 
@@ -601,7 +601,7 @@ func (cc *connectStreamingClientConn) CloseRequest() error {
 }
 
 func (cc *connectStreamingClientConn) Receive(msg any) error {
-	if _, err := cc.duplexCall.BlockUntilResponseReady(); err != nil {
+	if _, err := cc.duplexCall.blockUntilResponseReady(); err != nil {
 		return err
 	}
 	err := cc.unmarshaler.Unmarshal(msg)
@@ -634,12 +634,12 @@ func (cc *connectStreamingClientConn) Receive(msg any) error {
 }
 
 func (cc *connectStreamingClientConn) ResponseHeader() http.Header {
-	_, _ = cc.duplexCall.BlockUntilResponseReady()
+	_, _ = cc.duplexCall.blockUntilResponseReady()
 	return cc.responseHeader
 }
 
 func (cc *connectStreamingClientConn) ResponseTrailer() http.Header {
-	_, _ = cc.duplexCall.BlockUntilResponseReady()
+	_, _ = cc.duplexCall.blockUntilResponseReady()
 	return cc.responseTrailer
 }
 

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -474,7 +474,7 @@ func (cc *connectUnaryClientConn) CloseRequest() error {
 }
 
 func (cc *connectUnaryClientConn) Receive(msg any) error {
-	if err := cc.duplexCall.BlockUntilResponseReady(); err != nil {
+	if _, err := cc.duplexCall.BlockUntilResponseReady(); err != nil {
 		return err
 	}
 	if err := cc.unmarshaler.Unmarshal(msg); err != nil {
@@ -484,12 +484,12 @@ func (cc *connectUnaryClientConn) Receive(msg any) error {
 }
 
 func (cc *connectUnaryClientConn) ResponseHeader() http.Header {
-	_ = cc.duplexCall.BlockUntilResponseReady()
+	_, _ = cc.duplexCall.BlockUntilResponseReady()
 	return cc.responseHeader
 }
 
 func (cc *connectUnaryClientConn) ResponseTrailer() http.Header {
-	_ = cc.duplexCall.BlockUntilResponseReady()
+	_, _ = cc.duplexCall.BlockUntilResponseReady()
 	return cc.responseTrailer
 }
 
@@ -601,7 +601,7 @@ func (cc *connectStreamingClientConn) CloseRequest() error {
 }
 
 func (cc *connectStreamingClientConn) Receive(msg any) error {
-	if err := cc.duplexCall.BlockUntilResponseReady(); err != nil {
+	if _, err := cc.duplexCall.BlockUntilResponseReady(); err != nil {
 		return err
 	}
 	err := cc.unmarshaler.Unmarshal(msg)
@@ -634,12 +634,12 @@ func (cc *connectStreamingClientConn) Receive(msg any) error {
 }
 
 func (cc *connectStreamingClientConn) ResponseHeader() http.Header {
-	_ = cc.duplexCall.BlockUntilResponseReady()
+	_, _ = cc.duplexCall.BlockUntilResponseReady()
 	return cc.responseHeader
 }
 
 func (cc *connectStreamingClientConn) ResponseTrailer() http.Header {
-	_ = cc.duplexCall.BlockUntilResponseReady()
+	_, _ = cc.duplexCall.BlockUntilResponseReady()
 	return cc.responseTrailer
 }
 

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -364,7 +364,7 @@ func (cc *grpcClientConn) CloseRequest() error {
 }
 
 func (cc *grpcClientConn) Receive(msg any) error {
-	if err := cc.duplexCall.BlockUntilResponseReady(); err != nil {
+	if _, err := cc.duplexCall.BlockUntilResponseReady(); err != nil {
 		return err
 	}
 	err := cc.unmarshaler.Unmarshal(msg)
@@ -419,12 +419,12 @@ func (cc *grpcClientConn) Receive(msg any) error {
 }
 
 func (cc *grpcClientConn) ResponseHeader() http.Header {
-	_ = cc.duplexCall.BlockUntilResponseReady()
+	_, _ = cc.duplexCall.BlockUntilResponseReady()
 	return cc.responseHeader
 }
 
 func (cc *grpcClientConn) ResponseTrailer() http.Header {
-	_ = cc.duplexCall.BlockUntilResponseReady()
+	_, _ = cc.duplexCall.BlockUntilResponseReady()
 	return cc.responseTrailer
 }
 

--- a/protocol_grpc.go
+++ b/protocol_grpc.go
@@ -364,7 +364,7 @@ func (cc *grpcClientConn) CloseRequest() error {
 }
 
 func (cc *grpcClientConn) Receive(msg any) error {
-	if _, err := cc.duplexCall.BlockUntilResponseReady(); err != nil {
+	if _, err := cc.duplexCall.blockUntilResponseReady(); err != nil {
 		return err
 	}
 	err := cc.unmarshaler.Unmarshal(msg)
@@ -419,12 +419,12 @@ func (cc *grpcClientConn) Receive(msg any) error {
 }
 
 func (cc *grpcClientConn) ResponseHeader() http.Header {
-	_, _ = cc.duplexCall.BlockUntilResponseReady()
+	_, _ = cc.duplexCall.blockUntilResponseReady()
 	return cc.responseHeader
 }
 
 func (cc *grpcClientConn) ResponseTrailer() http.Header {
-	_, _ = cc.duplexCall.BlockUntilResponseReady()
+	_, _ = cc.duplexCall.blockUntilResponseReady()
 	return cc.responseTrailer
 }
 


### PR DESCRIPTION
The ctx.Done() branch added in #937 let read-side methods touch d.response without synchronizing with makeRequest (a data race), and a random select could shadow a ready response with a cancelled context, leaving CloseRead to skip closing the body (a leak). BlockUntilResponseReady now prefers responseReady, falling through to ctx.Done() only when no response is ready.

Race is captured on main: https://github.com/connectrpc/connect-go/actions/runs/27833079526/job/82374393481
This fix is for unreleased code, only exists on main.
