### PR TITLE
V2 implement eager stream creation

### DIFF
--- a/cmd/connect-go-v2-migrate/rewrite.go
+++ b/cmd/connect-go-v2-migrate/rewrite.go
@@ -58,6 +58,8 @@ const (
 	ruleInterceptorMigration = "interceptor_migration"
 	ruleStreamParamType      = "stream_param_type"
 	ruleStreamParamAmbiguous = "stream_param_ambiguous"
+	ruleStreamSendNil        = "stream_send_nil"
+	ruleRequestHeaderTiming  = "request_header_timing"
 	ruleEcosystemMigration   = "ecosystem_migration"
 	ruleBufgenReinstall      = "bufgen_reinstall_plugin"
 	ruleBufgenGoMod          = "bufgen_update_go_mod"

--- a/cmd/connect-go-v2-migrate/streams.go
+++ b/cmd/connect-go-v2-migrate/streams.go
@@ -160,7 +160,7 @@ func rewriteStreams(funcType *ast.FuncType, body *ast.BlockStmt, state *rewriteS
 	holders := map[string]bool{}
 	rewriteStreamBlocks(body, streamVars, funcType, state, report, holders)
 	dropMsgForHolders(body, holders, report)
-	threadStreamMethods(body, streamVars, report)
+	threadStreamMethods(body, streamVars, params, report)
 	rewriteStreamMetadata(body, streamVars, params, state, report, contextParamName(funcType))
 }
 
@@ -206,7 +206,7 @@ func rewriteStreamMetadata(body *ast.BlockStmt, streamVars map[string]bool, para
 // stream is opened and rewrites its metadata reads to the seeded info. A single
 // client stream with a usable, not-yet-seeded context qualifies; others warn.
 func rewriteClientStreamMetadata(body *ast.BlockStmt, streamVars map[string]bool, params map[string]streamParam, state *rewriteState, report *Report, ctxName string) {
-	const warnMsg = "client stream %s metadata moves to connect.NewClientContext(ctx) and info.RequestHeader()/ResponseHeader()/ResponseTrailer() in v2"
+	const warnMsg = "client stream %s metadata moves to connect.NewClientContext(ctx) and info.RequestHeader()/ResponseHeader()/ResponseTrailer() in v2. Set request headers before the stream is created"
 	withMeta := map[string]token.Pos{}
 	for name := range streamVars {
 		if _, isHandler := params[name]; isHandler {
@@ -238,6 +238,7 @@ func rewriteClientStreamMetadata(body *ast.BlockStmt, streamVars map[string]bool
 	seed := newClientContextSeed(state, ctxName, infoName)
 	body.List = append(body.List[:insertAt], append([]ast.Stmt{seed}, body.List[insertAt:]...)...)
 	report.bump("client_context_insert")
+	headerReads := requestHeaderReadPositions(body, holder)
 	walkFuncBody(body, func(n ast.Node) {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
@@ -247,11 +248,47 @@ func rewriteClientStreamMetadata(body *ast.BlockStmt, streamVars map[string]bool
 		if !ok || !isStreamMetadataMethod(sel.Sel.Name) {
 			return
 		}
+		root := rootIdent(sel)
+		if root == nil || root.Name != holder {
+			return
+		}
+		pos := call.Pos()
+		if sel.Sel.Name == "RequestHeader" && !headerReads[pos] {
+			report.warnAtf(pos, ruleRequestHeaderTiming, "v2 sends request headers when the stream is created. Set them before %s is created.", holder)
+		}
+		call.Fun = &ast.SelectorExpr{X: ast.NewIdent(infoName), Sel: ast.NewIdent(sel.Sel.Name)}
+		report.bump("client_stream_metadata_rewrite")
+	})
+}
+
+// requestHeaderReadPositions marks holder.RequestHeader() calls chained into a
+// read-only method. Reads stay correct after the stream is created, writes do
+// not.
+func requestHeaderReadPositions(body *ast.BlockStmt, holder string) map[token.Pos]bool {
+	reads := map[token.Pos]bool{}
+	walkFuncBody(body, func(n ast.Node) {
+		outer, isSel := n.(*ast.SelectorExpr)
+		if !isSel {
+			return
+		}
+		switch outer.Sel.Name {
+		case "Get", "Values", "Clone":
+		default:
+			return
+		}
+		inner, isCall := outer.X.(*ast.CallExpr)
+		if !isCall {
+			return
+		}
+		sel, isInnerSel := inner.Fun.(*ast.SelectorExpr)
+		if !isInnerSel || sel.Sel.Name != "RequestHeader" {
+			return
+		}
 		if root := rootIdent(sel); root != nil && root.Name == holder {
-			call.Fun = &ast.SelectorExpr{X: ast.NewIdent(infoName), Sel: ast.NewIdent(sel.Sel.Name)}
-			report.bump("client_stream_metadata_rewrite")
+			reads[inner.Pos()] = true
 		}
 	})
+	return reads
 }
 
 // streamParam is a server handler stream parameter.
@@ -1021,8 +1058,10 @@ func isStreamMsgCall(node ast.Node, streamName string) bool {
 
 // threadStreamMethods renames CloseRequest/CloseResponse to CloseSend/Close on
 // stream variables. (Send/Receive keep their v1 shape; the loop reshape handles
-// the bool-to-error Receive change.)
-func threadStreamMethods(body *ast.BlockStmt, streamVars map[string]bool, report *Report) {
+// the bool-to-error Receive change.) It warns on the v1 Send(nil) idiom, which
+// v2 replaces with stream creation on the client and SendHeaders on the
+// handler.
+func threadStreamMethods(body *ast.BlockStmt, streamVars map[string]bool, params map[string]streamParam, report *Report) {
 	walkFuncBody(body, func(n ast.Node) {
 		call, isCall := n.(*ast.CallExpr)
 		if !isCall {
@@ -1032,8 +1071,8 @@ func threadStreamMethods(body *ast.BlockStmt, streamVars map[string]bool, report
 		if !isSel {
 			return
 		}
-		id, isIdent := sel.X.(*ast.Ident)
-		if !isIdent || !streamVars[id.Name] {
+		recv, isIdent := sel.X.(*ast.Ident)
+		if !isIdent || !streamVars[recv.Name] {
 			return
 		}
 		switch sel.Sel.Name {
@@ -1043,6 +1082,19 @@ func threadStreamMethods(body *ast.BlockStmt, streamVars map[string]bool, report
 		case "CloseResponse":
 			sel.Sel = ast.NewIdent("Close")
 			report.bump("stream_close_rename")
+		case identSend:
+			if len(call.Args) != 1 {
+				return
+			}
+			arg, isArgIdent := call.Args[0].(*ast.Ident)
+			if !isArgIdent || arg.Name != "nil" {
+				return
+			}
+			if _, isHandler := params[recv.Name]; isHandler {
+				report.warnAtf(call.Pos(), ruleStreamSendNil, "%s.Send(nil) sent response headers without a message in v1. Use %s.SendHeaders() in v2.", recv.Name, recv.Name)
+				return
+			}
+			report.warnAtf(call.Pos(), ruleStreamSendNil, "%s.Send(nil) sent request headers without a message in v1. v2 sends them when the stream is created. Delete this call.", recv.Name)
 		}
 	})
 }

--- a/cmd/connect-go-v2-migrate/streams_test.go
+++ b/cmd/connect-go-v2-migrate/streams_test.go
@@ -36,6 +36,33 @@ func TestStreamWarnings(t *testing.T) {
 }`,
 			wantWarn: "connect.BidiStream",
 		},
+		{
+			name: "client_send_nil",
+			body: `func f(ctx context.Context, client pingClient) error {
+	stream := client.CumSum(ctx)
+	if err := stream.Send(nil); err != nil {
+		return err
+	}
+	return stream.CloseRequest()
+}`,
+			wantWarn: "stream.Send(nil)",
+		},
+		{
+			name: "handler_send_nil",
+			body: `func h(ctx context.Context, stream *connect.BidiStream[in, out]) error {
+	return stream.Send(nil)
+}`,
+			wantWarn: "Use stream.SendHeaders() in v2",
+		},
+		{
+			name: "request_header_after_create",
+			body: `func f(ctx context.Context, client pingClient) error {
+	stream := client.CumSum(ctx)
+	stream.RequestHeader().Set("k", "v")
+	return stream.CloseRequest()
+}`,
+			wantWarn: "Set them before stream is created",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -56,6 +83,36 @@ func TestStreamWarnings(t *testing.T) {
 				t.Errorf("expected a warning containing %q; got %v", test.wantWarn, report.Warnings)
 			}
 		})
+	}
+}
+
+// TestRequestHeaderReadNoTimingWarning checks that a read-only chain on a
+// client stream's RequestHeader does not trigger the timing warning. Reads
+// stay correct after the stream is created.
+func TestRequestHeaderReadNoTimingWarning(t *testing.T) {
+	t.Parallel()
+	src := `package p
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+)
+
+func f(ctx context.Context, client pingClient) error {
+	stream := client.CumSum(ctx)
+	_ = stream.RequestHeader().Get("k")
+	return stream.CloseRequest()
+}
+`
+	_, report, err := Rewrite("input.go", []byte(src), true)
+	if err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+	for _, warning := range report.Warnings {
+		if warning.Rule == ruleRequestHeaderTiming {
+			t.Errorf("unexpected timing warning: %v", warning.Msg)
+		}
 	}
 }
 

--- a/cmd/connect-go-v2-migrate/testdata/build/genv2/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/cmd/connect-go-v2-migrate/testdata/build/genv2/connect/ping/v1/pingv1connect/ping.connect.go
@@ -119,12 +119,6 @@ type PingServiceSumClientStream struct {
 	stream connect.ClientStream
 }
 
-// SendHeaders opens the stream and flushes the request headers without a message. The first Send or
-// Receive does this implicitly.
-func (s PingServiceSumClientStream) SendHeaders() error {
-	return s.stream.SendHeaders()
-}
-
 // Send sends a request message to the server.
 func (s PingServiceSumClientStream) Send(req *v1.SumRequest) error {
 	return s.stream.Send(req)
@@ -166,12 +160,6 @@ func (s PingServiceCountUpClientStream) Close() error {
 // PingServiceCumSumClientStream is the client stream for the PingService's CumSum RPC.
 type PingServiceCumSumClientStream struct {
 	stream connect.ClientStream
-}
-
-// SendHeaders opens the stream and flushes the request headers without a message. The first Send or
-// Receive does this implicitly.
-func (s PingServiceCumSumClientStream) SendHeaders() error {
-	return s.stream.SendHeaders()
 }
 
 // Send sends a request message to the server.

--- a/cmd/connect-go-v2-migrate/testdata/script/client_stream_header.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/client_stream_header.txtar
@@ -105,5 +105,8 @@ Proposed rewrites (rerun with -w to apply):
  
 
 
+The following issues require manual code changes:
+  ./service.go:23:2: v2 sends request headers when the stream is created. Set them before stream is created.
+
 Scanned 1 Go file and 0 Buf templates. 1 rewrite(s) ready (rerun with -w to apply).
 Full migration guide: https://github.com/connectrpc/connect-go/blob/main/docs/v2-migration.md

--- a/cmd/protoc-gen-connect-go/main.go
+++ b/cmd/protoc-gen-connect-go/main.go
@@ -402,11 +402,6 @@ func generatePerRPCClientStreams(g *protogen.GeneratedFile, service *protogen.Se
 		g.P("}")
 		g.P()
 		if card == connect.StreamTypeClient || card == connect.StreamTypeBidi {
-			wrapComments(g, "SendHeaders opens the stream and flushes the request headers without a message. The first Send or Receive does this implicitly.")
-			g.P("func (s ", typeName, ") SendHeaders() error {")
-			g.P("return s.stream.SendHeaders()")
-			g.P("}")
-			g.P()
 			wrapComments(g, "Send sends a request message to the server.")
 			g.P("func (s ", typeName, ") Send(req *", input, ") error {")
 			g.P("return s.stream.Send(req)")

--- a/connect.go
+++ b/connect.go
@@ -190,7 +190,8 @@ const (
 // can dispatch directly to a [Server], use a test double, or adapt another wire
 // protocol without regenerating clients.
 type Transport interface {
-	// NewClientStream opens a client stream for spec.
+	// NewClientStream opens a client stream for spec. Request headers are
+	// captured from the ctx's client [CallInfo].
 	NewClientStream(ctx context.Context, spec Spec) (ClientStream, error)
 }
 
@@ -404,11 +405,10 @@ type Spec struct {
 // resources and unblocks any pending operation.
 // [Client.CallUnary] drives this full sequence internally.
 //
-// The first Send or Receive flushes the request headers from
-// [CallInfo.RequestHeader] and opens the stream. Call
-// [ClientStream.SendHeaders] to flush them eagerly without sending a message.
-// After the headers are flushed, later mutations to the request headers may
-// not affect the request.
+// The stream is dispatched by the time the [Client] call returns, with the
+// request headers from [CallInfo.RequestHeader] committed. Set request
+// headers before invoking the call. Later mutations do not affect the
+// request.
 //
 // Send transmits request messages, and Receive reads response messages. The
 // msg passed to Send and Receive must match the message type described by the
@@ -431,12 +431,6 @@ type Spec struct {
 // alongside the stream into [ClientFunc], and the CallInfo is reached through
 // ctx via [CallInfoForClientContext].
 type ClientStream interface {
-	// SendHeaders flushes the request headers and opens the stream without
-	// sending a request message. The first Send or Receive does this
-	// implicitly; call SendHeaders only to flush eagerly, for example to let
-	// the server begin work, surface connection errors before the first
-	// message, or record timing. It is idempotent.
-	SendHeaders() error
 	// Send sends msg as the next request message.
 	Send(msg any) error
 	// CloseSend closes the request side of the stream. It is idempotent.
@@ -729,8 +723,8 @@ type CallInfo struct {
 	request, response, trailer Header
 }
 
-// RequestHeader returns the request headers. The client sets them before the
-// first Send, and the server reads them.
+// RequestHeader returns the request headers. The client sets them before
+// invoking the RPC, and the server reads them.
 func (c *CallInfo) RequestHeader() *Header { return &c.request }
 
 // ResponseHeader returns the response headers. The server sets them before

--- a/connecthttp/client_stream.go
+++ b/connecthttp/client_stream.go
@@ -62,11 +62,6 @@ func (s *connectUnaryClientStream) flushHeader() {
 	s.protoClient.WriteRequestHeader(s.streamType, header)
 }
 
-func (s *connectUnaryClientStream) SendHeaders() error {
-	s.flushHeader()
-	return nil
-}
-
 func (s *connectUnaryClientStream) Send(msg any) error {
 	if s.sendClosed {
 		return io.EOF
@@ -144,8 +139,8 @@ func (s *connectStreamingClientStream) flushHeader() {
 	s.protoClient.WriteRequestHeader(s.streamType, header)
 }
 
-// SendHeaders opens the stream without sending a message.
-func (s *connectStreamingClientStream) SendHeaders() error {
+// start flushes the request headers and dispatches the HTTP request.
+func (s *connectStreamingClientStream) start() error {
 	s.flushHeader()
 	return s.conn.Send(nil)
 }

--- a/connecthttp/connect_ext_test.go
+++ b/connecthttp/connect_ext_test.go
@@ -317,12 +317,12 @@ func TestServer(t *testing.T) {
 		t.Run("sum_close_and_receive_without_send", func(t *testing.T) {
 			t.Parallel()
 			ctx, callInfo := connect.NewClientContext(t.Context())
+			for _, el := range expectedHeaderValues {
+				callInfo.RequestHeader().Add(clientHeader, el)
+			}
 			stream, err := client.Sum(ctx)
 			if err != nil {
 				t.Fatal(err)
-			}
-			for _, el := range expectedHeaderValues {
-				callInfo.RequestHeader().Add(clientHeader, el)
 			}
 			got, err := stream.CloseAndReceive()
 			assert.Nil(t, err)
@@ -414,12 +414,12 @@ func TestServer(t *testing.T) {
 		t.Run("cumsum_empty_stream", func(t *testing.T) {
 			t.Parallel()
 			ctx, callInfo := connect.NewClientContext(t.Context())
+			for _, el := range expectedHeaderValues {
+				callInfo.RequestHeader().Add(clientHeader, el)
+			}
 			stream, err := client.CumSum(ctx)
 			if err != nil {
 				t.Fatal(err)
-			}
-			for _, el := range expectedHeaderValues {
-				callInfo.RequestHeader().Add(clientHeader, el)
 			}
 			if !expectSuccess { // server doesn't support HTTP/2
 				failNoHTTP2(t, stream)
@@ -440,12 +440,12 @@ func TestServer(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(t.Context())
 			ctx, callInfo := connect.NewClientContext(ctx)
+			for _, el := range expectedHeaderValues {
+				callInfo.RequestHeader().Add(clientHeader, el)
+			}
 			stream, err := client.CumSum(ctx)
 			if err != nil {
 				t.Fatal(err)
-			}
-			for _, el := range expectedHeaderValues {
-				callInfo.RequestHeader().Add(clientHeader, el)
 			}
 			if !expectSuccess { // server doesn't support HTTP/2
 				failNoHTTP2(t, stream)
@@ -474,6 +474,9 @@ func TestServer(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(t.Context())
 			ctx, callInfo := connect.NewClientContext(ctx)
+			for _, el := range expectedHeaderValues {
+				callInfo.RequestHeader().Add(clientHeader, el)
+			}
 			stream, err := client.CumSum(ctx)
 			if err != nil {
 				t.Fatal(err)
@@ -482,9 +485,6 @@ func TestServer(t *testing.T) {
 				failNoHTTP2(t, stream)
 				cancel()
 				return
-			}
-			for _, el := range expectedHeaderValues {
-				callInfo.RequestHeader().Add(clientHeader, el)
 			}
 			assert.Nil(t, stream.Send(&pingv1.CumSumRequest{Number: 8}))
 			cancel()
@@ -870,12 +870,9 @@ func TestErrorHeaderPropagation(t *testing.T) {
 		t.Run("bidi", func(t *testing.T) {
 			t.Parallel()
 			ctx, callInfo := connect.NewClientContext(t.Context())
+			callInfo.RequestHeader().Set("X-Test", t.Name())
 			stream, err := client.CumSum(ctx)
 			if err != nil {
-				t.Fatal(err)
-			}
-			callInfo.RequestHeader().Set("X-Test", t.Name())
-			if err := stream.SendHeaders(); err != nil {
 				t.Fatal(err)
 			}
 			_, err = stream.Receive()
@@ -886,13 +883,10 @@ func TestErrorHeaderPropagation(t *testing.T) {
 			t.Run("wire", func(t *testing.T) {
 				ctx, callInfo := connect.NewClientContext(t.Context())
 				t.Parallel()
-				stream, err := client.CumSum(ctx)
-				if err != nil {
-					t.Fatal(err)
-				}
 				callInfo.RequestHeader().Set("X-Test", t.Name())
 				callInfo.RequestHeader().Set("X-Test-Is-Wire", "true")
-				if err := stream.SendHeaders(); err != nil {
+				stream, err := client.CumSum(ctx)
+				if err != nil {
 					t.Fatal(err)
 				}
 				_, err = stream.Receive()
@@ -1307,9 +1301,6 @@ func TestHandlerErrorScrub(t *testing.T) {
 					t.Fatal(err)
 				}
 				defer stream.Close()
-				if err := stream.SendHeaders(); err != nil {
-					t.Fatal(err)
-				}
 				_, err = stream.Receive()
 				assertScrubbed(t, err, wantCodes[name])
 			})
@@ -1476,11 +1467,7 @@ func TestContextError(t *testing.T) {
 	)
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	stream, err := client.CumSum(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = stream.Send(&pingv1.CumSumRequest{})
+	_, err := client.CumSum(ctx)
 	var connectErr *connect.Error
 	assert.NotNil(t, err)
 	assert.True(t, errors.As(err, &connectErr))
@@ -2305,7 +2292,6 @@ func TestBidiStreamServerSendsFirstMessage(t *testing.T) {
 			assert.Nil(t, stream.CloseSend())
 			assert.Nil(t, stream.Close())
 		})
-		assert.Nil(t, stream.SendHeaders())
 		select {
 		case <-time.After(time.Second):
 			t.Error("timed out to get request headers")
@@ -2383,7 +2369,6 @@ func TestStreamForServer(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Nil(t, stream.SendHeaders())
 		assert.Nil(t, stream.CloseSend())
 	})
 	t.Run("server-stream", func(t *testing.T) {
@@ -3201,8 +3186,6 @@ func TestClientDisconnect(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			// Send header.
-			assert.Nil(t, stream.Send(nil))
 			<-gotRequest
 			// Client abruptly disconnects.
 			if !assert.NotNil(t, clientConn) {

--- a/connecthttp/connecthttp.go
+++ b/connecthttp/connecthttp.go
@@ -343,7 +343,17 @@ func (t *transport) NewClientStream(ctx context.Context, spec connect.Spec) (con
 	if spec.StreamType == connect.StreamTypeUnary {
 		return &connectUnaryClientStream{conn: conn, info: info, protoClient: protocolClient, streamType: spec.StreamType}, nil
 	}
-	return &connectStreamingClientStream{conn: conn, info: info, protoClient: protocolClient, streamType: spec.StreamType}, nil
+	stream := &connectStreamingClientStream{conn: conn, info: info, protoClient: protocolClient, streamType: spec.StreamType}
+	if spec.StreamType&connect.StreamTypeClient != 0 {
+		// Client-streaming and bidi RPCs dispatch eagerly. Unary and
+		// server-streaming RPCs dispatch on Send to size the request body.
+		if err := stream.start(); err != nil {
+			_ = conn.CloseRequest()
+			_ = conn.CloseResponse()
+			return nil, err
+		}
+	}
+	return stream, nil
 }
 
 // urlForProcedure returns a cached *url.URL for the given procedure path,

--- a/connectinprocess/connectinprocess.go
+++ b/connectinprocess/connectinprocess.go
@@ -89,7 +89,11 @@ func (t *transport) NewClientStream(ctx context.Context, spec connect.Spec) (con
 	if spec.StreamType == connect.StreamTypeUnary {
 		return newUnaryClientStream(ctx, t, spec), nil
 	}
-	return &clientStream{p: newStreamPair(ctx, t, spec)}, nil
+	pair := newStreamPair(ctx, t, spec)
+	if spec.StreamType&connect.StreamTypeClient != 0 {
+		pair.dispatch()
+	}
+	return &clientStream{p: pair}, nil
 }
 
 type options struct {

--- a/connectinprocess/stream.go
+++ b/connectinprocess/stream.go
@@ -28,8 +28,9 @@ import (
 //
 // Messages flow through unbuffered channels, providing natural backpressure:
 // each Send blocks until the peer's Receive consumes the message. The server
-// runs on its own goroutine, which is started lazily upon the first call to
-// SendHeaders, Send, or Receive.
+// runs on its own goroutine. The transport starts it when a client-streaming
+// or bidi stream is created. Server-streaming RPCs start it on the first
+// Send or Receive.
 //
 // Lifecycle channels:
 //   - closeSendCh: Closed by the client's CloseSend. The server's Receive
@@ -118,11 +119,6 @@ func (p *streamPair) run() {
 // clientStream is the client-side half of a streamPair.
 type clientStream struct {
 	p *streamPair
-}
-
-func (s *clientStream) SendHeaders() error {
-	s.p.dispatch()
-	return nil
 }
 
 func (s *clientStream) Send(msg any) error {

--- a/connectinprocess/unary.go
+++ b/connectinprocess/unary.go
@@ -66,8 +66,6 @@ func newUnaryClientStream(ctx context.Context, t *transport, spec connect.Spec) 
 	return stream
 }
 
-func (s *unaryClientStream) SendHeaders() error { return nil }
-
 func (s *unaryClientStream) Send(msg any) error {
 	if s.sendClosed {
 		return io.EOF

--- a/docs/v2-guide.md
+++ b/docs/v2-guide.md
@@ -266,8 +266,6 @@ type PingServiceSumClientStream struct {
 	stream connect.ClientStream
 }
 
-func (s PingServiceSumClientStream) SendHeaders() error { return s.stream.SendHeaders() }
-
 func (s PingServiceSumClientStream) Send(req *v1.SumRequest) error {
 	return s.stream.Send(req)
 }
@@ -414,7 +412,6 @@ Streaming RPCs operate on two interfaces. The client drives a [`ClientStream`](h
 
 ```go
 type ClientStream interface {
-	SendHeaders() error
 	Send(msg any) error
 	CloseSend() error
 	Receive(msg any) error
@@ -428,7 +425,7 @@ type ServerStream interface {
 }
 ```
 
-Stream operations take no context: the call context is bound when the transport opens the stream, so per-call values such as loggers are available without threading a context through every `Send` and `Receive`. Clean receive-side completion is reported by an error matching `io.EOF` under `errors.Is`, which separates a clean end-of-stream from a network `io.EOF` that v1 conflated ([#774](https://github.com/connectrpc/connect-go/issues/774), [#397](https://github.com/connectrpc/connect-go/issues/397)).
+Stream operations take no context: the call context is bound when the transport opens the stream, so per-call values such as loggers are available without threading a context through every `Send` and `Receive`. Client-streaming and bidi RPCs dispatch when the stream is created. Set request headers on the `CallInfo` before invoking the call. Clean receive-side completion is reported by an error matching `io.EOF` under `errors.Is`, which separates a clean end-of-stream from a network `io.EOF` that v1 conflated ([#774](https://github.com/connectrpc/connect-go/issues/774), [#397](https://github.com/connectrpc/connect-go/issues/397)).
 
 Ownership differs by side. A caller owns its `ClientStream`: reading to `io.EOF` releases the stream's resources, and canceling the call's context or calling `Close` abandons it early. `Close` is idempotent, so `defer stream.Close()` is always safe. A handler ends the RPC by returning, so `ServerStream` has no `Close`; the transport finalizes the response when the handler returns. Each stream allows one active send-side and one active receive-side operation at a time, and the two sides may run concurrently.
 

--- a/docs/v2-migration.md
+++ b/docs/v2-migration.md
@@ -472,9 +472,9 @@ The tool maps ecosystem interceptor constructors where it can:
 ### Streaming
 
 Streaming generated code defines a named stream type per RPC (for example,
-`PingServiceCumSumClientStream`) instead of the v1 generics. Stream `Send`, `Receive`,
-and `SendHeaders` keep their v1 shape and take no `context.Context`; the call's
-context is bound when the stream is opened.
+`PingServiceCumSumClientStream`) instead of the v1 generics. Stream `Send` and
+`Receive` keep their v1 shape. Client-streaming and bidi RPCs dispatch when
+the stream is created. Request headers are set on creation.
 
 Stream metadata moves off the stream and onto the `CallInfo`, since the
 generated stream types no longer carry headers. A handler stream's

--- a/internal/conformance/internal/gen/connectrpc/conformance/v1/conformancev1connect/service.connect.go
+++ b/internal/conformance/internal/gen/connectrpc/conformance/v1/conformancev1connect/service.connect.go
@@ -252,12 +252,6 @@ type ConformanceServiceClientStreamClientStream struct {
 	stream connect.ClientStream
 }
 
-// SendHeaders opens the stream and flushes the request headers without a message. The first Send or
-// Receive does this implicitly.
-func (s ConformanceServiceClientStreamClientStream) SendHeaders() error {
-	return s.stream.SendHeaders()
-}
-
 // Send sends a request message to the server.
 func (s ConformanceServiceClientStreamClientStream) Send(req *v1.ClientStreamRequest) error {
 	return s.stream.Send(req)
@@ -280,12 +274,6 @@ func (s ConformanceServiceClientStreamClientStream) CloseAndReceive() (*v1.Clien
 // BidiStream RPC.
 type ConformanceServiceBidiStreamClientStream struct {
 	stream connect.ClientStream
-}
-
-// SendHeaders opens the stream and flushes the request headers without a message. The first Send or
-// Receive does this implicitly.
-func (s ConformanceServiceBidiStreamClientStream) SendHeaders() error {
-	return s.stream.SendHeaders()
 }
 
 // Send sends a request message to the server.

--- a/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
@@ -119,12 +119,6 @@ type PingServiceSumClientStream struct {
 	stream connect.ClientStream
 }
 
-// SendHeaders opens the stream and flushes the request headers without a message. The first Send or
-// Receive does this implicitly.
-func (s PingServiceSumClientStream) SendHeaders() error {
-	return s.stream.SendHeaders()
-}
-
 // Send sends a request message to the server.
 func (s PingServiceSumClientStream) Send(req *v1.SumRequest) error {
 	return s.stream.Send(req)
@@ -166,12 +160,6 @@ func (s PingServiceCountUpClientStream) Close() error {
 // PingServiceCumSumClientStream is the client stream for the PingService's CumSum RPC.
 type PingServiceCumSumClientStream struct {
 	stream connect.ClientStream
-}
-
-// SendHeaders opens the stream and flushes the request headers without a message. The first Send or
-// Receive does this implicitly.
-func (s PingServiceCumSumClientStream) SendHeaders() error {
-	return s.stream.SendHeaders()
 }
 
 // Send sends a request message to the server.


### PR DESCRIPTION
> Until now v2 kept v1's deferred dispatch: a client or bidi stream sends nothing until the first Send. That kept migration one-to-one and kept all four RPC shapes consistent. This PR is raised for direct feedback from maintainers.

This PR proposes a behavior change. Client-streaming and bidi RPCs send the request when the stream is created, before the first Send.

###  Changes

v2 has no stream header method, so the natural port of v1 generics code moves `stream.RequestHeader()` writes to `info.RequestHeader()` in the same position, after the stream is created. v2 as implemented defers the `CallInfo` capture to the first `Send` so that this port works unchanged:

```go
// v1 generics
stream := client.CumSum(ctx)
stream.RequestHeader().Set("X-Tenant", "acme")
// the natural v2 port, works today, but wouldn't with this PR
ctx, info := connect.NewClientContext(ctx)
stream, err := client.CumSum(ctx)
info.RequestHeader().Set("X-Tenant", "acme")
```

This PR takes a migration cost in exchange for eager dispatch. Header writes after the call must move above it, and connect-go-v2-migrate warns on each one:

```go
// after this PR
ctx, info := connect.NewClientContext(ctx)
info.RequestHeader().Set("X-Tenant", "acme")
stream, err := client.CumSum(ctx)
```

This matches the v1 simple mode contract: headers are captured and the request is sent when the method is called. The server sees the RPC without waiting for a client message, and a canceled context fails at creation instead of on the first `Send`.

### Summary

Removes the `SendHeaders()` method from `ClientStream`. The headers are captured on stream creation. `ServerStream` keeps it to send response headers without a message.

Unary and server-streaming RPCs still send on `Send` inside the call.  Buffering the single request message preserves Content-Length, retries via GetBody, and the GET fallback. Callers cannot observe the difference.

The tool `connect-go-v2-migrate` warns on `Send(nil)` and on header writes after stream creation.