### PR TITLE
V2 set default finite message read limit

### DIFF
--- a/cmd/connect-go-v2-migrate/construction.go
+++ b/cmd/connect-go-v2-migrate/construction.go
@@ -33,6 +33,7 @@ func rewriteServerConstruction(file *ast.File, state *rewriteState, report *Repo
 	ictx := newEcosystemContext(file)
 	stubs := connectStubAliases(file)
 	interceptorVars := interceptorOptionVars(file, state.connectAlias)
+	readLimitVars := readLimitOptionVars(file, state.connectAlias)
 	var blocks []*ast.BlockStmt
 	walk(file, func(n ast.Node) {
 		if block, ok := n.(*ast.BlockStmt); ok {
@@ -63,7 +64,7 @@ func rewriteServerConstruction(file *ast.File, state *rewriteState, report *Repo
 				}
 				run = append(run, nextMatch)
 			}
-			repl := buildConstructionReplacement(block, run, state, report, ictx)
+			repl := buildConstructionReplacement(block, run, state, report, ictx, readLimitVars)
 			block.List = append(block.List[:index:index], append(repl, block.List[index+len(run):]...)...)
 			index += len(repl) - 1
 		}
@@ -82,6 +83,8 @@ type constructionMatch struct {
 	interceptors []ast.Expr
 	otherOpts    []ast.Expr
 	groupKey     string
+	optsSpread   bool
+	pos          token.Pos
 }
 
 // matchConstruction matches `<mux>.Handle(<pkg>connect.New<Svc>Handler(svc, opts...))`
@@ -144,13 +147,15 @@ func matchConstruction(stmt ast.Stmt, state *rewriteState, ictx ecosystemContext
 		interceptors: interceptors,
 		otherOpts:    otherOpts,
 		groupKey:     key.String(),
+		optsSpread:   ctorCall.Ellipsis.IsValid(),
+		pos:          ctorCall.Pos(),
 	}, true
 }
 
 // buildConstructionReplacement emits the v2 statements for a run of matches
 // sharing one server: a connect.NewServer assignment, one Register call per
 // match, and a single connecthttp.Mount.
-func buildConstructionReplacement(block *ast.BlockStmt, run []constructionMatch, state *rewriteState, report *Report, ictx ecosystemContext) []ast.Stmt {
+func buildConstructionReplacement(block *ast.BlockStmt, run []constructionMatch, state *rewriteState, report *Report, ictx ecosystemContext, readLimitVars map[string]bool) []ast.Stmt {
 	first := run[0]
 	mapped := make([]ast.Expr, 0, len(first.interceptors))
 	for _, interceptor := range first.interceptors {
@@ -171,12 +176,82 @@ func buildConstructionReplacement(block *ast.BlockStmt, run []constructionMatch,
 		}})
 		report.bump(match.counter)
 	}
-	mountArgs := append([]ast.Expr{first.mux, ast.NewIdent(serverName)}, first.otherOpts...)
+	mountOpts := first.otherOpts
+	if presence := findReadLimit(mountOpts, first.optsSpread, state, readLimitVars); presence != readLimitSet {
+		mountOpts = injectReadLimit(mountOpts, state)
+		reportReadLimit(report, presence, first.pos)
+		report.bump("read_limit_pinned")
+	}
+	mountArgs := append([]ast.Expr{first.mux, ast.NewIdent(serverName)}, mountOpts...)
 	stmts = append(stmts, &ast.ExprStmt{X: callExpr(state.connectHTTPAlias, "Mount", mountArgs...)})
 
 	state.usedV2 = true
 	state.usedConnectHTTP = true
 	return stmts
+}
+
+// readLimitPresence reports whether an option list already pins the read limit.
+type readLimitPresence int
+
+const (
+	readLimitAbsent readLimitPresence = iota
+	readLimitSet
+	readLimitHidden
+)
+
+// findReadLimit classifies opts, treating a trailing spread as hidden.
+func findReadLimit(opts []ast.Expr, spread bool, state *rewriteState, vars map[string]bool) readLimitPresence {
+	for _, opt := range opts {
+		if call, ok := opt.(*ast.CallExpr); ok && isConnectSelector(call.Fun, state.connectAlias, "WithReadMaxBytes") {
+			return readLimitSet
+		}
+		if id, ok := opt.(*ast.Ident); ok && vars[id.Name] {
+			return readLimitSet
+		}
+	}
+	if spread {
+		return readLimitHidden
+	}
+	return readLimitAbsent
+}
+
+// readLimitOptionVars returns local variables assigned a connect.WithReadMaxBytes value.
+func readLimitOptionVars(file *ast.File, connectAlias string) map[string]bool {
+	vars := map[string]bool{}
+	walk(file, func(n ast.Node) {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) != len(assign.Rhs) {
+			return
+		}
+		for i, rhs := range assign.Rhs {
+			call, isCall := rhs.(*ast.CallExpr)
+			if !isCall || !isConnectSelector(call.Fun, connectAlias, "WithReadMaxBytes") {
+				continue
+			}
+			if id, ok := assign.Lhs[i].(*ast.Ident); ok {
+				vars[id.Name] = true
+			}
+		}
+	})
+	return vars
+}
+
+// injectReadLimit prepends an unlimited read limit, preserving the v1 default.
+// It goes first so a later option, including one inside a spread, still wins.
+func injectReadLimit(opts []ast.Expr, state *rewriteState) []ast.Expr {
+	zero := &ast.BasicLit{Kind: token.INT, Value: "0"}
+	pinned := callExpr(state.connectHTTPAlias, "WithReadMaxBytes", zero)
+	return append([]ast.Expr{pinned}, opts...)
+}
+
+// reportReadLimit warns that the call was pinned and how to take the v2 default.
+func reportReadLimit(report *Report, presence readLimitPresence, pos token.Pos) {
+	const base = "v2 limits reads to 4 MiB per message where v1 allowed any size, so this call is pinned to WithReadMaxBytes(0) to keep v1 behaviour. Drop it to take the v2 default."
+	if presence == readLimitHidden {
+		report.warnAtf(pos, ruleReadLimitDefault, "%s The pin goes first, ahead of options this tool cannot read into, so a limit set there still wins.", base)
+		return
+	}
+	report.warnAtf(pos, ruleReadLimitDefault, "%s", base)
 }
 
 // splitHandlerOptions partitions constructor options into interceptors (inline
