### PR TITLE
V2 configure codecs and compressors as ordered lists

### DIFF
--- a/cmd/connect-go-v2-migrate/reshape_warn_test.go
+++ b/cmd/connect-go-v2-migrate/reshape_warn_test.go
@@ -130,7 +130,7 @@ func TestReshapedSymbolWarnings(t *testing.T) {
 		{
 			name:     "with_accept_compression",
 			body:     `var _ = connect.WithAcceptCompression`,
-			wantWarn: "connecthttp.WithCompressor",
+			wantWarn: "connecthttp.WithCompressors",
 		},
 		{
 			name:     "with_interceptors",

--- a/cmd/connect-go-v2-migrate/rewrite.go
+++ b/cmd/connect-go-v2-migrate/rewrite.go
@@ -84,7 +84,6 @@ var (
 		"WithHTTPGet":                      true,
 		"WithHTTPGetMaxURLSize":            true,
 		"WithProtoJSON":                    true,
-		"WithCodec":                        true,
 		"ErrorWriter":                      true,
 		"NewErrorWriter":                   true,
 		"IsNotModifiedError":               true,
@@ -94,8 +93,9 @@ var (
 	reshapedToConnectHTTP = map[string]string{
 		"HandlerOption":                 "connecthttp.Option (interceptors go to connect.NewServer, HTTP options to connecthttp.Mount)",
 		"ClientOption":                  "connecthttp.Option (interceptors go to connect.NewClient, HTTP options to connecthttp.NewTransport)",
-		"WithAcceptCompression":         "connecthttp.WithCompressor to register a connect.Compressor (see connectgzip), then connecthttp.WithAcceptCompression(name) to advertise it",
-		"WithCompression":               "connecthttp.WithCompressor(connect.Compressor) (see connectgzip); the (name, decompressor, compressor) signature changed",
+		"WithCodec":                     "connecthttp.WithCodecs(...connect.Codec), which REPLACES the default codecs instead of adding to them; list every codec you need in one call",
+		"WithAcceptCompression":         "connecthttp.WithCompressors(...connect.Compressor) (see connectgzip), which REPLACES the default compressors; they are advertised automatically, and nil constructors become an empty connecthttp.WithCompressors()",
+		"WithCompression":               "connecthttp.WithCompressors(...connect.Compressor) (see connectgzip), which REPLACES the default compressors; the (name, decompressor, compressor) signature changed",
 		"WithConditionalHandlerOptions": "connecthttp.WithConditionalOptions(func(connect.Spec) []connecthttp.Option); the callback signature changed",
 		"NewNotModifiedError":           "connecthttp.NewNotModifiedError (takes no http.Header argument)",
 	}

--- a/cmd/connect-go-v2-migrate/testdata/script/drop_v1_import_after_option.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/drop_v1_import_after_option.txtar
@@ -1,4 +1,4 @@
-# After WithCodec moves to connecthttp, the now-unused v1 connect import is dropped.
+# After WithProtoJSON moves to connecthttp, the now-unused v1 connect import is dropped.
 stubs v2
 exec migrate
 cmp stdout out.txt
@@ -16,7 +16,7 @@ import (
 )
 
 func codec() {
-	opt := connect.WithCodec(nil)
+	opt := connect.WithProtoJSON()
 	fmt.Println(opt)
 }
 -- out.txt --
@@ -33,8 +33,8 @@ Proposed rewrites (rerun with -w to apply):
  )
  
  func codec() {
--	opt := connect.WithCodec(nil)
-+	opt := connecthttp.WithCodec(nil)
+-	opt := connect.WithProtoJSON()
++	opt := connecthttp.WithProtoJSON()
  	fmt.Println(opt)
  }
  

--- a/cmd/connect-go-v2-migrate/testdata/script/options_all.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/options_all.txtar
@@ -32,7 +32,7 @@ func clientOpts() []connect.ClientOption {
 }
 -- out.txt --
 Proposed rewrites (rerun with -w to apply):
-  ./opts.go: import_add_connecthttp=1 option_protocol=2 option_to_connecthttp=10
+  ./opts.go: import_add_connecthttp=1 option_protocol=2 option_to_connecthttp=9
 --- ./opts.go
 +++ ./opts.go
 @@ -1,23 +1,26 @@
@@ -49,11 +49,10 @@ Proposed rewrites (rerun with -w to apply):
 -		connect.WithGRPC(),
 -		connect.WithGRPCWeb(),
 -		connect.WithProtoJSON(),
--		connect.WithCodec(nil),
 +		connecthttp.WithGRPC(),
 +		connecthttp.WithGRPCWeb(),
 +		connecthttp.WithProtoJSON(),
-+		connecthttp.WithCodec(nil),
+ 		connect.WithCodec(nil),
  		connect.WithCompression("gzip", nil, nil),
  		connect.WithAcceptCompression("gzip", nil, nil),
 -		connect.WithSendGzip(),
@@ -78,10 +77,11 @@ Proposed rewrites (rerun with -w to apply):
 
 
 The following issues require manual code changes:
-  ./opts.go:3:8: connectrpc.com/connect (v1) import retained because it still uses connect.ClientOption, connect.WithAcceptCompression, connect.WithCompression, connect.WithConditionalHandlerOptions.
+  ./opts.go:3:8: connectrpc.com/connect (v1) import retained because it still uses connect.ClientOption, connect.WithAcceptCompression, connect.WithCodec, connect.WithCompression, connect.WithConditionalHandlerOptions.
   ./opts.go:5:21: connect.ClientOption -> connecthttp.Option (interceptors go to connect.NewClient, HTTP options to connecthttp.NewTransport)
-  ./opts.go:11:3: connect.WithCompression -> connecthttp.WithCompressor(connect.Compressor) (see connectgzip); the (name, decompressor, compressor) signature changed
-  ./opts.go:12:3: connect.WithAcceptCompression -> connecthttp.WithCompressor to register a connect.Compressor (see connectgzip), then connecthttp.WithAcceptCompression(name) to advertise it
+  ./opts.go:10:3: connect.WithCodec -> connecthttp.WithCodecs(...connect.Codec), which REPLACES the default codecs instead of adding to them; list every codec you need in one call
+  ./opts.go:11:3: connect.WithCompression -> connecthttp.WithCompressors(...connect.Compressor) (see connectgzip), which REPLACES the default compressors; the (name, decompressor, compressor) signature changed
+  ./opts.go:12:3: connect.WithAcceptCompression -> connecthttp.WithCompressors(...connect.Compressor) (see connectgzip), which REPLACES the default compressors; they are advertised automatically, and nil constructors become an empty connecthttp.WithCompressors()
   ./opts.go:21:3: connect.WithConditionalHandlerOptions -> connecthttp.WithConditionalOptions(func(connect.Spec) []connecthttp.Option); the callback signature changed
 
 Scanned 1 Go file and 0 Buf templates. 1 rewrite(s) ready (rerun with -w to apply).

--- a/cmd/connect-go-v2-migrate/testdata/script/options_http_only.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/options_http_only.txtar
@@ -12,7 +12,7 @@ package p
 import "connectrpc.com/connect"
 
 func opts() []connect.ClientOption {
-	return []connect.ClientOption{connect.WithCodec(nil), connect.WithReadMaxBytes(1)}
+	return []connect.ClientOption{connect.WithProtoJSON(), connect.WithReadMaxBytes(1)}
 }
 -- out.txt --
 Proposed rewrites (rerun with -w to apply):
@@ -28,9 +28,9 @@ Proposed rewrites (rerun with -w to apply):
 +)
  
 -func opts() []connect.ClientOption {
--	return []connect.ClientOption{connect.WithCodec(nil), connect.WithReadMaxBytes(1)}
+-	return []connect.ClientOption{connect.WithProtoJSON(), connect.WithReadMaxBytes(1)}
 +func opts() []connecthttp.Option {
-+	return []connecthttp.Option{connecthttp.WithCodec(nil), connecthttp.WithReadMaxBytes(1)}
++	return []connecthttp.Option{connecthttp.WithProtoJSON(), connecthttp.WithReadMaxBytes(1)}
  }
  
 

--- a/cmd/connect-go-v2-migrate/testdata/script/package_split.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/package_split.txtar
@@ -20,7 +20,7 @@ func options() []connect.HandlerOption {
 		connect.WithCompressMinBytes(512),
 		connect.WithRequireConnectProtocolHeader(),
 		connect.WithGRPC(),
-		connect.WithCodec(nil),
+		connect.WithProtoJSON(),
 	}
 }
 -- out.txt --
@@ -43,7 +43,7 @@ Proposed rewrites (rerun with -w to apply):
 -		connect.WithCompressMinBytes(512),
 -		connect.WithRequireConnectProtocolHeader(),
 -		connect.WithGRPC(),
--		connect.WithCodec(nil),
+-		connect.WithProtoJSON(),
 +func options() []connecthttp.Option {
 +	return []connecthttp.Option{
 +		connecthttp.WithReadMaxBytes(1024),
@@ -51,7 +51,7 @@ Proposed rewrites (rerun with -w to apply):
 +		connecthttp.WithCompressMinBytes(512),
 +		connecthttp.WithRequireConnectProtocolHeader(),
 +		connecthttp.WithGRPC(),
-+		connecthttp.WithCodec(nil),
++		connecthttp.WithProtoJSON(),
  	}
  }
  

--- a/cmd/connect-go-v2-migrate/testdata/script/with_codec.txtar
+++ b/cmd/connect-go-v2-migrate/testdata/script/with_codec.txtar
@@ -1,4 +1,5 @@
-# connect.WithCodec -> connecthttp.WithCodecs; the v1 import drops for connecthttp.
+# connect.WithCodec is warned, not rewritten: v2's WithCodecs replaces the
+# default codecs instead of adding to them, so the v1 import is retained.
 stubs v2
 exec migrate
 cmp stdout out.txt
@@ -13,22 +14,9 @@ import "connectrpc.com/connect"
 
 var _ = connect.WithCodec(nil)
 -- out.txt --
-Proposed rewrites (rerun with -w to apply):
-  ./service.go: import_add_connecthttp=1 import_drop_v1=1 option_to_connecthttp=1
---- ./service.go
-+++ ./service.go
-@@ -1,6 +1,8 @@
- package p
- 
--import "connectrpc.com/connect"
-+import (
-+	"connectrpc.com/connect/v2/connecthttp"
-+)
- 
--var _ = connect.WithCodec(nil)
-+var _ = connecthttp.WithCodec(nil)
- 
+The following issues require manual code changes:
+  ./service.go:3:8: connectrpc.com/connect (v1) import retained because it still uses connect.WithCodec.
+  ./service.go:5:9: connect.WithCodec -> connecthttp.WithCodecs(...connect.Codec), which REPLACES the default codecs instead of adding to them; list every codec you need in one call
 
-
-Scanned 1 Go file and 0 Buf templates. 1 rewrite(s) ready (rerun with -w to apply).
+Scanned 1 Go file and 0 Buf templates. No automatic rewrites were applied.
 Full migration guide: https://github.com/connectrpc/connect-go/blob/main/docs/v2-migration.md

--- a/connecthttp/client_ext_test.go
+++ b/connecthttp/client_ext_test.go
@@ -84,7 +84,7 @@ func TestNewClient_UnknownSendCodec(t *testing.T) {
 	t.Parallel()
 	client := pingv1connect.NewPingServiceClient(connect.NewClient(connecthttp.NewTransport(http.DefaultClient,
 		"http://127.0.0.1:8080",
-		// The codec is never registered with WithCodec, so each call fails.
+		// The codec is never registered with WithCodecs, so each call fails.
 		connecthttp.WithSendCodec("invalid"))),
 	)
 	_, err := client.Ping(t.Context(), &pingv1.PingRequest{})

--- a/connecthttp/client_stream.go
+++ b/connecthttp/client_stream.go
@@ -195,15 +195,12 @@ func (t *transport) newProtocolClient(spec connect.Spec, opts *options) (protoco
 	if err != nil {
 		return nil, err
 	}
-	pools := make(map[string]*compressionPool, len(opts.compressors))
-	for name, compressor := range opts.compressors {
-		pools[name] = newCompressionPool(compressor)
-	}
+	codecs := newReadOnlyCodecs(opts.codecs)
 	return proto.NewClient(&protocolClientParams{
 		CompressionName:  opts.sendCompressor,
-		CompressionPools: newReadOnlyCompressionPools(pools, opts.compressorNames),
-		Codec:            opts.codecs[opts.sendCodecName],
-		Protobuf:         newReadOnlyCodecs(opts.codecs).Protobuf(),
+		CompressionPools: newReadOnlyCompressionPools(opts.compressors),
+		Codec:            codecs.Get(opts.getSendCodecName()),
+		Protobuf:         codecs.Protobuf(),
 		CompressMinBytes: opts.compressMinBytes,
 		HTTPClient:       t.httpClient,
 		URL:              t.urlForProcedure(spec.Procedure),

--- a/connecthttp/codec.go
+++ b/connecthttp/codec.go
@@ -39,7 +39,14 @@ type readOnlyCodecs interface {
 	Names() []string
 }
 
-func newReadOnlyCodecs(nameToCodec map[string]connect.Codec) readOnlyCodecs {
+func newReadOnlyCodecs(codecs []connect.Codec) readOnlyCodecs {
+	nameToCodec := make(map[string]connect.Codec, len(codecs))
+	for _, codec := range codecs {
+		if _, ok := nameToCodec[codec.Name()]; ok {
+			continue
+		}
+		nameToCodec[codec.Name()] = codec
+	}
 	return &codecMap{
 		nameToCodec: nameToCodec,
 	}

--- a/connecthttp/codec_test.go
+++ b/connecthttp/codec_test.go
@@ -16,6 +16,7 @@ package connecthttp
 
 import (
 	"bytes"
+	"slices"
 	"strings"
 	"testing"
 	"testing/quick"
@@ -124,5 +125,58 @@ func TestJSONCodec(t *testing.T) {
 			strings.Contains(err.Error(), "valid JSON"),
 			assert.Sprintf(`error message should explain that "" is not a valid JSON object`),
 		)
+	})
+}
+
+func TestCodecsOption(t *testing.T) {
+	t.Parallel()
+
+	names := func(options ...Option) []string {
+		opts := defaultOptions()
+		for _, option := range options {
+			option.apply(&opts)
+		}
+		got := newReadOnlyCodecs(opts.codecs).Names()
+		slices.Sort(got)
+		return got
+	}
+
+	t.Run("defaults to proto and json", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, names(), []string{connect.CodecNameJSON, connect.CodecNameProto})
+	})
+	t.Run("replaces the defaults", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, names(WithCodecs(connectproto.NewBinaryCodec())), []string{connect.CodecNameProto})
+	})
+	t.Run("last call wins", func(t *testing.T) {
+		t.Parallel()
+		opts := []Option{WithCodecs(connectproto.NewJSONCodec()), WithCodecs(connectproto.NewBinaryCodec())}
+		assert.Equal(t, names(opts...), []string{connect.CodecNameProto})
+	})
+	t.Run("sends with the first codec by default", func(t *testing.T) {
+		t.Parallel()
+		sendCodec := func(options ...Option) string {
+			opts := defaultOptions()
+			for _, option := range options {
+				option.apply(&opts)
+			}
+			return opts.getSendCodecName()
+		}
+		assert.Equal(t, sendCodec(), connect.CodecNameProto)
+		assert.Equal(t, sendCodec(
+			WithCodecs(connectproto.NewJSONCodec(), connectproto.NewBinaryCodec()),
+		), connect.CodecNameJSON)
+		// WithSendCodec overrides the first-listed default.
+		assert.Equal(t, sendCodec(
+			WithCodecs(connectproto.NewJSONCodec(), connectproto.NewBinaryCodec()),
+			WithSendCodec(connect.CodecNameProto),
+		), connect.CodecNameProto)
+		assert.Equal(t, sendCodec(WithCodecs()), "")
+	})
+	t.Run("repeated name is dropped", func(t *testing.T) {
+		t.Parallel()
+		opts := WithCodecs(connectproto.NewBinaryCodec(), connectproto.NewJSONCodec(), connectproto.NewBinaryCodec())
+		assert.Equal(t, names(opts), []string{connect.CodecNameJSON, connect.CodecNameProto})
 	})
 }

--- a/connecthttp/compression.go
+++ b/connecthttp/compression.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"io"
 	"math"
-	"slices"
 	"strings"
 
 	"connectrpc.com/connect/v2"
@@ -90,19 +89,16 @@ type readOnlyCompressionPools interface {
 	CommaSeparatedNames() string
 }
 
-func newReadOnlyCompressionPools(
-	nameToPool map[string]*compressionPool,
-	reversedNames []string,
-) readOnlyCompressionPools {
-	// Client and handler configs keep compression names in registration order,
-	// but we want the last registered to be the most preferred.
-	names := make([]string, 0, len(reversedNames))
-	seen := make(map[string]struct{}, len(reversedNames))
-	for _, name := range slices.Backward(reversedNames) {
-		if _, ok := seen[name]; ok {
+func newReadOnlyCompressionPools(compressors []connect.Compressor) readOnlyCompressionPools {
+	// List of compressors in preference order. A repeated name is ignored.
+	nameToPool := make(map[string]*compressionPool, len(compressors))
+	names := make([]string, 0, len(compressors))
+	for _, compressor := range compressors {
+		name := compressor.Name()
+		if _, ok := nameToPool[name]; ok {
 			continue
 		}
-		seen[name] = struct{}{}
+		nameToPool[name] = newCompressionPool(compressor)
 		names = append(names, name)
 	}
 	return &namedCompressionPools{

--- a/connecthttp/compression_test.go
+++ b/connecthttp/compression_test.go
@@ -25,53 +25,44 @@ import (
 func TestCompressionOption(t *testing.T) {
 	t.Parallel()
 
-	apply := func(opts ...Option) *options {
-		o := defaultOptions()
-		for _, opt := range opts {
-			opt.apply(&o)
+	// preference returns the negotiated preference order, most preferred first.
+	preference := func(options ...Option) string {
+		opts := defaultOptions()
+		for _, option := range options {
+			option.apply(&opts)
 		}
-		return &o
+		return newReadOnlyCompressionPools(opts.compressors).CommaSeparatedNames()
 	}
-	checkPools := func(t *testing.T, opts *options) {
-		t.Helper()
-		assert.Equal(t, len(opts.compressorNames), len(opts.compressors))
-		for _, name := range opts.compressorNames {
-			assert.NotNil(t, opts.compressors[name])
-		}
-	}
+	const (
+		gzip     = connect.CompressionNameGzip
+		identity = connect.CompressionNameIdentity
+	)
 
-	t.Run("defaults", func(t *testing.T) {
+	t.Run("defaults to gzip", func(t *testing.T) {
 		t.Parallel()
-		opts := apply()
-		assert.Equal(t, opts.compressorNames, []string{connect.CompressionNameGzip})
-		checkPools(t, opts)
+		assert.Equal(t, preference(), gzip)
 	})
-	t.Run("withCompressors registers and accepts", func(t *testing.T) {
+	t.Run("first listed is most preferred", func(t *testing.T) {
 		t.Parallel()
-		opts := apply(WithCompressor(identityCompressor{}))
-		assert.Equal(t, opts.compressorNames, []string{connect.CompressionNameGzip, connect.CompressionNameIdentity})
-		checkPools(t, opts)
+		assert.Equal(t, preference(WithCompressors(identityCompressor{}, stubCompressor(gzip))), identity+","+gzip)
 	})
-	t.Run("withNoCompression-disables", func(t *testing.T) {
+	t.Run("replaces the defaults", func(t *testing.T) {
 		t.Parallel()
-		opts := apply(WithNoCompression())
-		assert.Equal(t, opts.compressorNames, nil)
-		assert.Equal(t, len(opts.compressors), 0)
+		assert.Equal(t, preference(WithCompressors(identityCompressor{})), identity)
 	})
-	t.Run("withAcceptCompression-selects-name", func(t *testing.T) {
+	t.Run("no arguments disables compression", func(t *testing.T) {
 		t.Parallel()
-		opts := apply(WithAcceptCompression("br"))
-		assert.Equal(t, opts.compressorNames, []string{connect.CompressionNameGzip, "br"})
+		assert.Equal(t, preference(WithCompressors()), "")
 	})
-	t.Run("withAcceptCompression-empty-name-noop", func(t *testing.T) {
+	t.Run("last call wins", func(t *testing.T) {
 		t.Parallel()
-		opts := apply(WithAcceptCompression(""))
-		assert.Equal(t, opts.compressorNames, []string{connect.CompressionNameGzip})
+		opts := []Option{WithCompressors(identityCompressor{}), WithCompressors(stubCompressor(gzip))}
+		assert.Equal(t, preference(opts...), gzip)
 	})
-	t.Run("withAcceptCompression-deduplicates", func(t *testing.T) {
+	t.Run("repeated name keeps its first entry", func(t *testing.T) {
 		t.Parallel()
-		opts := apply(WithAcceptCompression(connect.CompressionNameGzip))
-		assert.Equal(t, opts.compressorNames, []string{connect.CompressionNameGzip})
+		opts := []Option{WithCompressors(identityCompressor{}, stubCompressor(gzip), identityCompressor{})}
+		assert.Equal(t, preference(opts...), identity+","+gzip)
 	})
 }
 

--- a/connecthttp/connect_ext_test.go
+++ b/connecthttp/connect_ext_test.go
@@ -38,6 +38,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect/v2"
+	"connectrpc.com/connect/v2/connectgzip"
 	"connectrpc.com/connect/v2/connecthttp"
 	"connectrpc.com/connect/v2/connectproto"
 	"connectrpc.com/connect/v2/internal/assert"
@@ -1454,7 +1455,7 @@ func TestFailCodec(t *testing.T) {
 	server := memhttptest.NewServer(t, handler)
 	client := pingv1connect.NewPingServiceClient(connect.NewClient(connecthttp.NewTransport(server.Client(),
 		server.URL(),
-		connecthttp.WithCodec(failCodec{}))),
+		connecthttp.WithCodecs(failCodec{}))),
 	)
 	stream, err := client.CumSum(t.Context())
 	if err != nil {
@@ -1736,18 +1737,44 @@ func TestCustomCompression(t *testing.T) {
 	mux := http.NewServeMux()
 	srv := connect.NewServer()
 	pingv1connect.RegisterPingServiceHandler(srv, pingServer{})
-	connecthttp.Mount(mux, srv, connecthttp.WithCompressor(deflateCompressor{}))
+	connecthttp.Mount(mux, srv, connecthttp.WithCompressors(deflateCompressor{}))
 
 	server := memhttptest.NewServer(t, mux)
 	client := pingv1connect.NewPingServiceClient(connect.NewClient(connecthttp.NewTransport(server.Client(),
 		server.URL(),
-		connecthttp.WithCompressor(deflateCompressor{}),
+		connecthttp.WithCompressors(deflateCompressor{}),
 		connecthttp.WithSendCompression("deflate"))),
 	)
 	request := &pingv1.PingRequest{Text: "testing 1..2..3.."}
 	response, err := client.Ping(t.Context(), request)
 	assert.Nil(t, err)
 	assert.Equal(t, response, &pingv1.PingResponse{Text: request.GetText()})
+}
+
+func TestServerCompressionPreference(t *testing.T) {
+	// The server picks its own most preferred encoding out of the client's
+	// accept list, rather than honoring the order the client sent. See
+	// https://github.com/connectrpc/connectrpc.com/pull/322.
+	t.Parallel()
+	mux := http.NewServeMux()
+	srv := connect.NewServer()
+	pingv1connect.RegisterPingServiceHandler(srv, pingServer{})
+	// The handler prefers gzip and falls back to deflate.
+	connecthttp.Mount(mux, srv,
+		connecthttp.WithCompressors(connectgzip.New(), deflateCompressor{}),
+	)
+	server := memhttptest.NewServer(t, mux)
+	// The client advertises "deflate,gzip", listing deflate first. The
+	// handler's preference wins over the client's ordering.
+	client := pingv1connect.NewPingServiceClient(connect.NewClient(connecthttp.NewTransport(
+		server.Client(),
+		server.URL(),
+		connecthttp.WithCompressors(deflateCompressor{}, connectgzip.New()),
+	)))
+	ctx, info := connect.NewClientContext(t.Context())
+	_, err := client.Ping(ctx, &pingv1.PingRequest{Text: strings.Repeat("connect", 32)})
+	assert.Nil(t, err)
+	assert.Equal(t, info.ResponseEncoding, connect.CompressionNameGzip)
 }
 
 func TestClientWithoutGzipSupport(t *testing.T) {
@@ -1762,7 +1789,7 @@ func TestClientWithoutGzipSupport(t *testing.T) {
 	server := memhttptest.NewServer(t, mux)
 	client := pingv1connect.NewPingServiceClient(connect.NewClient(connecthttp.NewTransport(server.Client(),
 		server.URL(),
-		connecthttp.WithNoCompression(),
+		connecthttp.WithCompressors(),
 		connecthttp.WithSendGzip())),
 	)
 	request := &pingv1.PingRequest{Text: "gzip me!"}
@@ -2557,11 +2584,11 @@ func TestFailCompression(t *testing.T) {
 	mux := http.NewServeMux()
 	srv := connect.NewServer()
 	pingv1connect.RegisterPingServiceHandler(srv, pingServer{})
-	connecthttp.Mount(mux, srv, connecthttp.WithCompressor(failCompressor{}))
+	connecthttp.Mount(mux, srv, connecthttp.WithCompressors(failCompressor{}))
 	server := memhttptest.NewServer(t, mux)
 	client := pingv1connect.NewPingServiceClient(connect.NewClient(
 		connecthttp.NewTransport(server.Client(), server.URL(),
-			connecthttp.WithCompressor(failCompressor{}),
+			connecthttp.WithCompressors(failCompressor{}),
 			connecthttp.WithSendCompression(failCompressor{}.Name()),
 		),
 	))

--- a/connecthttp/connecthttp.go
+++ b/connecthttp/connecthttp.go
@@ -22,7 +22,6 @@ package connecthttp
 import (
 	"context"
 	"crypto/tls"
-	"maps"
 	"net/http"
 	"net/url"
 	"slices"
@@ -212,30 +211,26 @@ func NewTransport(httpClient HTTPClient, baseURL string, options ...Option) conn
 // server starts from before user options are applied.
 func defaultOptions() options {
 	return options{
-		protocol:        connect.ProtocolNameConnect,
-		codecs:          defaultCodecs(),
-		sendCodecName:   connect.CodecNameProto,
-		compressors:     defaultCompressors(),
-		compressorNames: []string{connect.CompressionNameGzip},
-		readMaxBytes:    defaultReadMaxBytes,
-		getUseFallback:  true,
+		protocol:       connect.ProtocolNameConnect,
+		codecs:         defaultCodecs(),
+		compressors:    defaultCompressors(),
+		readMaxBytes:   defaultReadMaxBytes,
+		getUseFallback: true,
 	}
 }
 
 // defaultCodecs returns the proto and JSON codecs every transport and handler
 // registers by default.
-func defaultCodecs() map[string]connect.Codec {
-	return map[string]connect.Codec{
-		connect.CodecNameProto: connectproto.NewBinaryCodec(),
-		connect.CodecNameJSON:  connectproto.NewJSONCodec(),
+func defaultCodecs() []connect.Codec {
+	return []connect.Codec{
+		connectproto.NewBinaryCodec(),
+		connectproto.NewJSONCodec(),
 	}
 }
 
 // defaultCompressors returns the gzip compressor registered by default.
-func defaultCompressors() map[string]connect.Compressor {
-	return map[string]connect.Compressor{
-		connect.CompressionNameGzip: connectgzip.New(),
-	}
+func defaultCompressors() []connect.Compressor {
+	return []connect.Compressor{connectgzip.New()}
 }
 
 // Mount registers an [http.Handler] for each of server's procedures on mux,
@@ -314,12 +309,20 @@ func (t *transport) NewClientStream(ctx context.Context, spec connect.Spec) (con
 	info.TransportInfo = clientInfo
 	opts := t.options.forSpec(spec)
 	if opts.sendCompressor != "" && opts.sendCompressor != connect.CompressionNameIdentity {
-		if _, ok := opts.compressors[opts.sendCompressor]; !ok {
+		if !slices.ContainsFunc(opts.compressors, func(c connect.Compressor) bool {
+			return c.Name() == opts.sendCompressor
+		}) {
 			return nil, connect.Errorf(connect.CodeUnknown, "unknown compression %q", opts.sendCompressor)
 		}
 	}
-	if _, ok := opts.codecs[opts.sendCodecName]; !ok {
-		return nil, connect.Errorf(connect.CodeUnknown, "unknown codec %q", opts.sendCodecName)
+	sendCodecName := opts.getSendCodecName()
+	if sendCodecName == "" {
+		return nil, connect.Errorf(connect.CodeUnknown, "no codecs registered")
+	}
+	if !slices.ContainsFunc(opts.codecs, func(c connect.Codec) bool {
+		return c.Name() == sendCodecName
+	}) {
+		return nil, connect.Errorf(connect.CodeUnknown, "unknown codec %q", sendCodecName)
 	}
 	if t.baseURLErr != nil {
 		return nil, connect.Errorf(connect.CodeUnavailable, "invalid base URL: %v", t.baseURLErr)
@@ -333,7 +336,7 @@ func (t *transport) NewClientStream(ctx context.Context, spec connect.Spec) (con
 	info.Spec = spec
 	info.PeerAddr = peer.Addr
 	info.Protocol = peer.Protocol
-	info.Codec = opts.sendCodecName
+	info.Codec = sendCodecName
 	info.RequestEncoding = encodingOrIdentity(opts.sendCompressor)
 	conn.onRequestSend(func(request *http.Request) {
 		clientInfo.request = request
@@ -365,9 +368,8 @@ func (t *transport) urlForProcedure(procedure string) *url.URL {
 // fields relevant to it and ignores the rest.
 type options struct {
 	// Shared by clients and servers.
-	codecs           map[string]connect.Codec
-	compressors      map[string]connect.Compressor
-	compressorNames  []string
+	codecs           []connect.Codec
+	compressors      []connect.Compressor
 	compressMinBytes int
 	readMaxBytes     int
 	sendMaxBytes     int
@@ -404,14 +406,24 @@ func (o *options) forSpec(spec connect.Spec) *options {
 	return clone
 }
 
+// getSendCodecName returns the name of codec to use.
+func (o *options) getSendCodecName() string {
+	if o.sendCodecName != "" {
+		return o.sendCodecName
+	}
+	if len(o.codecs) == 0 {
+		return ""
+	}
+	return o.codecs[0].Name()
+}
+
 // clone returns a deep-enough copy of c that applying options to the copy does
 // not mutate the receiver's maps and slices. The conditional list is dropped to
 // avoid re-evaluating it.
 func (o *options) clone() *options {
 	opts := *o
-	opts.codecs = maps.Clone(o.codecs)
-	opts.compressors = maps.Clone(o.compressors)
-	opts.compressorNames = slices.Clone(o.compressorNames)
+	opts.codecs = slices.Clone(o.codecs)
+	opts.compressors = slices.Clone(o.compressors)
 	opts.conditional = nil
 	return &opts
 }

--- a/connecthttp/handler.go
+++ b/connecthttp/handler.go
@@ -124,9 +124,8 @@ func (h *handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 }
 
 type handlerConfig struct {
-	CompressionPools             map[string]*compressionPool
-	CompressionNames             []string
-	Codecs                       map[string]connect.Codec
+	Compressors                  []connect.Compressor
+	Codecs                       []connect.Codec
 	CompressMinBytes             int
 	Procedure                    string
 	Schema                       any
@@ -154,10 +153,7 @@ func (c *handlerConfig) newProtocolHandlers() []protocolHandler {
 	}
 	handlers := make([]protocolHandler, 0, len(protocols))
 	codecs := newReadOnlyCodecs(c.Codecs)
-	compressors := newReadOnlyCompressionPools(
-		c.CompressionPools,
-		c.CompressionNames,
-	)
+	compressors := newReadOnlyCompressionPools(c.Compressors)
 	for _, protocol := range protocols {
 		handlers = append(handlers, protocol.NewHandler(&protocolHandlerParams{
 			spec:                         c.newSpec(),

--- a/connecthttp/option.go
+++ b/connecthttp/option.go
@@ -51,73 +51,62 @@ func WithProtoJSON() Option {
 	return WithSendCodec(connect.CodecNameJSON)
 }
 
-// WithSendCodec selects the codec (by name) used for outgoing client requests.
-// The codec must also be registered via [WithCodec]. Defaults to
-// [connect.CodecNameProto]. [Mount] ignores this option.
+// WithSendCodec configures a client to use the specified codec by name for
+// outgoing requests. The named codec must be registered via [WithCodecs].
+//
+// If this option is not used, clients default to using the first codec
+// provided to [WithCodecs]. [Mount] ignore this option.
 func WithSendCodec(name string) Option {
 	return sendCodecOption(name)
 }
 
-// WithCodec registers a [connect.Codec]. Clients may use it for outgoing
-// requests. Servers accept it on inbound requests. Multiple WithCodec options
-// merge. Defaults to
-// [connectrpc.com/connect/v2/connectproto.BinaryCodec] and
-// [connectrpc.com/connect/v2/connectproto.JSONCodec].
-func WithCodec(codec connect.Codec) Option {
-	return codecsOption([]connect.Codec{codec})
+// WithCodecs configures the supported codecs for a client or handler. It
+// replaces any previously configured codecs, including the defaults.
+//
+// Handlers match incoming requests to codecs by name based on the content
+// type, so order only matters for clients. By default, a client sends
+// requests using the first codec in this list unless [WithSendCodec]
+// specifies otherwise. If multiple codecs share the same name, only the
+// first is kept.
+//
+// By default, the Protobuf binary and JSON codecs from
+// [connectrpc.com/connect/v2/connectproto] are registered, with binary
+// Protobuf listed first (making it the default send codec).
+func WithCodecs(codecs ...connect.Codec) Option {
+	return codecsOption(codecs)
 }
 
-// WithCompressor registers a [connect.Compressor]. Clients advertise it in
-// Accept-Encoding and may use it for sending; servers accept it on inbound
-// requests and use it for responses. Compressors add to the default set, and
-// the most recently registered is the most preferred. Multiple WithCompressor
-// options accumulate.
+// WithCompressors configures the supported compressors for a client or
+// handler. It replaces any previously configured compressors, including the
+// default gzip.
 //
-// The default is gzip. Use [WithNoCompression] to disable compression.
-func WithCompressor(compressor connect.Compressor) Option {
-	return compressorsOption([]connect.Compressor{compressor})
+// Order determines preference, with the most preferred compressor listed
+// first. Clients advertise this preference order, and handlers respond using
+// their most preferred compressor that the client also accepts. If a client
+// sends a compressed request, the handler will always reply using the same
+// encoding.
+//
+// Calling WithCompressors with no arguments disables compression entirely. If
+// multiple compressors share the same name, only the first is kept.
+//
+// The default is gzip.
+func WithCompressors(compressors ...connect.Compressor) Option {
+	return compressorsOption(compressors)
 }
 
-// WithNoCompression disables compression on both clients and servers: it
-// removes every registered compressor (including the default gzip) so nothing
-// is advertised, accepted, or sent compressed. A later [WithCompressor]
-// re-registers compressors after it.
-func WithNoCompression() Option {
-	return noCompressionOption{}
-}
-
-// WithAcceptCompression makes a compression algorithm available to a client or
-// handler by name, advertising it in Accept-Encoding. The named compressor must
-// be registered via [WithCompressor]; the name simply selects from that pool.
-// The first registered algorithm is treated as the least preferred, and the
-// last registered algorithm is the most preferred.
+// WithSendCompression configures a client to compress outgoing requests using
+// the specified algorithm by name. The named compressor must already be
+// registered via [WithCompressors] (or be the default gzip compressor).
 //
-// It's safe to use this option liberally: servers will ignore any compression
-// algorithms they don't support. To compress requests, pair this option with
-// [WithSendCompression].
-//
-// Clients and servers support gzip by default.
-//
-// Calling WithAcceptCompression with an empty name is a no-op.
-func WithAcceptCompression(name string) Option {
-	return acceptCompressionOption(name)
-}
-
-// WithSendCompression selects the compressor (by name) to apply to outgoing
-// client payloads. The compressor must be registered via [WithCompressor] (or
-// be the default "gzip" compressor). Requests are sent uncompressed by default,
-// to support servers that don't support compression. [Mount] ignores this
-// option.
+// By default, clients send uncompressed requests to ensure compatibility with
+// servers that do not support compression. [Mount] ignores this option.
 func WithSendCompression(name string) Option {
 	return sendCompressorOption(name)
 }
 
-// WithSendGzip configures the client to gzip requests. Since clients have
-// access to a gzip compressor by default, WithSendGzip doesn't require
-// [WithCompressor].
-//
-// Some servers don't support gzip, so clients default to sending uncompressed
-// requests.
+// WithSendGzip is a convenience option that configures a client to gzip
+// outgoing requests. Because gzip is registered by default, this does not
+// require a corresponding [WithCompressors] option.
 func WithSendGzip() Option {
 	return WithSendCompression(connect.CompressionNameGzip)
 }
@@ -237,42 +226,13 @@ func (o sendCodecOption) apply(opts *options) { opts.sendCodecName = string(o) }
 type codecsOption []connect.Codec
 
 func (o codecsOption) apply(opts *options) {
-	if opts.codecs == nil {
-		opts.codecs = make(map[string]connect.Codec, len(o))
-	}
-	for _, c := range o {
-		opts.codecs[c.Name()] = c
-	}
+	opts.codecs = slices.Clone(o)
 }
 
 type compressorsOption []connect.Compressor
 
 func (o compressorsOption) apply(opts *options) {
-	for _, c := range o {
-		if _, dup := opts.compressors[c.Name()]; !dup {
-			opts.compressorNames = append(opts.compressorNames, c.Name())
-		}
-		opts.compressors[c.Name()] = c
-	}
-}
-
-type noCompressionOption struct{}
-
-func (noCompressionOption) apply(opts *options) {
-	opts.compressors = map[string]connect.Compressor{}
-	opts.compressorNames = nil
-}
-
-type acceptCompressionOption string
-
-func (o acceptCompressionOption) apply(opts *options) {
-	name := string(o)
-	if name == "" {
-		return
-	}
-	if !slices.Contains(opts.compressorNames, name) {
-		opts.compressorNames = append(opts.compressorNames, name)
-	}
+	opts.compressors = slices.Clone(o)
 }
 
 type sendCompressorOption string

--- a/connecthttp/protocol.go
+++ b/connecthttp/protocol.go
@@ -308,17 +308,21 @@ func discard(reader io.Reader) (int64, error) {
 // negotiateCompression determines and validates the request compression and
 // response compression using the available compressors and protocol-specific
 // Content-Encoding and Accept-Encoding headers.
-func negotiateCompression( //nolint:nonamedreturns
+//
+// Compression is symmetric: a compressed request gets a response in the same
+// encoding. Otherwise we choose from the client's accept list, which we treat
+// as unordered since neither the Connect nor the gRPC compression spec ranks
+// it, so the response uses the server's most preferred encoding that the
+// client accepts. Quality values aren't supported.
+func negotiateCompression(
 	availableCompressors readOnlyCompressionPools,
 	sent, accept string,
-) (requestCompression, responseCompression string, clientVisibleErr *connect.Error) {
-	requestCompression = connect.CompressionNameIdentity
+) (string, string, *connect.Error) {
+
 	if sent != "" && sent != connect.CompressionNameIdentity {
 		// We default to identity, so we only care if the client sends something
 		// other than the empty string or compressIdentity.
-		if availableCompressors.Contains(sent) {
-			requestCompression = sent
-		} else {
+		if !availableCompressors.Contains(sent) {
 			// To comply with
 			// https://github.com/grpc/grpc/blob/master/doc/compression.md and the
 			// Connect protocol, we should return connect.CodeUnimplemented and specify
@@ -330,24 +334,27 @@ func negotiateCompression( //nolint:nonamedreturns
 				sent, availableCompressors.CommaSeparatedNames(),
 			)
 		}
+		// Echo the request's encoding. This logic follows
+		// https://github.com/grpc/grpc/blob/master/doc/compression.md and common
+		// sense: a client that compressed its request can read that encoding back.
+		return sent, sent, nil
 	}
-	// Support asymmetric compression. This logic follows
-	// https://github.com/grpc/grpc/blob/master/doc/compression.md and common
-	// sense.
-	responseCompression = requestCompression
-	// If we're not already planning to compress the response, check whether the
-	// client requested a compression algorithm we support.
-	if responseCompression == connect.CompressionNameIdentity && accept != "" {
-		for _, name := range strings.FieldsFunc(accept, isCommaOrSpace) {
-			if availableCompressors.Contains(name) {
-				// We found a mutually supported compression algorithm. Unlike standard
-				// HTTP, there's no preference weighting, so can bail out immediately.
-				responseCompression = name
-				break
+
+	// If the request was uncompressed, we're free to choose. Walk our own
+	// compressors in preference order and take the first one the client
+	// accepts: both protocols leave the choice to the server.
+	if accept != "" {
+		names := availableCompressors.CommaSeparatedNames()
+		for name := range strings.FieldsFuncSeq(names, isCommaOrSpace) {
+			for accepted := range strings.FieldsFuncSeq(accept, isCommaOrSpace) {
+				if name == accepted {
+					return connect.CompressionNameIdentity, name, nil
+				}
 			}
 		}
 	}
-	return requestCompression, responseCompression, nil
+
+	return connect.CompressionNameIdentity, connect.CompressionNameIdentity, nil
 }
 
 // checkServerStreamsCanFlush ensures that bidi and server streaming handlers

--- a/connecthttp/protocol.go
+++ b/connecthttp/protocol.go
@@ -318,7 +318,6 @@ func negotiateCompression(
 	availableCompressors readOnlyCompressionPools,
 	sent, accept string,
 ) (string, string, *connect.Error) {
-
 	if sent != "" && sent != connect.CompressionNameIdentity {
 		// We default to identity, so we only care if the client sends something
 		// other than the empty string or compressIdentity.

--- a/connecthttp/protocol_test.go
+++ b/connecthttp/protocol_test.go
@@ -15,8 +15,10 @@
 package connecthttp
 
 import (
+	"io"
 	"testing"
 
+	"connectrpc.com/connect/v2"
 	"connectrpc.com/connect/v2/internal/assert"
 )
 
@@ -62,4 +64,168 @@ func BenchmarkCanonicalizeContentType(b *testing.B) {
 		}
 		b.ReportAllocs()
 	})
+}
+
+func TestNegotiateCompression(t *testing.T) {
+	t.Parallel()
+	// pools builds the server's compressors in preference order, so the first
+	// name given is the most preferred.
+	pools := func(registered ...string) readOnlyCompressionPools {
+		compressors := make([]connect.Compressor, 0, len(registered))
+		for _, name := range registered {
+			compressors = append(compressors, stubCompressor(name))
+		}
+		return newReadOnlyCompressionPools(compressors)
+	}
+
+	tests := []struct {
+		name         string
+		pools        readOnlyCompressionPools
+		sent         string
+		accept       string
+		wantRequest  string
+		wantResponse string
+		wantErrCode  connect.Code
+	}{{
+		// The three worked examples from connectrpc.com#322, where the client
+		// sends "gzip,br,zstd" and the server's configuration decides.
+		name:         "server supports gzip only",
+		pools:        pools("gzip"),
+		accept:       "gzip,br,zstd",
+		wantRequest:  "identity",
+		wantResponse: "gzip",
+	}, {
+		name:         "server prefers gzip over zstd and br",
+		pools:        pools("gzip", "zstd", "br"),
+		accept:       "gzip,br,zstd",
+		wantRequest:  "identity",
+		wantResponse: "gzip",
+	}, {
+		name:         "server prefers br over zstd and gzip",
+		pools:        pools("br", "zstd", "gzip"),
+		accept:       "gzip,br,zstd",
+		wantRequest:  "identity",
+		wantResponse: "br",
+	}, {
+		name:         "server preference beats client order",
+		pools:        pools("br", "gzip"),
+		accept:       "gzip,br",
+		wantRequest:  "identity",
+		wantResponse: "br",
+	}, {
+		// Compression is symmetric: a compressed request is answered in the
+		// same encoding, even when the server would otherwise prefer br.
+		name:         "request encoding echoed over server preference",
+		pools:        pools("br", "gzip"),
+		sent:         "gzip",
+		accept:       "gzip,br",
+		wantRequest:  "gzip",
+		wantResponse: "gzip",
+	}, {
+		name:         "request encoding echoed without accept",
+		pools:        pools("br", "gzip"),
+		sent:         "gzip",
+		wantRequest:  "gzip",
+		wantResponse: "gzip",
+	}, {
+		// Server preference only decides when the request was uncompressed.
+		name:         "server preference applies to uncompressed request",
+		pools:        pools("br", "gzip"),
+		sent:         "identity",
+		accept:       "gzip,br",
+		wantRequest:  "identity",
+		wantResponse: "br",
+	}, {
+		name:         "no mutually supported encoding",
+		pools:        pools("gzip"),
+		accept:       "br,zstd",
+		wantRequest:  "identity",
+		wantResponse: "identity",
+	}, {
+		name:         "identity accepted",
+		pools:        pools("gzip"),
+		accept:       "identity",
+		wantRequest:  "identity",
+		wantResponse: "identity",
+	}, {
+		name:         "space separated accept",
+		pools:        pools("br", "gzip"),
+		accept:       "gzip, br",
+		wantRequest:  "identity",
+		wantResponse: "br",
+	}, {
+		name:         "no compressors registered",
+		pools:        pools(),
+		accept:       "gzip,br",
+		wantRequest:  "identity",
+		wantResponse: "identity",
+	}, {
+		name:        "unknown request encoding",
+		pools:       pools("gzip"),
+		sent:        "br",
+		accept:      "gzip",
+		wantErrCode: connect.CodeUnimplemented,
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			request, response, err := negotiateCompression(test.pools, test.sent, test.accept)
+			if test.wantErrCode != 0 {
+				assert.NotNil(t, err)
+				assert.Equal(t, connect.CodeOf(err), test.wantErrCode)
+				return
+			}
+			assert.Nil(t, err)
+			assert.Equal(t, request, test.wantRequest)
+			assert.Equal(t, response, test.wantResponse)
+		})
+	}
+}
+
+func BenchmarkNegotiateCompression(b *testing.B) {
+	pools := func(registered ...string) readOnlyCompressionPools {
+		compressors := make([]connect.Compressor, 0, len(registered))
+		for _, name := range registered {
+			compressors = append(compressors, stubCompressor(name))
+		}
+		return newReadOnlyCompressionPools(compressors)
+	}
+
+	b.Run("default", func(b *testing.B) {
+		available := pools(connect.CompressionNameGzip)
+		for b.Loop() {
+			_, _, _ = negotiateCompression(available, "", "gzip")
+		}
+		b.ReportAllocs()
+	})
+
+	b.Run("multiple compressors", func(b *testing.B) {
+		available := pools(connect.CompressionNameGzip, "zstd", "br")
+		for b.Loop() {
+			_, _, _ = negotiateCompression(available, "", "gzip,br,zstd")
+		}
+		b.ReportAllocs()
+	})
+
+	b.Run("no mutually supported encoding", func(b *testing.B) {
+		available := pools(connect.CompressionNameGzip)
+		for b.Loop() {
+			_, _, _ = negotiateCompression(available, "", "br,zstd")
+		}
+		b.ReportAllocs()
+	})
+}
+
+// stubCompressor is a [connect.Compressor] that only carries a name. The
+// negotiation tests exercise name selection, never the payload path.
+type stubCompressor string
+
+func (c stubCompressor) Name() string { return string(c) }
+
+func (stubCompressor) Compress(dst io.Writer) (io.WriteCloser, error) {
+	return identityWriteCloser{dst}, nil
+}
+
+func (stubCompressor) Decompress(src io.Reader) (io.ReadCloser, error) {
+	return io.NopCloser(src), nil
 }

--- a/connecthttp/server_stream.go
+++ b/connecthttp/server_stream.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"maps"
 	"net/http"
 
 	"connectrpc.com/connect/v2"
@@ -90,16 +89,9 @@ func (s *handlerStream) Send(msg any) error {
 // newServerHandlerConfig builds a v1 handlerConfig for spec from the resolved
 // server options, adapting the v2 codec/compressors to the in-package types.
 func newServerHandlerConfig(spec connect.Spec, opts *options) *handlerConfig {
-	codecs := make(map[string]connect.Codec, len(opts.codecs))
-	maps.Copy(codecs, opts.codecs)
-	pools := make(map[string]*compressionPool, len(opts.compressors))
-	for name, compressor := range opts.compressors {
-		pools[name] = newCompressionPool(compressor)
-	}
 	return &handlerConfig{
-		CompressionPools:             pools,
-		CompressionNames:             opts.compressorNames,
-		Codecs:                       codecs,
+		Compressors:                  opts.compressors,
+		Codecs:                       opts.codecs,
 		CompressMinBytes:             opts.compressMinBytes,
 		Procedure:                    spec.Procedure,
 		Schema:                       spec.Schema,

--- a/docs/v2-guide.md
+++ b/docs/v2-guide.md
@@ -384,11 +384,16 @@ connecthttp.WithSendMaxBytes(2048)
 connecthttp.WithCompressMinBytes(512)
 connecthttp.WithHTTPGet()                            // client only
 connecthttp.WithRequireConnectProtocolHeader()      // server only
-connecthttp.WithCodec(connectproto.NewJSONCodec())  // register; one per call
-connecthttp.WithCompressor(connectgzip.New())
+connecthttp.WithCodecs(connectproto.NewBinaryCodec(), connectproto.NewJSONCodec())
+connecthttp.WithCompressors(connectgzip.New())
 ```
 
-By default `connecthttp` registers the protobuf binary and JSON codecs from `connectproto` and sends with the binary codec, so a transport built with no options is ready to use.
+By default, `connecthttp` is ready to use without configuration. It registers the gzip compressor alongside the Protobuf binary and JSON codecs from `connectproto`, defaulting to binary for outgoing requests.
+
+When customizing these, `WithCodecs` and `WithCompressors` replace the default sets entirely, so you must list everything you need in a single call. Order matters for both, but in different ways:
+
+* **Compressors:** Listed in order of preference (most preferred first). This order dictates which encoding a handler chooses for its response.
+* **Codecs:** Handlers match incoming requests by content type, so order only affects clients. Clients send outgoing requests using the first codec in the list, unless explicitly overridden by `WithSendCodec`.
 
 ### connectinprocess
 

--- a/docs/v2-migration.md
+++ b/docs/v2-migration.md
@@ -406,7 +406,6 @@ connect.WithHTTPGetMaxURLSize(8192, true)
 connect.WithProtoJSON()
 connect.WithGRPC()
 connect.WithGRPCWeb()
-connect.WithCodec(codec)
 connect.WithSendCompression("gzip")
 ```
 
@@ -422,7 +421,6 @@ connecthttp.WithHTTPGetMaxURLSize(8192, true)
 connecthttp.WithProtoJSON()
 connecthttp.WithGRPC()
 connecthttp.WithGRPCWeb()
-connecthttp.WithCodec(codec)
 connecthttp.WithSendCompression("gzip")
 ```
 
@@ -454,8 +452,9 @@ Options whose signature changed are warned with the v2 replacement:
 
 | v1 | v2 |
 | --- | --- |
-| `connect.WithCompression(name, dec, comp)` | `connecthttp.WithCompressor(connect.Compressor)` (register a `connectgzip`-style compressor) |
-| `connect.WithAcceptCompression(name, dec, comp)` | `connecthttp.WithCompressor(...)` to register, then `connecthttp.WithAcceptCompression(name)` to advertise; `connecthttp.WithNoCompression()` to disable |
+| `connect.WithCodec(codec)` | `connecthttp.WithCodecs(...connect.Codec)`, which **replaces** the default codecs instead of adding to them. List every codec you need in one call, including `connectproto.NewBinaryCodec()` if you still want it |
+| `connect.WithCompression(name, dec, comp)` | `connecthttp.WithCompressors(...connect.Compressor)` (a `connectgzip`-style compressor), which **replaces** the defaults. The `(name, decompressor, compressor)` signature is gone |
+| `connect.WithAcceptCompression(name, dec, comp)` | `connecthttp.WithCompressors(...connect.Compressor)`; registered compressors are advertised automatically, and the order is the preference order, most preferred first. The `nil` constructors that removed one become an empty `connecthttp.WithCompressors()` |
 | `connect.WithConditionalHandlerOptions(fn)` | `connecthttp.WithConditionalOptions(func(connect.Spec) []connecthttp.Option)` (callback signature changed) |
 | `connect.NewNotModifiedError(header)` | `connecthttp.NewNotModifiedError()` (no header argument) |
 

--- a/internal/conformance/internal/app/referenceclient/client.go
+++ b/internal/conformance/internal/app/referenceclient/client.go
@@ -27,6 +27,7 @@ import (
 
 	"connectrpc.com/connect/v2/connectgzip"
 	"connectrpc.com/connect/v2/connecthttp"
+	"connectrpc.com/connect/v2/connectproto"
 	"connectrpc.com/connect/v2/internal/conformance/internal"
 	conformancev1 "connectrpc.com/connect/v2/internal/conformance/internal/gen/connectrpc/conformance/v1"
 	"connectrpc.com/connect/v2/internal/conformance/internal/gen/connectrpc/conformance/v1/conformancev1connect"
@@ -170,7 +171,7 @@ func invoke(ctx context.Context, transports *transports, req *conformancev1.Clie
 	case conformancev1.Codec_CODEC_JSON:
 		jsonCodec := internal.NewStrictJSONCodec()
 		clientOptions = append(clientOptions,
-			connecthttp.WithCodec(jsonCodec),
+			connecthttp.WithCodecs(connectproto.NewBinaryCodec(), jsonCodec),
 			connecthttp.WithSendCodec(jsonCodec.Name()),
 		)
 	case conformancev1.Codec_CODEC_TEXT: //nolint:staticcheck // staticcheck complains because this const is deprecated
@@ -186,7 +187,7 @@ func invoke(ctx context.Context, transports *transports, req *conformancev1.Clie
 		// send gzipped requests
 		gzipCompressor := connectgzip.New()
 		clientOptions = append(clientOptions,
-			connecthttp.WithCompressor(gzipCompressor),
+			connecthttp.WithCompressors(gzipCompressor),
 			connecthttp.WithSendCompression(gzipCompressor.Name()),
 		)
 	case conformancev1.Compression_COMPRESSION_IDENTITY, conformancev1.Compression_COMPRESSION_UNSPECIFIED:

--- a/internal/conformance/internal/app/referenceserver/server.go
+++ b/internal/conformance/internal/app/referenceserver/server.go
@@ -33,6 +33,7 @@ import (
 	"connectrpc.com/connect/v2"
 	"connectrpc.com/connect/v2/connectgzip"
 	"connectrpc.com/connect/v2/connecthttp"
+	"connectrpc.com/connect/v2/connectproto"
 	"connectrpc.com/connect/v2/internal/conformance/internal"
 	conformancev1 "connectrpc.com/connect/v2/internal/conformance/internal/gen/connectrpc/conformance/v1"
 	"connectrpc.com/connect/v2/internal/conformance/internal/gen/connectrpc/conformance/v1/conformancev1connect"
@@ -179,8 +180,8 @@ const (
 func createServer(req *conformancev1.ServerCompatRequest, listenAddr, tlsCertFile, tlsKeyFile string) (httpServer, []byte, error) {
 	mux := http.NewServeMux()
 	opts := []connecthttp.Option{
-		connecthttp.WithCompressor(connectgzip.New()),
-		connecthttp.WithCodec(internal.NewStrictJSONCodec()),
+		connecthttp.WithCompressors(connectgzip.New()),
+		connecthttp.WithCodecs(connectproto.NewBinaryCodec(), internal.NewStrictJSONCodec()),
 	}
 	// A zero limit means unlimited, which is what the conformance suite expects
 	// when it does not set one.


### PR DESCRIPTION
This PR moves codec and compressor configuration from additive options to authoritative slices (`WithCodecs` and `WithCompressors`). This resolves a few historical API limitations and lets the caller state the preference order directly.

Compression negotiation is unchanged. The server still responds with the client's first supported entry, matching v1. The recent spec update https://github.com/connectrpc/connectrpc.com/pull/405 would let the server choose the response encoding instead, which matters because browsers hardcode `Accept-Encoding: gzip, deflate, br, zstd` and can never negotiate past `gzip` under the current rule. That spec change isn't ready for v2, so it's left out here. The ordered slices are the piece it needs, so it can land on top later without another API break.

Ordering was the underlying problem. Additive options made the preference order implicit in registration order, and the most recently registered compressor was the most preferred, which reads backwards. `WithCompressors` and `WithCodecs` now replace the defaults, and the order you provide in the slice is exactly what gets advertised. It applies to both codecs and compressors for consistency and matches the pattern in [connect-py](https://github.com/connectrpc/connect-py).

This simplifies the option API surface. Removes `WithAcceptCompression`, registered compressors are now always advertised, and removes `WithNoCompression`, an empty `WithCompressors()`  disables compressors.

Migration tool has been updated to warn on `connect.WithCodec`, `WithCompression`, and `WithAcceptCompression` options. These aren't mechanical translations and require review. For example, the conformance tests set a custom JSON codec for a stricter encoding and has been updated.

### Examples 

Compression preference in order:
```go
// Prefer brotli, fall back to gzip. Sends Accept-Encoding: br,gzip
connecthttp.WithCompressors(brotli, connectgzip.New())
```

Removing the default JSON codec was previously impossible:
```go
// Serve binary Protobuf only.
connecthttp.Mount(mux, srv, connecthttp.WithCodecs(connectproto.NewBinaryCodec()))
```

Client prefer the first registered codec, so looses the need to always set these two options:
```go
// before
connecthttp.WithCodec(jsonCodec), connecthttp.WithSendCodec(jsonCodec.Name())
// after
connecthttp.WithCodecs(jsonCodec)
```
