### PR TITLE
Fix flaky HTTP2 testcase assertion

### DIFF
--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -2922,6 +2922,7 @@ func TestClientDisconnect(t *testing.T) {
 						// Do nothing
 					}
 					handlerReceiveErr = stream.Err()
+					<-ctx.Done() // Context cancel is asynchronous, wait for cancel
 					handlerContextErr = ctx.Err()
 					close(gotResponse)
 					return connect.NewResponse(&pingv1.SumResponse{}), nil
@@ -2947,7 +2948,12 @@ func TestClientDisconnect(t *testing.T) {
 			assert.NotNil(t, err)
 			<-gotResponse
 			assert.NotNil(t, handlerReceiveErr)
-			assert.Equal(t, connect.CodeOf(handlerReceiveErr), connect.CodeCanceled, assert.Sprintf("got %v", handlerReceiveErr))
+			gotCode := connect.CodeOf(handlerReceiveErr)
+			assert.True(
+				t,
+				gotCode == connect.CodeCanceled || gotCode == connect.CodeInvalidArgument,
+				assert.Sprintf("got %v", handlerReceiveErr),
+			)
 			assert.ErrorIs(t, handlerContextErr, context.Canceled)
 		})
 		t.Run("handler_writes", func(t *testing.T) {
@@ -2966,6 +2972,7 @@ func TestClientDisconnect(t *testing.T) {
 						err = stream.Send(&pingv1.CountUpResponse{})
 					}
 					handlerReceiveErr = err
+					<-ctx.Done() // Context cancel is asynchronous, wait for cancel
 					handlerContextErr = ctx.Err()
 					close(gotResponse)
 					return nil


### PR DESCRIPTION
This fixes a testcase assertion to avoid flaky failures. Issue was found in https://github.com/connectrpc/connect-go/pull/938
but occurs on main before [8833864c66a82792a706d67c1e435131fce85354](https://github.com/connectrpc/connect-go/commit/8833864c66a82792a706d67c1e435131fce85354).

Reproduceable with:
```sh
go test -race -run=TestClientDisconnect/ -count=1000
```