### PR TITLE
Guard against boxed nil *Error

### DIFF
--- a/code_test.go
+++ b/code_test.go
@@ -54,3 +54,16 @@ func assertCodeRoundTrips(tb testing.TB, code Code) {
 		assert.NotNil(tb, invalid.UnmarshalText([]byte("code_"+strconv.Itoa(int(code)))))
 	}
 }
+
+func TestCodeOfNil(t *testing.T) {
+	t.Parallel()
+	t.Run("nil error", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, CodeOf(nil), CodeUnknown)
+	})
+	t.Run("boxed (*Error)(nil) error", func(t *testing.T) {
+		t.Parallel()
+		var nilErr *Error = nil
+		assert.Equal(t, CodeOf(nilErr), CodeUnknown)
+	})
+}

--- a/error.go
+++ b/error.go
@@ -265,11 +265,11 @@ func errorf(c Code, template string, args ...any) *Error {
 	return NewError(c, fmt.Errorf(template, args...))
 }
 
-// asError uses errors.As to unwrap any error and look for a connect *Error.
+// asError uses errors.As to unwrap any error and look for a non-nil connect *Error.
 func asError(err error) (*Error, bool) {
 	var connectErr *Error
 	ok := errors.As(err, &connectErr)
-	return connectErr, ok
+	return connectErr, ok && connectErr != nil // Protect against typed nils (*Error)(nil).
 }
 
 // wrapIfUncoded ensures that all errors are wrapped. It leaves already-wrapped

--- a/error_test.go
+++ b/error_test.go
@@ -27,6 +27,15 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
+func TestErrorNil(t *testing.T) {
+	t.Parallel()
+	// This library never boxes (*Error)(nil) as a golang error. Users may do this, asError must handle it gracefully.
+	var connectErr *Error = nil
+
+	_, ok := asError(connectErr)
+	assert.False(t, ok)
+}
+
 func TestErrorNilUnderlying(t *testing.T) {
 	t.Parallel()
 	err := NewError(CodeUnknown, nil)


### PR DESCRIPTION
Users may pass `(*Error)(nil)` to `connect.CodeOf` which causes it to be boxed. `asError` used to let this through.

For example, if I write slightly non-idiomatic go code:
```
// Notice mixing a concrete instance with what normally would be just error
func Helper(r *http.Request) *connect.Error {
  // some common error cases ...
  // and default, signaling there is no error
  return nil
}

func TestHelper(t *testing.T) {
	err := Helper(r)
	if err == nil {
		assert.Equal(t, connect.CodeUnknown, connect.CodeOf(nil))
	} else {
		assert.Equal(t, ..., connect.CodeOf(err))
	}
}
```

One could of course argue, that returning `error` from `Helper` is better, or have a second bool return value indicating the helper did not find an error case. I think people are very used to pick `nil` as not an error. So following that reasoning, `*connect.Error` methods should support the receiver pointer being `nil`. Or what I propose in this PR let methods like connect.CodeOf guard against users passing in a `(*Error)(nil)` boxed as `error`.