### PR TITLE
Fix connect.WithGRPC typo in the missing client option error

### DIFF
--- a/error.go
+++ b/error.go
@@ -376,7 +376,7 @@ func wrapIfLikelyWithGRPCNotUsedError(err error) error {
 	if errString := err.Error(); strings.HasPrefix(errString, `Post "`) &&
 		strings.Contains(errString, `http2: Transport: cannot retry err`) &&
 		strings.HasSuffix(errString, `after Request.Body was written; define Request.GetBody to avoid this error`) {
-		return fmt.Errorf("possible missing connect.WithGPRC() client option when talking to gRPC server, see %s: %w", commonErrorsURL, err)
+		return fmt.Errorf("possible missing connect.WithGRPC() client option when talking to gRPC server, see %s: %w", commonErrorsURL, err)
 	}
 	return err
 }


### PR DESCRIPTION
The hint you get when a Connect-protocol client talks to a gRPC-only server without `WithGRPC()` names the option wrong:

```
unavailable: possible missing connect.WithGPRC() client option when talking to gRPC server, see https://connectrpc.com/docs/go/common-errors: Post "http://...
```

`GPRC` is a transposition of `GRPC`, so the option name it tells you to add doesn't exist. `git grep WithGPRC` finds the single line, the doc comment right above it already spells it correctly, and the common-errors page the message links to quotes it as `connect.WithGRPC()`. v2 has it right too (`connecthttp/error.go`). Looks like it's been there since #229.

No test on this one - the only thing to assert would be the exact hint wording, and that'd just turn a future rewording into a CI failure. Happy to add one if you'd rather.