@@ -262,6 +337,7 @@ func rewriteClientConstruction(file *ast.File, state *rewriteState, report *Repo
 	ictx := newEcosystemContext(file)
 	stubs := connectStubAliases(file)
 	interceptorVars := interceptorOptionVars(file, state.connectAlias)
+	readLimitVars := readLimitOptionVars(file, state.connectAlias)
 	walk(file, func(n ast.Node) {
 		call, isCall := n.(*ast.CallExpr)
 		if !isCall || len(call.Args) < 2 {
@@ -283,8 +359,19 @@ func rewriteClientConstruction(file *ast.File, state *rewriteState, report *Repo
 		for _, interceptor := range interceptors {
 			mapped = append(mapped, mapInterceptor(interceptor, report, ictx, "Client"))
 		}
+		if presence := findReadLimit(otherOpts, call.Ellipsis.IsValid(), state, readLimitVars); presence != readLimitSet {
+			otherOpts = injectReadLimit(otherOpts, state)
+			reportReadLimit(report, presence, call.Pos())
+			report.bump("read_limit_pinned")
+		}
 		transportArgs := append([]ast.Expr{call.Args[0], call.Args[1]}, otherOpts...)
 		transport := callExpr(state.connectHTTPAlias, "NewTransport", transportArgs...)
+		// The spread belongs on the transport, which now owns the option list;
+		// left on the outer call it would spread the client instead.
+		if call.Ellipsis.IsValid() {
+			transport.Ellipsis = call.Ellipsis
+			call.Ellipsis = token.NoPos
+		}
 		newClient := callExpr(state.connectV2Alias, "NewClient", append([]ast.Expr{transport}, mapped...)...)
 		call.Args = []ast.Expr{newClient}
 		state.usedV2 = true

--- a/cmd/connect-go-v2-migrate/rewrite.go
+++ b/cmd/connect-go-v2-migrate/rewrite.go
@@ -61,6 +61,7 @@ const (
 	ruleBufgenReinstall         = "bufgen_reinstall_plugin"
 	ruleBufgenGoMod             = "bufgen_update_go_mod"
 	ruleBufgenRemoteUnpublished = "bufgen_remote_unpublished"
+	ruleReadLimitDefault        = "read_limit_default"
 )
 
 var (

--- a/cmd/connect-go-v2-migrate/testdata/script/client_construction.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/client_construction.txtar
@@ -23,7 +23,7 @@ func newClient() pingv1connect.PingServiceClient {
 }
 -- out.txt --
 Proposed rewrites (rerun with -w to apply):
-  ./client_construction.go: client_construction=1 import_add_connecthttp=1 import_add_connectv2=1
+  ./client_construction.go: client_construction=1 import_add_connecthttp=1 import_add_connectv2=1 read_limit_pinned=1
 --- ./client_construction.go
 +++ ./client_construction.go
 @@ -3,13 +3,14 @@
@@ -40,11 +40,14 @@ Proposed rewrites (rerun with -w to apply):
 -		http.DefaultClient,
 -		"http://localhost:8080/",
 +	return pingv1connect.NewPingServiceClient(connect.NewClient(connecthttp.NewTransport(http.DefaultClient,
-+		"http://localhost:8080/")),
++		"http://localhost:8080/", connecthttp.WithReadMaxBytes(0))),
  	)
  }
  
 
+
+The following issues require manual code changes:
+  ./client_construction.go:10:9: v2 limits reads to 4 MiB per message where v1 allowed any size, so this call is pinned to WithReadMaxBytes(0) to keep v1 behaviour. Drop it to take the v2 default.
 
 Scanned 1 Go file and 0 Buf templates. 1 rewrite(s) ready (rerun with -w to apply).
 Full migration guide: https://github.com/connectrpc/connect-go/blob/main/docs/v2-migration.md

--- a/cmd/connect-go-v2-migrate/testdata/script/client_construction_protocol.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/client_construction_protocol.txtar
@@ -24,7 +24,7 @@ func newClient() pingv1connect.PingServiceClient {
 }
 -- out.txt --
 Proposed rewrites (rerun with -w to apply):
-  ./client_construction_protocol.go: client_construction=1 import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 option_protocol=1
+  ./client_construction_protocol.go: client_construction=1 import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 option_protocol=1 read_limit_pinned=1
 --- ./client_construction_protocol.go
 +++ ./client_construction_protocol.go
 @@ -3,7 +3,8 @@
@@ -42,10 +42,13 @@ Proposed rewrites (rerun with -w to apply):
  // connecthttp.WithGRPC() inside connecthttp.NewTransport.
  func newClient() pingv1connect.PingServiceClient {
 -	return pingv1connect.NewPingServiceClient(http.DefaultClient, "http://localhost:8080/", connect.WithGRPC())
-+	return pingv1connect.NewPingServiceClient(connect.NewClient(connecthttp.NewTransport(http.DefaultClient, "http://localhost:8080/", connecthttp.WithGRPC())))
++	return pingv1connect.NewPingServiceClient(connect.NewClient(connecthttp.NewTransport(http.DefaultClient, "http://localhost:8080/", connecthttp.WithReadMaxBytes(0), connecthttp.WithGRPC())))
  }
  
 
+
+The following issues require manual code changes:
+  ./client_construction_protocol.go:14:9: v2 limits reads to 4 MiB per message where v1 allowed any size, so this call is pinned to WithReadMaxBytes(0) to keep v1 behaviour. Drop it to take the v2 default.
 
 Scanned 1 Go file and 0 Buf templates. 1 rewrite(s) ready (rerun with -w to apply).
 Full migration guide: https://github.com/connectrpc/connect-go/blob/main/docs/v2-migration.md

--- a/cmd/connect-go-v2-migrate/testdata/script/client_construction_readlimit_var.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/client_construction_readlimit_var.txtar
@@ -1,0 +1,49 @@
+# A read limit held in a local variable still counts as set, so the migrator
+# leaves the call alone rather than pinning it to unlimited.
+stubs v2
+exec migrate
+cmp stdout out.txt
+! stdout 'read_limit_pinned'
+! stdout 'WithReadMaxBytes\(0\)'
+exec migrate -w
+exec go build ./...
+-- readlimit_var.go --
+package app
+
+import (
+	"net/http"
+
+	"connectrpc.com/connect"
+	"example.com/app/gen/connect/ping/v1/pingv1connect"
+)
+
+func newClient() pingv1connect.PingServiceClient {
+	limit := connect.WithReadMaxBytes(1 << 20)
+	return pingv1connect.NewPingServiceClient(http.DefaultClient, "http://localhost:8080/", limit)
+}
+-- out.txt --
+Proposed rewrites (rerun with -w to apply):
+  ./readlimit_var.go: client_construction=1 import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 option_to_connecthttp=1
+--- ./readlimit_var.go
++++ ./readlimit_var.go
+@@ -3,12 +3,13 @@
+ import (
+ 	"net/http"
+ 
+-	"connectrpc.com/connect"
++	"connectrpc.com/connect/v2"
++	"connectrpc.com/connect/v2/connecthttp"
+ 	"example.com/app/gen/connect/ping/v1/pingv1connect"
+ )
+ 
+ func newClient() pingv1connect.PingServiceClient {
+-	limit := connect.WithReadMaxBytes(1 << 20)
+-	return pingv1connect.NewPingServiceClient(http.DefaultClient, "http://localhost:8080/", limit)
++	limit := connecthttp.WithReadMaxBytes(1 << 20)
++	return pingv1connect.NewPingServiceClient(connect.NewClient(connecthttp.NewTransport(http.DefaultClient, "http://localhost:8080/", limit)))
+ }
+ 
+
+
+Scanned 1 Go file and 0 Buf templates. 1 rewrite(s) ready (rerun with -w to apply).
+Full migration guide: https://github.com/connectrpc/connect-go/blob/main/docs/v2-migration.md

--- a/cmd/connect-go-v2-migrate/testdata/script/client_construction_spread.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/client_construction_spread.txtar
@@ -1,0 +1,51 @@
+# A v1 client built from a spread option slice. The spread must move onto the
+# transport, which now owns the option list; left on the outer call it would
+# spread the client itself and fail to compile. The []connect.ClientOption
+# parameter type still needs a manual update, so this is golden-only.
+stubs v2
+exec migrate
+cmp stdout out.txt
+# The pin goes before the spread, so a limit inside opts is applied later and wins.
+stdout 'NewTransport\(http.DefaultClient, "http://localhost:8080/", connecthttp.WithReadMaxBytes\(0\), opts...\)'
+stdout 'connect.ClientOption -> connecthttp.Option'
+-- spread.go --
+package app
+
+import (
+	"net/http"
+
+	"connectrpc.com/connect"
+	"example.com/app/gen/connect/ping/v1/pingv1connect"
+)
+
+func newClient(opts []connect.ClientOption) pingv1connect.PingServiceClient {
+	return pingv1connect.NewPingServiceClient(http.DefaultClient, "http://localhost:8080/", opts...)
+}
+-- out.txt --
+Proposed rewrites (rerun with -w to apply):
+  ./spread.go: client_construction=1 import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 read_limit_pinned=1
+--- ./spread.go
++++ ./spread.go
+@@ -3,11 +3,12 @@
+ import (
+ 	"net/http"
+ 
+-	"connectrpc.com/connect"
++	"connectrpc.com/connect/v2"
++	"connectrpc.com/connect/v2/connecthttp"
+ 	"example.com/app/gen/connect/ping/v1/pingv1connect"
+ )
+ 
+ func newClient(opts []connect.ClientOption) pingv1connect.PingServiceClient {
+-	return pingv1connect.NewPingServiceClient(http.DefaultClient, "http://localhost:8080/", opts...)
++	return pingv1connect.NewPingServiceClient(connect.NewClient(connecthttp.NewTransport(http.DefaultClient, "http://localhost:8080/", connecthttp.WithReadMaxBytes(0), opts...)))
+ }
+ 
+
+
+The following issues require manual code changes:
+  ./spread.go:10:23: connect.ClientOption -> connecthttp.Option (interceptors go to connect.NewClient, HTTP options to connecthttp.NewTransport)
+  ./spread.go:11:9: v2 limits reads to 4 MiB per message where v1 allowed any size, so this call is pinned to WithReadMaxBytes(0) to keep v1 behaviour. Drop it to take the v2 default. The pin goes first, ahead of options this tool cannot read into, so a limit set there still wins.
+
+Scanned 1 Go file and 0 Buf templates. 1 rewrite(s) ready (rerun with -w to apply).
+Full migration guide: https://github.com/connectrpc/connect-go/blob/main/docs/v2-migration.md

--- a/cmd/connect-go-v2-migrate/testdata/script/ecosystem_grpchealth.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/ecosystem_grpchealth.txtar
@@ -18,7 +18,7 @@ func run() error {
 }
 -- out.txt --
 Proposed rewrites (rerun with -w to apply):
-  ./ecosystem_grpchealth.go: grpchealth_register=1 import_add_connecthttp=1 import_add_connectv2=1 import_ecosystem_v2=1
+  ./ecosystem_grpchealth.go: grpchealth_register=1 import_add_connecthttp=1 import_add_connectv2=1 import_ecosystem_v2=1 read_limit_pinned=1
 --- ./ecosystem_grpchealth.go
 +++ ./ecosystem_grpchealth.go
 @@ -3,13 +3,17 @@
@@ -37,11 +37,14 @@ Proposed rewrites (rerun with -w to apply):
 -	mux.Handle(grpchealth.NewHandler(checker))
 +	server := connect.NewServer()
 +	grpchealth.Register(server, checker)
-+	connecthttp.Mount(mux, server)
++	connecthttp.Mount(mux, server, connecthttp.WithReadMaxBytes(0))
  	return http.ListenAndServe(":8080", mux)
  }
  
 
+
+The following issues require manual code changes:
+  ./ecosystem_grpchealth.go:12:13: v2 limits reads to 4 MiB per message where v1 allowed any size, so this call is pinned to WithReadMaxBytes(0) to keep v1 behaviour. Drop it to take the v2 default.
 
 Scanned 1 Go file and 0 Buf templates. 1 rewrite(s) ready (rerun with -w to apply).
 

--- a/cmd/connect-go-v2-migrate/testdata/script/ecosystem_grpcreflect_client.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/ecosystem_grpcreflect_client.txtar
@@ -15,7 +15,7 @@ func newReflectClient() *grpcreflect.Client {
 }
 -- out.txt --
 Proposed rewrites (rerun with -w to apply):
-  ./ecosystem_grpcreflect_client.go: grpcreflect_client=1 import_add_connecthttp=1 import_add_connectv2=1 import_ecosystem_v2=1
+  ./ecosystem_grpcreflect_client.go: grpcreflect_client=1 import_add_connecthttp=1 import_add_connectv2=1 import_ecosystem_v2=1 read_limit_pinned=1
 --- ./ecosystem_grpcreflect_client.go
 +++ ./ecosystem_grpcreflect_client.go
 @@ -3,10 +3,12 @@
@@ -30,10 +30,13 @@ Proposed rewrites (rerun with -w to apply):
  
  func newReflectClient() *grpcreflect.Client {
 -	return grpcreflect.NewClient(http.DefaultClient, "http://localhost:8080")
-+	return grpcreflect.NewClient(connect.NewClient(connecthttp.NewTransport(http.DefaultClient, "http://localhost:8080")))
++	return grpcreflect.NewClient(connect.NewClient(connecthttp.NewTransport(http.DefaultClient, "http://localhost:8080", connecthttp.WithReadMaxBytes(0))))
  }
  
 
+
+The following issues require manual code changes:
+  ./ecosystem_grpcreflect_client.go:10:9: v2 limits reads to 4 MiB per message where v1 allowed any size, so this call is pinned to WithReadMaxBytes(0) to keep v1 behaviour. Drop it to take the v2 default.
 
 Scanned 1 Go file and 0 Buf templates. 1 rewrite(s) ready (rerun with -w to apply).
 

--- a/cmd/connect-go-v2-migrate/testdata/script/ecosystem_otel_dup.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/ecosystem_otel_dup.txtar
@@ -26,7 +26,7 @@ func run() error {
 }
 -- out.txt --
 Proposed rewrites (rerun with -w to apply):
-  ./service.go: import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 import_ecosystem_v2=1 server_construction=1
+  ./service.go: import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 import_ecosystem_v2=1 read_limit_pinned=1 server_construction=1
 --- ./service.go
 +++ ./service.go
 @@ -3,8 +3,9 @@
@@ -48,13 +48,14 @@ Proposed rewrites (rerun with -w to apply):
 -	mux.Handle(pingv1connect.NewPingServiceHandler(&pingServer{}, connect.WithInterceptors(otelconnect.NewInterceptor())))
 +	server := connect.NewServer(otelconnect.NewInterceptor())
 +	pingv1connect.RegisterPingServiceHandler(server, &pingServer{})
-+	connecthttp.Mount(mux, server)
++	connecthttp.Mount(mux, server, connecthttp.WithReadMaxBytes(0))
  	return http.ListenAndServe(":8080", mux)
  }
  
 
 
 The following issues require manual code changes:
+  ./service.go:17:13: v2 limits reads to 4 MiB per message where v1 allowed any size, so this call is pinned to WithReadMaxBytes(0) to keep v1 behaviour. Drop it to take the v2 default.
   ./service.go:17:89: otelconnect.NewInterceptor stays in the connect.NewServer(...) list unmigrated. v2 uses otelconnect.NewServerInterceptor (connectrpc.com/otelconnect/v2), which returns an error and is assigned before the constructor.
 
 Scanned 1 Go file and 0 Buf templates. 1 rewrite(s) ready (rerun with -w to apply).

--- a/cmd/connect-go-v2-migrate/testdata/script/handler_construction.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/handler_construction.txtar
@@ -30,7 +30,7 @@ func run() error {
 }
 -- out.txt --
 Proposed rewrites (rerun with -w to apply):
-  ./handler_construction.go: import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 import_ecosystem_v2=1 interceptor_validate_v2=1 server_construction=1
+  ./handler_construction.go: import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 import_ecosystem_v2=1 interceptor_validate_v2=1 read_limit_pinned=1 server_construction=1
 --- ./handler_construction.go
 +++ ./handler_construction.go
 @@ -3,9 +3,10 @@
@@ -62,12 +62,15 @@ Proposed rewrites (rerun with -w to apply):
 +		// Validation via Protovalidate is almost always recommended.
 +		validate.NewServerInterceptor())
 +	pingv1connect.RegisterPingServiceHandler(server, &PingServer{})
