### PR TITLE
fix: correct typos in comments

### DIFF
--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -629,7 +629,7 @@ func TestClientDeadlineHandling(t *testing.T) {
 	})
 
 	// This case creates significantly more load than the above one, but uses a normal
-	// client so pools and re-uses connections. It also uses all stream types to send
+	// client so pools and reuses connections. It also uses all stream types to send
 	// messages, to make sure that all stream implementations handle deadlines correctly.
 	// The I/O errors related to deadlines are historically harder to reproduce, so it
 	// throws a lot more effort into reproducing, particularly a longer duration for

--- a/client_stream.go
+++ b/client_stream.go
@@ -234,7 +234,7 @@ func (s *ServerStreamForClient[Res]) ResponseTrailer() http.Header {
 // Close the receive side of the stream.
 //
 // Close is non-blocking. To gracefully close the stream and allow for
-// connection resuse ensure all messages have been received before calling
+// connection reuse ensure all messages have been received before calling
 // Close. All messages are received when Receive returns false.
 func (s *ServerStreamForClient[Res]) Close() error {
 	if s.constructErr != nil {
@@ -329,7 +329,7 @@ func (b *BidiStreamForClient[Req, Res]) Receive() (*Res, error) {
 // CloseResponse closes the receive side of the stream.
 //
 // CloseResponse is non-blocking. To gracefully close the stream and allow for
-// connection resuse ensure all messages have been received before calling
+// connection reuse ensure all messages have been received before calling
 // CloseResponse. All messages are received when Receive returns an error
 // wrapping [io.EOF].
 func (b *BidiStreamForClient[Req, Res]) CloseResponse() error {
@@ -424,7 +424,7 @@ func (b *BidiStreamForClientSimple[Req, Res]) Receive() (*Res, error) {
 // CloseResponse closes the receive side of the stream.
 //
 // CloseResponse is non-blocking. To gracefully close the stream and allow for
-// connection resuse ensure all messages have been received before calling
+// connection reuse ensure all messages have been received before calling
 // CloseResponse. All messages are received when Receive returns an error
 // wrapping [io.EOF].
 func (b *BidiStreamForClientSimple[Req, Res]) CloseResponse() error {

--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -459,7 +459,7 @@ func clientSignature(g *protogen.GeneratedFile, method *protogen.Method, named b
 			"[" + g.QualifiedGoIdent(method.Output.GoIdent) + "]" +
 			", error)"
 	}
-	// unary; symmetric so we can re-use server templating
+	// unary; symmetric so we can reuse server templating
 	return method.GoName + serverSignatureParams(g, method, named, simple)
 }
 

--- a/context.go
+++ b/context.go
@@ -68,7 +68,7 @@ type CallInfo interface {
 // can be used to set request metadata before the RPC is invoked and to inspect
 // response metadata after the RPC completes.
 //
-// The returned context may be re-used across RPCs as long as they are
+// The returned context may be reused across RPCs as long as they are
 // not concurrent. Results of all CallInfo methods other than
 // RequestHeader() are undefined if the context is used with concurrent RPCs.
 func NewClientContext(ctx context.Context) (context.Context, CallInfo) {

--- a/envelope.go
+++ b/envelope.go
@@ -179,7 +179,7 @@ func (w *envelopeWriter) Write(env *envelope) *Error {
 }
 
 func (w *envelopeWriter) marshalAppend(message any, codec marshalAppender) *Error {
-	// Codec supports MarshalAppend; try to re-use a []byte from the pool.
+	// Codec supports MarshalAppend; try to reuse a []byte from the pool.
 	buffer := w.bufferPool.Get()
 	defer w.bufferPool.Put(buffer)
 	raw, err := codec.MarshalAppend(buffer.Bytes(), message)

--- a/handler.go
+++ b/handler.go
@@ -260,7 +260,7 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 	// We don't need to defer functions to close the request body or read to
 	// EOF: the stream we construct later on already does that, and we only
 	// return early when dealing with misbehaving clients. In those cases, it's
-	// okay if we can't re-use the connection.
+	// okay if we can't reuse the connection.
 	isBidi := (h.spec.StreamType & StreamTypeBidi) == StreamTypeBidi
 	if isBidi && request.ProtoMajor < 2 {
 		// Clients coded to expect full-duplex connections may hang if they've

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -1128,7 +1128,7 @@ func (u *connectUnaryUnmarshaler) UnmarshalFunc(message any, unmarshal func([]by
 		return errorf(CodeUnknown, "read message: %w", err)
 	}
 	if u.readMaxBytes > 0 && bytesRead > int64(u.readMaxBytes) {
-		// Attempt to read to end in order to allow connection re-use
+		// Attempt to read to end in order to allow connection reuse
 		discardedBytes, err := io.Copy(io.Discard, u.reader)
 		if err != nil {
 			return errorf(CodeResourceExhausted, "message is larger than configured max %d - unable to determine message size: %w", u.readMaxBytes, err)


### PR DESCRIPTION
## Summary

Fix spelling errors in code comments, found by running `codespell`.

- `resuse` -> `reuse` in `client_stream.go` (3 occurrences in `Close`/`CloseResponse` doc comments)
- `re-uses` -> `reuses` in `client_ext_test.go`
- `re-used` -> `reused` in `context.go`
- `re-use` -> `reuse` in `envelope.go`, `handler.go`, `protocol_connect.go`, and `cmd/protoc-gen-connect-go/main.go`

All changes are in comments only — no logic or behavior is affected.