### PR TITLE
Create release binary for protoc-gen-connect-go

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,12 @@ jobs:
         # supported version.
         if: matrix.go-version.name == 'latest'
         run: make checkgenerate && make lint
+      - name: Check Release
+        # Verifies that the release build works, so breakage surfaces here
+        # rather than when a release is being cut. Releases are built with the
+        # most recent supported version, so that's all we need to check.
+        if: matrix.go-version.name == 'latest'
+        run: make checkrelease
   conformance:
     name: conformance (go:${{ matrix.go-version.name }})
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,25 @@
+name: release
+on:
+  release:
+    types: [published]
+permissions:
+  contents: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Release events fire for every tag, limit to target vX.Y.Z.
+    if: ${{ startsWith(github.event.release.tag_name, 'v') }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - name: Install Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: 1.27.x
+          check-latest: true
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ github.TOKEN }}
+        run: make release

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.tmp/
+/dist/
 *.pprof
 *.svg
 .idea

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,65 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+project_name: protoc-gen-connect-go
+
+before:
+  hooks:
+    # connect.go's Version constant is edited by hand (RELEASE.md step 2) and is
+    # what the plugin reports via --version, while the archive names below come
+    # from the git tag. Nothing else checks that the two agree, so a missed edit
+    # would silently ship mislabelled binaries. Skipped for snapshot builds,
+    # where there is no release tag to compare against.
+    - sh -c 'if [ "{{ .IsSnapshot }}" != "true" ]; then version="v$(go run ./cmd/protoc-gen-connect-go --version)"; if [ "$version" != "{{ .Tag }}" ]; then echo "connect.Version is $version, but the release tag is {{ .Tag }}" >&2; exit 1; fi; fi'
+
+builds:
+  - id: protoc-gen-connect-go
+    binary: protoc-gen-connect-go
+    main: ./cmd/protoc-gen-connect-go
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      # Omit the symbol table and DWARF data, this is not a debuggable artifact.
+      - -s -w
+
+archives:
+  - formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    # Matches the naming used by bufbuild/buf and connectconformance releases.
+    name_template: >-
+      protoc-gen-connect-go-
+      {{- .Tag }}-
+      {{- title .Os }}-
+      {{- if and (eq .Os "linux") (eq .Arch "arm64") }}aarch64
+      {{- else if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+    files:
+      - LICENSE
+
+checksum:
+  # The default template uses .Version, which renders without the leading "v"
+  # that the archives above use. Pin it so the whole release is consistent.
+  name_template: 'protoc-gen-connect-go-{{ .Tag }}-checksums.txt'
+
+changelog:
+  # Release notes are written by hand in the GitHub UI, so there is nothing to
+  # generate here. Skipping it also avoids walking history that the release
+  # workflow's shallow checkout doesn't have.
+  disable: true
+
+release:
+  github:
+    owner: connectrpc
+    name: connect-go
+  # Releases are created and their notes curated by hand in the GitHub UI, as
+  # described in RELEASE.md. This only attaches artifacts to the existing
+  # release.
+  mode: keep-existing

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ COPYRIGHT_YEARS := 2021-2026
 LICENSE_IGNORE := --ignore .github/ --ignore ".*\.ya?ml"
 BUF_VERSION := 1.69.0
 GOLANGCI_LINT_VERSION ?= v2.13.1
+GORELEASER_VERSION ?= v2.18.0
 
 .PHONY: help
 help: ## Describe useful make targets
@@ -98,6 +99,16 @@ checkgenerate:
 	@# Used in CI to verify that `make generate` doesn't produce a diff.
 	test -z "$$(git status --porcelain | tee /dev/stderr)"
 
+.PHONY: release
+release: $(BIN)/goreleaser ## Build release artifacts and attach them to the release
+	goreleaser release
+
+.PHONY: checkrelease
+checkrelease: $(BIN)/goreleaser
+	@# Used in CI to verify that the release build works. Skips validation and
+	@# doesn't publish anything.
+	goreleaser release --clean --snapshot
+
 .PHONY: $(BIN)/protoc-gen-connect-go
 $(BIN)/protoc-gen-connect-go:
 	@mkdir -p $(@D)
@@ -114,6 +125,10 @@ $(BIN)/license-header: Makefile
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+$(BIN)/goreleaser: Makefile
+	@mkdir -p $(@D)
+	go install github.com/goreleaser/goreleaser/v2@$(GORELEASER_VERSION)
 
 $(BIN)/protoc-gen-go: Makefile go.mod
 	@mkdir -p $(@D)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,13 +32,16 @@ This document outlines how to create a release of connect-go.
 
 7. Publish the release.
 
-8. On a new branch, open [connect.go](connect.go) and change the `Version` to increment the minor tag and append the `-dev` suffix. Use the next minor release - we never anticipate bugs and patch releases.
+8. Check the [release workflow] triggered by publishing. It attaches the `protoc-gen-connect-go` binaries and a checksums file to the release. It fails if the `Version` constant doesn't match the tag: correct the constant, then delete the release and its tag and repeat step 6.
+
+9. On a new branch, open [connect.go](connect.go) and change the `Version` to increment the minor tag and append the `-dev` suffix. Use the next minor release - we never anticipate bugs and patch releases.
 
    ```patch
    -const Version = "1.14.0"
    +const Version = "1.15.0-dev"
    ```
 
-9. Open a PR titled "Back to development" ([Example PR #662](https://github.com/connectrpc/connect-go/pull/662)). Once it's reviewed and CI passes, merge it.
+10. Open a PR titled "Back to development" ([Example PR #662](https://github.com/connectrpc/connect-go/pull/662)). Once it's reviewed and CI passes, merge it.
 
 [latest release]: https://github.com/connectrpc/connect-go/releases/latest
+[release workflow]: https://github.com/connectrpc/connect-go/actions/workflows/release.yaml


### PR DESCRIPTION
This adds release artifacts and updates the RELEASE.md to validate.

Builds `protoc-gen-connect-go-vX.Y.Z-{Darwin,Linux,Windows}-{x86_64,arm64/aarch64}` archives, each containing the binary, LICENSE and checksum.

Closes https://github.com/connectrpc/connect-go/issues/695