-+	connecthttp.Mount(mux, server)
++	connecthttp.Mount(mux, server, connecthttp.WithReadMaxBytes(0))
 +
  	return http.ListenAndServe(":8080", mux)
  }
  
 
+
+The following issues require manual code changes:
+  ./handler_construction.go:18:3: v2 limits reads to 4 MiB per message where v1 allowed any size, so this call is pinned to WithReadMaxBytes(0) to keep v1 behaviour. Drop it to take the v2 default.
 
 Scanned 1 Go file and 0 Buf templates. 1 rewrite(s) ready (rerun with -w to apply).
 

--- a/cmd/connect-go-v2-migrate/testdata/script/handler_construction_group.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/handler_construction_group.txtar
@@ -25,7 +25,7 @@ func run() error {
 }
 -- out.txt --
 Proposed rewrites (rerun with -w to apply):
-  ./handler_construction_group.go: grpchealth_register=1 import_add_connecthttp=1 import_add_connectv2=1 import_ecosystem_v2=1 server_construction=1
+  ./handler_construction_group.go: grpchealth_register=1 import_add_connecthttp=1 import_add_connectv2=1 import_ecosystem_v2=1 read_limit_pinned=1 server_construction=1
 --- ./handler_construction_group.go
 +++ ./handler_construction_group.go
 @@ -3,8 +3,10 @@
