### PR TITLE
Upgrade golangci-lint to v2.12.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,8 @@ linters:
     - funcorder        # consider enabling in the future
     - funlen           # rely on code review to limit function length
     - gocognit         # dubious "cognitive overhead" quantification
+    - goconst          # too many false positives
+    - gomodguard       # deprecated, replaced by gomodguard_v2
     - inamedparam      # convention is not followed
     - ireturn          # "accept interfaces, return structs" isn't ironclad
     - lll              # don't want hard limits for line length

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ export GOBIN := $(abspath $(BIN))
 COPYRIGHT_YEARS := 2021-2026
 LICENSE_IGNORE := --ignore .github/ --ignore ".*\.ya?ml"
 BUF_VERSION := 1.69.0
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.2
 
 .PHONY: help
 help: ## Describe useful make targets

--- a/compression.go
+++ b/compression.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -188,8 +189,7 @@ func newReadOnlyCompressionPools(
 	// but we want the last registered to be the most preferred.
 	names := make([]string, 0, len(reversedNames))
 	seen := make(map[string]struct{}, len(reversedNames))
-	for i := len(reversedNames) - 1; i >= 0; i-- {
-		name := reversedNames[i]
+	for _, name := range slices.Backward(reversedNames) {
 		if _, ok := seen[name]; ok {
 			continue
 		}

--- a/interceptor.go
+++ b/interceptor.go
@@ -17,6 +17,7 @@ package connect
 import (
 	"context"
 	"errors"
+	"slices"
 )
 
 var (
@@ -83,8 +84,8 @@ func newChain(interceptors []Interceptor) *chain {
 	// the slice act first. Rather than doing this dance repeatedly, reverse the
 	// interceptor order now.
 	var chain chain
-	for i := len(interceptors) - 1; i >= 0; i-- {
-		if interceptor := interceptors[i]; interceptor != nil {
+	for _, interceptor := range slices.Backward(interceptors) {
+		if interceptor != nil {
 			chain.interceptors = append(chain.interceptors, interceptor)
 		}
 	}

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -197,7 +197,7 @@ func isNil(got any) bool {
 	// itself non-nil, but the user's code passed a nil value.
 	val := reflect.ValueOf(got)
 	switch val.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
 		return val.IsNil()
 	default:
 		return false


### PR DESCRIPTION
Use slices.Backward for cleaner reverse iteration in compression.go and interceptor.go. 

Add explanatory comments for disabled linters (goconst, gomodguard) and bump golangci-lint to v2.12.2.

<!--
Before submitting your PR, please read through the contribution guide!

https://github.com/connectrpc/connect-go/blob/main/.github/CONTRIBUTING.md
-->
