### PR TITLE
Fix off-by-one in WithHTTPGetMaxURLSize URL length check

### DIFF
--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -228,6 +228,53 @@ func TestGetNoContentHeaders(t *testing.T) {
 	assert.Equal(t, http.MethodGet, unaryReq.HTTPMethod())
 }
 
+type urlSizeRecordingTransport struct {
+	base   http.RoundTripper
+	urlLen int
+}
+
+func (t *urlSizeRecordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.urlLen = len(req.URL.String())
+	return t.base.RoundTrip(req)
+}
+
+func TestGetURLSizeBoundary(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.Handle(pingv1connect.NewPingServiceHandler(&pingServer{}))
+	server := memhttptest.NewServer(t, mux)
+	ctx := t.Context()
+	call := func(httpClient connect.HTTPClient, options ...connect.ClientOption) (*connect.Request[pingv1.PingRequest], error) {
+		client := pingv1connect.NewPingServiceClient(
+			httpClient,
+			server.URL(),
+			append([]connect.ClientOption{connect.WithHTTPGet()}, options...)...,
+		)
+		request := connect.NewRequest(&pingv1.PingRequest{Text: "boundary"})
+		_, err := client.Ping(ctx, request)
+		return request, err
+	}
+
+	transport := &urlSizeRecordingTransport{base: server.Client().Transport}
+	unlimited, err := call(&http.Client{Transport: transport})
+	assert.Nil(t, err)
+	assert.Equal(t, unlimited.HTTPMethod(), http.MethodGet)
+	urlSize := transport.urlLen
+
+	atLimit, err := call(server.Client(), connect.WithHTTPGetMaxURLSize(urlSize, false))
+	assert.Nil(t, err)
+	assert.Equal(t, atLimit.HTTPMethod(), http.MethodGet)
+
+	atLimitWithFallback, err := call(server.Client(), connect.WithHTTPGetMaxURLSize(urlSize, true))
+	assert.Nil(t, err)
+	assert.Equal(t, atLimitWithFallback.HTTPMethod(), http.MethodGet)
+
+	overLimit, err := call(server.Client(), connect.WithHTTPGetMaxURLSize(urlSize-1, true))
+	assert.Nil(t, err)
+	assert.Equal(t, overLimit.HTTPMethod(), http.MethodPost)
+}
+
 func TestConnectionDropped(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()

--- a/protocol_connect.go
+++ b/protocol_connect.go
@@ -1015,7 +1015,7 @@ func (m *connectUnaryRequestMarshaler) marshalWithGet(message any) *Error {
 	}
 	if !isTooBig {
 		url := m.buildGetURL(data, false /* compressed */)
-		if m.getURLMaxBytes <= 0 || len(url.String()) < m.getURLMaxBytes {
+		if m.getURLMaxBytes <= 0 || len(url.String()) <= m.getURLMaxBytes {
 			m.writeWithGet(url)
 			return nil
 		}
@@ -1042,7 +1042,7 @@ func (m *connectUnaryRequestMarshaler) marshalWithGet(message any) *Error {
 		return NewError(CodeResourceExhausted, fmt.Errorf("compressed message size %d exceeds sendMaxBytes %d", compressed.Len(), m.sendMaxBytes))
 	}
 	url := m.buildGetURL(compressed.Bytes(), true /* compressed */)
-	if m.getURLMaxBytes <= 0 || len(url.String()) < m.getURLMaxBytes {
+	if m.getURLMaxBytes <= 0 || len(url.String()) <= m.getURLMaxBytes {
 		m.writeWithGet(url)
 		return nil
 	}


### PR DESCRIPTION
The [`WithHTTPGetMaxURLSize` docs](https://github.com/connectrpc/connect-go/blob/2cfd7899157774f75f964d395c266e48775e93cc/option.go#L533-L550) describe an inclusive limit: it "sets the maximum allowable URL length", and the POST fallback applies when the URL "would be longer than the configured maximum value". The implementation uses a strict less-than, so a URL of exactly the configured size is downgraded to POST, or fails with the self-contradictory message "url size 4096 exceeds getURLMaxBytes 4096" when the fallback is disabled.

This changes both comparisons in `marshalWithGet` to less-than-or-equal and adds a regression test that asserts GET at the exact limit and POST one byte over. The test fails on main and passes with this change:

```sh
go test -race -run TestGetURLSizeBoundary .
```

Happy to file a tracking issue first if that's preferred.