@@ -49,12 +49,15 @@ Proposed rewrites (rerun with -w to apply):
 +	server := connect.NewServer()
 +	pingv1connect.RegisterPingServiceHandler(server, &PingServer{})
 +	grpchealth.Register(server, checker)
-+	connecthttp.Mount(mux, server)
++	connecthttp.Mount(mux, server, connecthttp.WithReadMaxBytes(0))
 +
  	return http.ListenAndServe(":8080", mux)
  }
  
 
+
+The following issues require manual code changes:
+  ./handler_construction_group.go:17:13: v2 limits reads to 4 MiB per message where v1 allowed any size, so this call is pinned to WithReadMaxBytes(0) to keep v1 behaviour. Drop it to take the v2 default.
 
 Scanned 1 Go file and 0 Buf templates. 1 rewrite(s) ready (rerun with -w to apply).
 

--- a/cmd/connect-go-v2-migrate/testdata/script/handler_construction_group_split.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/handler_construction_group_split.txtar
@@ -30,7 +30,7 @@ func run() error {
 }
 -- out.txt --
 Proposed rewrites (rerun with -w to apply):
-  ./handler_construction_group_split.go: grpchealth_register=1 import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 import_ecosystem_v2=2 interceptor_validate_v2=1 server_construction=1
+  ./handler_construction_group_split.go: grpchealth_register=1 import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 import_ecosystem_v2=2 interceptor_validate_v2=1 read_limit_pinned=2 server_construction=1
 --- ./handler_construction_group_split.go
 +++ ./handler_construction_group_split.go
 @@ -3,10 +3,11 @@
