### PR TITLE
refactor: Replace sort package with slices package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,6 @@ linters:
   default: all
   disable:
     - cyclop           # covered by gocyclo
-    - depguard         # unnecessary for small libraries
     - funcorder        # consider enabling in the future
     - funlen           # rely on code review to limit function length
     - gocognit         # dubious "cognitive overhead" quantification
@@ -26,6 +25,12 @@ linters:
     exhaustruct:
       include:
         - connectrpc\.com/connect\..*[pP]arams
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: sort
+              desc: use slices package instead
     forbidigo:
       forbid:
         - pattern: ^fmt\.Print

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -30,7 +30,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -4464,8 +4464,8 @@ func compareValues(hdr1 []string, hdr2 []string) bool {
 	sorted2 := make([]string, len(hdr2))
 	copy(sorted2, hdr2)
 
-	sort.Strings(sorted1)
-	sort.Strings(sorted2)
+	slices.Sort(sorted1)
+	slices.Sort(sorted2)
 
 	for idx, el := range sorted1 {
 		if el != sorted2[idx] {

--- a/protocol.go
+++ b/protocol.go
@@ -22,7 +22,7 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -263,7 +263,7 @@ func sortedAcceptPostValue(handlers []protocolHandler) string {
 	for ct := range contentTypes {
 		accept = append(accept, ct)
 	}
-	sort.Strings(accept)
+	slices.Sort(accept)
 	return strings.Join(accept, ", ")
 }
 
@@ -278,7 +278,7 @@ func sortedAllowMethodValue(handlers []protocolHandler) string {
 	for ct := range methods {
 		allow = append(allow, ct)
 	}
-	sort.Strings(allow)
+	slices.Sort(allow)
 	return strings.Join(allow, ", ")
 }
 


### PR DESCRIPTION
## Summary
- Replace all usages of the `sort` package with the modern `slices` package (Go 1.21+)
- Use `slices.Sort` instead of `sort.Strings` for cleaner and more concise code
- Enable `depguard` linter to prevent future use of the deprecated `sort` package

## Changes
- `protocol.go`: Replace `sort.Strings` with `slices.Sort` (2 occurrences)
- `connect_ext_test.go`: Replace `sort.Strings` with `slices.Sort` (2 occurrences)
- `.golangci.yml`: Enable `depguard` linter with rule to deny `sort` package imports

## Test plan
- [x] `make lint` passes with 0 issues
- [x] `make test` passes
- [x] `go test -race ./...` passes with no race conditions