### PR TITLE
Update Go version for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         go-version:
         - name: latest
-          version: 1.26.x
+          version: 1.27.x
         - name: previous
-          version: 1.25.x
+          version: 1.26.x
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
@@ -46,9 +46,9 @@ jobs:
       matrix:
         go-version:
         - name: latest
-          version: 1.26.x
+          version: 1.27.x
         - name: previous
-          version: 1.25.x
+          version: 1.26.x
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
@@ -71,6 +71,6 @@ jobs:
         uses: actions/setup-go@v7
         with:
           # only the latest
-          go-version: 1.26.x
+          go-version: 1.27.x
       - name: Run Slow Tests
         run: make slowtest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version: ${{ matrix.go-version.version }}
+          check-latest: true
       - name: Unit Test
         run: make shorttest
       - name: Lint
@@ -58,6 +59,7 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version: ${{ matrix.go-version.version }}
+          check-latest: true
       - name: Run Conformance Tests
         run: make runconformance
   slowtest:
@@ -72,5 +74,6 @@ jobs:
         with:
           # only the latest
           go-version: 1.27.x
+          check-latest: true
       - name: Run Slow Tests
         run: make slowtest

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         go-version:
           - name: latest
-            version: 1.26.x
+            version: 1.27.x
           - name: previous
-            version: 1.25.x
+            version: 1.26.x
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version: ${{ matrix.go-version.version }}
+          check-latest: true
       - name: Test
         shell: bash
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters:
   disable:
     - cyclop           # covered by gocyclo
     - depguard         # unnecessary for small libraries
+    - exhaustruct      # deprecated, replaced by exhaustruct_v5
     - funcorder        # consider enabling in the future
     - funlen           # rely on code review to limit function length
     - gocognit         # dubious "cognitive overhead" quantification
@@ -25,9 +26,10 @@ linters:
   settings:
     errcheck:
       check-type-assertions: true
-    exhaustruct:
-      include:
+    exhaustruct_v5:
+      enforce-patterns:
         - connectrpc\.com/connect\..*[pP]arams
+      explicit-mode: true
     forbidigo:
       forbid:
         - pattern: ^fmt\.Print

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ export GOBIN := $(abspath $(BIN))
 COPYRIGHT_YEARS := 2021-2026
 LICENSE_IGNORE := --ignore .github/ --ignore ".*\.ya?ml"
 BUF_VERSION := 1.69.0
-GOLANGCI_LINT_VERSION ?= v2.12.2
+GOLANGCI_LINT_VERSION ?= v2.13.1
 
 .PHONY: help
 help: ## Describe useful make targets


### PR DESCRIPTION
This updates the CI to use Go 1.27 for latest. Main was flaky due to a HTTP/2 issue: https://github.com/golang/go/issues/80927