@@ -59,18 +59,20 @@ Proposed rewrites (rerun with -w to apply):
 -	mux.Handle(grpchealth.NewHandler(checker))
 +	server := connect.NewServer(validate.NewServerInterceptor())
 +	pingv1connect.RegisterPingServiceHandler(server, &PingServer{})
-+	connecthttp.Mount(mux, server)
++	connecthttp.Mount(mux, server, connecthttp.WithReadMaxBytes(0))
 +	srv := connect.NewServer()
 +
 +	grpchealth.Register(srv, checker)
-+	connecthttp.Mount(mux, srv)
++	connecthttp.Mount(mux, srv, connecthttp.WithReadMaxBytes(0))
  	return http.ListenAndServe(":8080", mux)
  }
  
 
 
 The following issues require manual code changes:
+  ./handler_construction_group_split.go:19:13: v2 limits reads to 4 MiB per message where v1 allowed any size, so this call is pinned to WithReadMaxBytes(0) to keep v1 behaviour. Drop it to take the v2 default.
   ./handler_construction_group_split.go:23:2: handlers on mux have differing options, so each group gets its own *connect.Server. v2 interceptors apply per server.
+  ./handler_construction_group_split.go:23:13: v2 limits reads to 4 MiB per message where v1 allowed any size, so this call is pinned to WithReadMaxBytes(0) to keep v1 behaviour. Drop it to take the v2 default.
 
 Scanned 1 Go file and 0 Buf templates. 1 rewrite(s) ready (rerun with -w to apply).
 

