### PR TITLE
Fix panic in stream Spec and Peer when client construction failed

### DIFF
--- a/client_ext_test.go
+++ b/client_ext_test.go
@@ -69,6 +69,8 @@ func TestNewClient_InitFailure(t *testing.T) {
 	t.Run("bidi", func(t *testing.T) {
 		t.Parallel()
 		bidiStream := client.CumSum(t.Context())
+		assert.Equal(t, bidiStream.Spec(), connect.Spec{})
+		assert.Equal(t, bidiStream.Peer(), connect.Peer{})
 		err := bidiStream.Send(&pingv1.CumSumRequest{})
 		validateExpectedError(t, err)
 	})
@@ -76,6 +78,8 @@ func TestNewClient_InitFailure(t *testing.T) {
 	t.Run("client_stream", func(t *testing.T) {
 		t.Parallel()
 		clientStream := client.Sum(t.Context())
+		assert.Equal(t, clientStream.Spec(), connect.Spec{})
+		assert.Equal(t, clientStream.Peer(), connect.Peer{})
 		err := clientStream.Send(&pingv1.SumRequest{})
 		validateExpectedError(t, err)
 	})

--- a/client_stream.go
+++ b/client_stream.go
@@ -43,11 +43,17 @@ type ClientStreamForClient[Req, Res any] struct {
 
 // Spec returns the specification for the RPC.
 func (c *ClientStreamForClient[_, _]) Spec() Spec {
+	if c.err != nil {
+		return Spec{}
+	}
 	return c.conn.Spec()
 }
 
 // Peer describes the server for the RPC.
 func (c *ClientStreamForClient[_, _]) Peer() Peer {
+	if c.err != nil {
+		return Peer{}
+	}
 	return c.conn.Peer()
 }
 
@@ -265,11 +271,17 @@ type BidiStreamForClient[Req, Res any] struct {
 
 // Spec returns the specification for the RPC.
 func (b *BidiStreamForClient[_, _]) Spec() Spec {
+	if b.err != nil {
+		return Spec{}
+	}
 	return b.conn.Spec()
 }
 
 // Peer describes the server for the RPC.
 func (b *BidiStreamForClient[_, _]) Peer() Peer {
+	if b.err != nil {
+		return Peer{}
+	}
 	return b.conn.Peer()
 }
 

--- a/client_stream_test.go
+++ b/client_stream_test.go
@@ -30,6 +30,8 @@ func TestClientStreamForClient_InitErrNoPanics(t *testing.T) {
 	t.Parallel()
 	initErr := errors.New("client init failure")
 	clientStream := &ClientStreamForClient[pingv1.PingRequest, pingv1.PingResponse]{err: initErr}
+	assert.Equal(t, clientStream.Spec(), Spec{})
+	assert.Equal(t, clientStream.Peer(), Peer{})
 	assert.ErrorIs(t, clientStream.Send(&pingv1.PingRequest{}), initErr)
 	verifyHeaders(t, clientStream.RequestHeader())
 	res, err := clientStream.CloseAndReceive()
@@ -46,6 +48,8 @@ func TestClientStreamForClientSimple_InitErrNoPanics(t *testing.T) {
 	clientStream := &ClientStreamForClientSimple[pingv1.PingRequest, pingv1.PingResponse]{
 		stream: &ClientStreamForClient[pingv1.PingRequest, pingv1.PingResponse]{err: initErr},
 	}
+	assert.Equal(t, clientStream.Spec(), Spec{})
+	assert.Equal(t, clientStream.Peer(), Peer{})
 	assert.ErrorIs(t, clientStream.Send(&pingv1.PingRequest{}), initErr)
 	res, err := clientStream.CloseAndReceive()
 	assert.Nil(t, res)
@@ -106,6 +110,8 @@ func TestBidiStreamForClient_InitErrNoPanics(t *testing.T) {
 	t.Parallel()
 	initErr := errors.New("client init failure")
 	bidiStream := &BidiStreamForClient[pingv1.CumSumRequest, pingv1.CumSumResponse]{err: initErr}
+	assert.Equal(t, bidiStream.Spec(), Spec{})
+	assert.Equal(t, bidiStream.Peer(), Peer{})
 	res, err := bidiStream.Receive()
 	assert.Nil(t, res)
 	assert.ErrorIs(t, err, initErr)
@@ -126,6 +132,8 @@ func TestBidiStreamForClientSimple_InitErrNoPanics(t *testing.T) {
 	bidiStream := &BidiStreamForClientSimple[pingv1.CumSumRequest, pingv1.CumSumResponse]{
 		stream: &BidiStreamForClient[pingv1.CumSumRequest, pingv1.CumSumResponse]{err: initErr},
 	}
+	assert.Equal(t, bidiStream.Spec(), Spec{})
+	assert.Equal(t, bidiStream.Peer(), Peer{})
 	res, err := bidiStream.Receive()
 	assert.Nil(t, res)
 	assert.ErrorIs(t, err, initErr)


### PR DESCRIPTION
`Spec()` and `Peer()` on a client stream panic with a nil pointer dereference when the client itself failed to build. `NewClient` holds that error back for the first call rather than returning it, so a URL with no scheme, or an option it doesnt like, still gets you a stream. `CallClientStream` and `CallBidiStream` return it on its own. No error beside it, so there's nothing to check first. The simple variants do return an error, but the stream they give you alongside panics just the same - their `stream == nil` guard isn't the state those calls produce.

Every other method on both types has checked that error since #265. `Spec` and `Peer` arrived in #364 three months later and missed it. `RequestHeader` on the same struct already answers this exact case with an empty `http.Header{}`, so empty `Spec{}` and `Peer{}` it is.

The assertions went in `TestNewClient_InitFailure` as well as the unit tests, since thats the one that builds a client through the public API - both of its subtests segfault on main without the guard. The other way round would be dropping an `errStreamingClientConn` into the four error paths in `client.go`, the way the interceptor chain does, but that turns `Conn()` on a failed client from nil into a live sentinel and the existing tests assert its nil.
