### PR TITLE
Set finite default for ReadMaxBytes

### DIFF
--- a/client.go
+++ b/client.go
@@ -334,6 +334,7 @@ func newClientConfig(rawURL string, options []ClientOption) (*clientConfig, *Err
 		Procedure:        protoPath,
 		CompressionPools: make(map[string]*compressionPool),
 		BufferPool:       newBufferPool(),
+		ReadMaxBytes:     defaultReadMaxBytes,
 	}
 	withProtoBinaryCodec().applyToClient(&config)
 	withGzip().applyToClient(&config)

--- a/connect_ext_test.go
+++ b/connect_ext_test.go
@@ -430,7 +430,7 @@ func TestServer(t *testing.T) {
 			if testing.Short() {
 				t.Skipf("skipping %s test in short mode", t.Name())
 			}
-			hellos := strings.Repeat("hello", 1024*1024) // ~5mb
+			hellos := strings.Repeat("hello", 512*1024) // ~2.5mb
 			request := connect.NewRequest(&pingv1.PingRequest{Text: hellos})
 			for _, el := range expectedHeaderValues {
 				request.Header().Add(clientHeader, el)
@@ -1686,7 +1686,7 @@ func TestClientWithReadMaxBytes(t *testing.T) {
 		} else {
 			compressionOption = connect.WithCompressMinBytes(math.MaxInt)
 		}
-		mux.Handle(pingv1connect.NewPingServiceHandler(pingServer{}, compressionOption))
+		mux.Handle(pingv1connect.NewPingServiceHandler(pingServer{}, compressionOption, connect.WithReadMaxBytes(0)))
 		server := memhttptest.NewServer(t, mux)
 		return server
 	}
@@ -1822,7 +1822,7 @@ func TestHandlerWithSendMaxBytes(t *testing.T) {
 	newHTTP2Server := func(t *testing.T, compressed bool, sendMaxBytes int) *memhttp.Server {
 		t.Helper()
 		mux := http.NewServeMux()
-		options := []connect.HandlerOption{connect.WithSendMaxBytes(sendMaxBytes)}
+		options := []connect.HandlerOption{connect.WithSendMaxBytes(sendMaxBytes), connect.WithReadMaxBytes(0)}
 		if compressed {
 			options = append(options, connect.WithCompressMinBytes(1))
 		} else {

--- a/handler.go
+++ b/handler.go
@@ -361,6 +361,7 @@ func newHandlerConfig(procedure string, streamType StreamType, options []Handler
 		CompressionPools: make(map[string]*compressionPool),
 		Codecs:           make(map[string]Codec),
 		BufferPool:       newBufferPool(),
+		ReadMaxBytes:     defaultReadMaxBytes,
 		StreamType:       streamType,
 	}
 	withProtoBinaryCodec().applyToHandler(&config)

--- a/option.go
+++ b/option.go
@@ -247,8 +247,8 @@ func WithCompressMinBytes(minBytes int) Option {
 // size of a message that the server can respond with. Limits apply to each Protobuf
 // message, not to the stream as a whole.
 //
-// Setting WithReadMaxBytes to zero allows any message size. Both clients and
-// handlers default to allowing any request size.
+// Both clients and handlers default to a limit of 4 MiB. Setting
+// WithReadMaxBytes to zero allows any message size.
 //
 // Handlers may also use [http.MaxBytesHandler] to limit the total size of the
 // HTTP request stream (rather than the per-message size). Connect handles

--- a/protocol.go
+++ b/protocol.go
@@ -44,6 +44,8 @@ const (
 	headerDate            = "Date"
 
 	discardLimit = 1024 * 1024 * 4 // 4MiB
+
+	defaultReadMaxBytes = 1024 * 1024 * 4 // 4MiB
 )
 
 var errNoTimeout = errors.New("no timeout")


### PR DESCRIPTION
Set a default `ReadMaxBytes` of 4 MiB for both clients and handlers. Both previously defaulted to no limit. 

The limit applies per message. Messages over the limit fail with `CodeResourceExhausted`.

This is a behavior change for anyone relying on unbounded reads. `WithReadMaxBytes(0)` restores the previous behavior, and existing `WithReadMaxBytes(n)` calls are unaffected. Handlers that want to bound the total size of a request stream rather than individual messages should still use `http.MaxBytesHandler`.