### PR TITLE
Run CI on pull requests targeting the v2 branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,10 @@
 name: ci
 on:
   push:
-    branches: [main]
+    branches: [main, v2]
     tags: ['v*']
   pull_request:
-    branches: [main]
+    branches: [main, v2]
   schedule:
     - cron: '15 22 * * *'
   workflow_dispatch: {} # support manual runs

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,10 +1,10 @@
 name: windows
 on:
   push:
-    branches: [main]
+    branches: [main, v2]
     tags: ['v*']
   pull_request:
-    branches: [main]
+    branches: [main, v2]
   schedule:
     - cron: '15 22 * * *'
   workflow_dispatch: {} # support manual runs


### PR DESCRIPTION
Add v2 to the push and pull_request branch filters in the CI so development on the upcoming v2 release gets the same checks as main.