--- a/cmd/connect-go-v2-migrate/testdata/script/handler_construction_interceptor_var.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/handler_construction_interceptor_var.txtar
@@ -32,7 +32,7 @@ func run() error {
 func newErrorInterceptor() connect.Interceptor { return nil }
 -- out.txt --
 Proposed rewrites (rerun with -w to apply):
-  ./handler_construction_interceptor_var.go: import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 server_construction=1
+  ./handler_construction_interceptor_var.go: import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 read_limit_pinned=1 server_construction=1
 --- ./handler_construction_interceptor_var.go
 +++ ./handler_construction_interceptor_var.go
 @@ -3,7 +3,8 @@
@@ -52,7 +52,7 @@ Proposed rewrites (rerun with -w to apply):
 -	mux.Handle(pingv1connect.NewPingServiceHandler(&PingServer{}, opt))
 +	server := connect.NewServer(opt)
 +	pingv1connect.RegisterPingServiceHandler(server, &PingServer{})
-+	connecthttp.Mount(mux, server)
++	connecthttp.Mount(mux, server, connecthttp.WithReadMaxBytes(0))
  	return http.ListenAndServe(":8080", mux)
  }
  
@@ -60,6 +60,7 @@ Proposed rewrites (rerun with -w to apply):
 
 The following issues require manual code changes:
   ./handler_construction_interceptor_var.go:19:9: connect.WithInterceptors -> interceptors pass to connect.NewServer(...) or connect.NewClient(...). The v2 type is connect.ServerInterceptor or connect.ClientInterceptor.
+  ./handler_construction_interceptor_var.go:21:13: v2 limits reads to 4 MiB per message where v1 allowed any size, so this call is pinned to WithReadMaxBytes(0) to keep v1 behaviour. Drop it to take the v2 default.
   ./handler_construction_interceptor_var.go:21:64: interceptor opt stays in the connect.NewServer(...) list unmigrated. Its v2 type is connect.ServerInterceptor.
 
 Scanned 1 Go file and 0 Buf templates. 1 rewrite(s) ready (rerun with -w to apply).

--- a/cmd/connect-go-v2-migrate/testdata/script/handler_v2.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/handler_v2.txtar
@@ -76,7 +76,7 @@ func setup() http.Handler {
 }
 -- out.txt --
 Proposed rewrites (rerun with -w to apply):
-  ./service.go: body_drop_msg=3 convert_code_const=1 convert_new_error=1 flip_residual_connect=1 import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 param_unwrap_request=3 result_unwrap_response=3 server_construction=1 stream_handler_param=3 stream_recv_loop=1 strip_new_response=2
+  ./service.go: body_drop_msg=3 convert_code_const=1 convert_new_error=1 flip_residual_connect=1 import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 param_unwrap_request=3 read_limit_pinned=1 result_unwrap_response=3 server_construction=1 stream_handler_param=3 stream_recv_loop=1 strip_new_response=2
 --- ./service.go
 +++ ./service.go
 @@ -6,34 +6,40 @@
@@ -150,11 +150,14 @@ Proposed rewrites (rerun with -w to apply):
 -	mux.Handle(pingv1connect.NewPingServiceHandler(&pingServer{}))
 +	server := connect.NewServer()
 +	pingv1connect.RegisterPingServiceHandler(server, &pingServer{})
-+	connecthttp.Mount(mux, server)
++	connecthttp.Mount(mux, server, connecthttp.WithReadMaxBytes(0))
  	return mux
  }
  
 
+
+The following issues require manual code changes:
+  ./service.go:63:13: v2 limits reads to 4 MiB per message where v1 allowed any size, so this call is pinned to WithReadMaxBytes(0) to keep v1 behaviour. Drop it to take the v2 default.
 
 Scanned 1 Go file and 0 Buf templates. 1 rewrite(s) ready (rerun with -w to apply).
 Full migration guide: https://github.com/connectrpc/connect-go/blob/main/docs/v2-migration.md

--- a/cmd/connect-go-v2-migrate/testdata/script/mock_v1import.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/mock_v1import.txtar
@@ -43,7 +43,7 @@ func (m *MockPusher) Ping(ctx context.Context, req *connect.Request[pingv1.PingR
 }
 -- out.txt --
 Proposed rewrites (rerun with -w to apply):
-  ./consumer.go: client_construction=1 import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 strip_new_request=1
+  ./consumer.go: client_construction=1 import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 read_limit_pinned=1 strip_new_request=1
 --- ./consumer.go
 +++ ./consumer.go
 @@ -4,14 +4,15 @@
@@ -60,12 +60,15 @@ Proposed rewrites (rerun with -w to apply):
  func ping(ctx context.Context) error {
 -	client := pingv1connect.NewPingServiceClient(http.DefaultClient, "http://localhost:8080")
 -	_, err := client.Ping(ctx, connect.NewRequest(&pingv1.PingRequest{Number: 1}))
-+	client := pingv1connect.NewPingServiceClient(connect.NewClient(connecthttp.NewTransport(http.DefaultClient, "http://localhost:8080")))
++	client := pingv1connect.NewPingServiceClient(connect.NewClient(connecthttp.NewTransport(http.DefaultClient, "http://localhost:8080", connecthttp.WithReadMaxBytes(0))))
 +	_, err := client.Ping(ctx, &pingv1.PingRequest{Number: 1})
  	return err
  }
  
 
+
+The following issues require manual code changes:
+  ./consumer.go:13:12: v2 limits reads to 4 MiB per message where v1 allowed any size, so this call is pinned to WithReadMaxBytes(0) to keep v1 behaviour. Drop it to take the v2 default.
 
 Generated mocks still import connect v1. Regenerate them after migrating:
   example.com/app/mocks/mockping

--- a/cmd/connect-go-v2-migrate/testdata/script/partial_stub.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/partial_stub.txtar
@@ -150,7 +150,7 @@ replace connectrpc.com/connect => ./connectv1
 replace connectrpc.com/connect/v2 => ./connectv2
 -- out.txt --
 Proposed rewrites (rerun with -w to apply):
-  ./consumer_a.go: client_construction=1 import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 strip_new_request=1
+  ./consumer_a.go: client_construction=1 import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 read_limit_pinned=1 strip_new_request=1
 --- ./consumer_a.go
 +++ ./consumer_a.go
 @@ -4,7 +4,8 @@
@@ -169,7 +169,7 @@ Proposed rewrites (rerun with -w to apply):
  func echo(ctx context.Context) error {
 -	client := av1connect.NewAServiceClient(http.DefaultClient, "http://localhost")
 -	_, err := client.Echo(ctx, connect.NewRequest(&av1.EchoRequest{Text: "hi"}))
-+	client := av1connect.NewAServiceClient(connect.NewClient(connecthttp.NewTransport(http.DefaultClient, "http://localhost")))
++	client := av1connect.NewAServiceClient(connect.NewClient(connecthttp.NewTransport(http.DefaultClient, "http://localhost", connecthttp.WithReadMaxBytes(0))))
 +	_, err := client.Echo(ctx, &av1.EchoRequest{Text: "hi"})
  	return err
  }
@@ -177,6 +177,7 @@ Proposed rewrites (rerun with -w to apply):
 
 
 The following issues require manual code changes:
+  ./consumer_a.go:15:12: v2 limits reads to 4 MiB per message where v1 allowed any size, so this call is pinned to WithReadMaxBytes(0) to keep v1 behaviour. Drop it to take the v2 default.
   ./consumer_b.go:7:2: connectrpc.com/connect (v1) import retained because it still uses connect.NewRequest.
 
 Deferred until their connect stubs are regenerated to v2:

--- a/cmd/connect-go-v2-migrate/testdata/script/stream_client_comment_defer.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/stream_client_comment_defer.txtar
@@ -87,7 +87,7 @@ Proposed rewrites (rerun with -w to apply):
  }
  
 
-  ./service_test.go: client_construction=1 import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 stream_recv_loop=1 strip_new_request=1
+  ./service_test.go: client_construction=1 import_add_connecthttp=1 import_add_connectv2=1 import_drop_v1=1 read_limit_pinned=1 stream_recv_loop=1 strip_new_request=1
 --- ./service_test.go
 +++ ./service_test.go
 @@ -2,35 +2,43 @@
@@ -110,7 +110,7 @@ Proposed rewrites (rerun with -w to apply):
  func TestCountUp(t *testing.T) {
  	t.Run("counts", func(t *testing.T) {
 -		cli := pingv1connect.NewPingServiceClient(http.DefaultClient, "http://localhost:8080")
-+		cli := pingv1connect.NewPingServiceClient(connect.NewClient(connecthttp.NewTransport(http.DefaultClient, "http://localhost:8080")))
++		cli := pingv1connect.NewPingServiceClient(connect.NewClient(connecthttp.NewTransport(http.DefaultClient, "http://localhost:8080", connecthttp.WithReadMaxBytes(0))))
  		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
  		defer cancel()
  
@@ -143,6 +143,9 @@ Proposed rewrites (rerun with -w to apply):
  			t.Fatal("no numbers received")
  		}
 
+
+The following issues require manual code changes:
+  ./service_test.go:16:10: v2 limits reads to 4 MiB per message where v1 allowed any size, so this call is pinned to WithReadMaxBytes(0) to keep v1 behaviour. Drop it to take the v2 default.
 
 Scanned 2 Go files and 0 Buf templates. 2 rewrite(s) ready (rerun with -w to apply).
 Full migration guide: https://github.com/connectrpc/connect-go/blob/main/docs/v2-migration.md

--- a/connecthttp/connect_ext_test.go
+++ b/connecthttp/connect_ext_test.go
@@ -267,7 +267,7 @@ func TestServer(t *testing.T) {
 				t.Skipf("skipping %s test in short mode", t.Name())
 			}
 			ctx, callInfo := connect.NewClientContext(t.Context())
-			hellos := strings.Repeat("hello", 1024*1024) // ~5mb
+			hellos := strings.Repeat("hello", 512*1024) // ~2.5mb
 			request := &pingv1.PingRequest{Text: hellos}
 			for _, el := range expectedHeaderValues {
 				callInfo.RequestHeader().Add(clientHeader, el)
@@ -1998,7 +1998,9 @@ func TestClientWithReadMaxBytes(t *testing.T) {
 		}
 		srv := connect.NewServer()
 		pingv1connect.RegisterPingServiceHandler(srv, pingServer{})
-		connecthttp.Mount(mux, srv, compressionOption)
+		// Disable the handler's default read limit: this test exercises the
+		// client's.
+		connecthttp.Mount(mux, srv, compressionOption, connecthttp.WithReadMaxBytes(0))
 		server := memhttptest.NewServer(t, mux)
 		return server
 	}
@@ -2134,7 +2136,8 @@ func TestHandlerWithSendMaxBytes(t *testing.T) {
 	newHTTP2Server := func(t *testing.T, compressed bool, sendMaxBytes int) *memhttp.Server {
 		t.Helper()
 		mux := http.NewServeMux()
-		options := []connecthttp.Option{connecthttp.WithSendMaxBytes(sendMaxBytes)}
+		// Disable the default read limit: this test exercises the send limit.
+		options := []connecthttp.Option{connecthttp.WithSendMaxBytes(sendMaxBytes), connecthttp.WithReadMaxBytes(0)}
 		if compressed {
 			options = append(options, connecthttp.WithCompressMinBytes(1))
 		} else {

--- a/connecthttp/connecthttp.go
+++ b/connecthttp/connecthttp.go
@@ -217,6 +217,7 @@ func defaultOptions() options {
 		sendCodecName:   connect.CodecNameProto,
 		compressors:     defaultCompressors(),
 		compressorNames: []string{connect.CompressionNameGzip},
+		readMaxBytes:    defaultReadMaxBytes,
 		getUseFallback:  true,
 	}
 }

--- a/connecthttp/option.go
+++ b/connecthttp/option.go
@@ -139,8 +139,8 @@ func WithCompressMinBytes(n int) Option {
 // limits the size of a message that the server can respond with. Limits apply
 // to each Protobuf message, not to the stream as a whole.
 //
-// Setting WithReadMaxBytes to zero allows any message size. Both clients and
-// handlers default to allowing any request size.
+// Both clients and handlers default to a limit of 4 MiB. Setting
+// WithReadMaxBytes to zero allows any message size.
 //
 // Handlers may also use [net/http.MaxBytesHandler] to limit the total size of
 // the HTTP request stream (rather than the per-message size). Connect handles

--- a/connecthttp/protocol.go
+++ b/connecthttp/protocol.go
@@ -37,6 +37,10 @@ const (
 	headerDate            = "Date"
 
 	discardLimit = 1024 * 1024 * 4 // 4MiB
+
+	// defaultReadMaxBytes is the default per-message read limit for clients and
+	// handlers, matching gRPC's default. WithReadMaxBytes overrides it.
+	defaultReadMaxBytes = 1024 * 1024 * 4 // 4MiB
 )
 
 var errNoTimeout = errors.New("no timeout")

--- a/docs/v2-migration.md
+++ b/docs/v2-migration.md
@@ -431,6 +431,25 @@ The `ErrorWriter` type, `NewErrorWriter`, and `IsNotModifiedError` move to
 
 ✅ `connect-go-v2-migrate` handles these.
 
+### Read limits are bounded by default
+
+In v1, the default read limit was unbounded. This meant any caller,
+authenticated or not, could force a server to buffer a message of any size. To
+improve safety, v2 introduces a default limit of 4 MiB per message, which can
+be overridden using `WithReadMaxBytes`. Messages exceeding this limit fail with
+the `CodeResourceExhausted` error code.
+
+To prevent unexpected runtime behavior changes during upgrades, the migration
+tool preserves the v1 unbounded behavior by default:
+
+```go
+// v2, as the tool writes it
+connecthttp.NewTransport(httpClient, baseURL, connecthttp.WithReadMaxBytes(0))
+connecthttp.Mount(mux, server, connecthttp.WithReadMaxBytes(0))
+```
+
+✅ `connect-go-v2-migrate` handles this, and ⚠️ warns at every call it pins.
+
 Options whose signature changed are warned with the v2 replacement:
 
 | v1 | v2 |

--- a/internal/conformance/internal/app/referenceclient/client.go
+++ b/internal/conformance/internal/app/referenceclient/client.go
@@ -195,9 +195,9 @@ func invoke(ctx context.Context, transports *transports, req *conformancev1.Clie
 		return nil, fmt.Errorf("compression %v is not supported (the v2 reference client supports gzip only)", req.Compression)
 	}
 
-	if req.MessageReceiveLimit > 0 {
-		clientOptions = append(clientOptions, connecthttp.WithReadMaxBytes(int(req.MessageReceiveLimit)))
-	}
+	// A zero limit means unlimited, which is what the conformance suite expects
+	// when it does not set one.
+	clientOptions = append(clientOptions, connecthttp.WithReadMaxBytes(int(req.MessageReceiveLimit)))
 
 	switch req.GetService() {
 	case conformancev1connect.ConformanceServiceName:

--- a/internal/conformance/internal/app/referenceserver/server.go
+++ b/internal/conformance/internal/app/referenceserver/server.go
@@ -182,9 +182,9 @@ func createServer(req *conformancev1.ServerCompatRequest, listenAddr, tlsCertFil
 		connecthttp.WithCompressor(connectgzip.New()),
 		connecthttp.WithCodec(internal.NewStrictJSONCodec()),
 	}
-	if req.MessageReceiveLimit > 0 {
-		opts = append(opts, connecthttp.WithReadMaxBytes(int(req.MessageReceiveLimit)))
-	}
+	// A zero limit means unlimited, which is what the conformance suite expects
+	// when it does not set one.
+	opts = append(opts, connecthttp.WithReadMaxBytes(int(req.MessageReceiveLimit)))
 	srv := connect.NewServer(serverNameHandlerInterceptor)
 
 	conformancev1connect.RegisterConformanceServiceHandler(srv, &conformanceServer{})


### PR DESCRIPTION
Set a default ReadMaxBytes of 4 MiB for both clients and handlers. Both previously defaulted to no limit.

This is a v2 behavior change. The migration tool is updated to apply the v1 unbounded behavoir when not set. It will also warn users to prompt setting a limit. 

Setting `connecthttp.WithReadMaxBytes(0)` restores the v1 behavior, and existing `WithReadMaxBytes(n)` calls are unaffected. Handlers that want to bound the total size of a request stream rather than individual messages should still use `http.MaxBytesHandler`.

Supersedes https://github.com/connectrpc/connect-go/pull/961